### PR TITLE
Options Overhaul and QCElemental

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: python
+language: generic
 
 # Run jobs on container-based infrastructure, can be overridden per job
 dist: xenial
@@ -6,22 +6,18 @@ dist: xenial
 matrix:
   include:
     - os: linux
-      python: 2.7
-      env: 
-        - PYTHON_VER=2.7
-        - PROG=PSI4
-    - os: linux
-      python: 3.5
       env:
-        - PYTHON_VER=3.5
+        - PYTHON_VER=3.6
         - PROG=RDKIT
     - os: linux
-      python: 3.6
       env:
         - PYTHON_VER=3.6
         - PROG=PSI4
     - os: linux
-      python: 3.6
+      env:
+        - PYTHON_VER=3.7
+        - PROG=PSI4
+    - os: linux
       env:
         - PYTHON_VER=3.6
         - PROG=ANI

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Quantum chemistry program executor and IO standardizer ([QCSchema](https://githu
 
 Available Compute Programs:
  - [Psi4](http://www.psicode.org)
- - [PRDKit](http://rdkit.org)
- - [PTorchANI](https://github.com/aiqm/torchani)
+ - [RDKit](http://rdkit.org)
+ - [TorchANI](https://github.com/aiqm/torchani)
 
 Available Procedures:
  - [Geometric](https://github.com/leeping/geomeTRIC)

--- a/devtools/conda-envs/psi.yaml
+++ b/devtools/conda-envs/psi.yaml
@@ -8,6 +8,7 @@ dependencies:
   - pyyaml
   - py-cpuinfo
   - psutil
+  - qcelemental
 
     # Testing
   - pytest
@@ -16,4 +17,5 @@ dependencies:
     # Pip depends
   - pip:
     - codecov
+    - pydantic
     - git+https://github.com/leeping/geomeTRIC#egg=geometric

--- a/devtools/conda-envs/rdkit.yaml
+++ b/devtools/conda-envs/rdkit.yaml
@@ -9,8 +9,11 @@ dependencies:
   - pyyaml
   - py-cpuinfo
   - psutil
+  - qcelemental
 
     # Testing
   - pytest
   - pytest-cov
   - codecov
+  - pip:
+    - pydantic

--- a/devtools/conda-envs/torchani.yaml
+++ b/devtools/conda-envs/torchani.yaml
@@ -10,10 +10,12 @@ dependencies:
   - pyyaml
   - py-cpuinfo
   - psutil
+  - qcelemental
 
     # Testing
   - pytest
   - pytest-cov
   - codecov
   - pip:
+    - pydantic
     - git+git://github.com/aiqm/torchani.git@cf192be#egg=torchani

--- a/qcengine/__init__.py
+++ b/qcengine/__init__.py
@@ -6,7 +6,7 @@ from . import config
 # Handle versioneer
 from ._version import get_versions
 from .compute import compute, compute_procedure
-from .config import get_config, load_options
+from .config import get_config
 from .stock_mols import get_molecule
 
 versions = get_versions()

--- a/qcengine/__init__.py
+++ b/qcengine/__init__.py
@@ -3,12 +3,13 @@ Base file for the dqm_compute module.
 """
 
 from . import config
-# Handle versioneer
-from ._version import get_versions
+
 from .compute import compute, compute_procedure
 from .config import get_config
 from .stock_mols import get_molecule
 
+# Handle versioneer
+from ._version import get_versions
 versions = get_versions()
 __version__ = versions['version']
 __git_revision__ = versions['full-revisionid']

--- a/qcengine/compute.py
+++ b/qcengine/compute.py
@@ -35,6 +35,11 @@ def compute(input_data, program, raise_error=False, capture_output=True, local_o
 
     """
     input_data = copy.deepcopy(input_data)
+
+    if local_options is None:
+        local_options = {}
+
+    local_options = {**local_options, **input_data.pop("_qcengine_local_config", {})}
     config = get_config(local_options=local_options)
 
     # Run the program
@@ -80,7 +85,9 @@ def compute_procedure(input_data, procedure, raise_error=False, capture_output=T
     with compute_wrapper(capture_output=capture_output) as metadata:
         output_data = input_data
         if procedure == "geometric":
+            input_data["input_specification"]["_qcengine_local_config"] = config.dict()
             output_data = get_module_function("geometric", "run_json.geometric_run_json")(input_data)
+            del input_data["input_specification"]["_qcengine_local_config"]
         else:
             output_data["success"] = False
             output_data["error_message"] = "QCEngine Call Error:\nProcedure {} not understood".format(program)

--- a/qcengine/compute.py
+++ b/qcengine/compute.py
@@ -4,11 +4,12 @@ Integrates the computes together
 
 import copy
 
-from . import programs
-from . import util
+from .programs import get_program
+from .util import compute_wrapper, handle_output_metadata, get_module_function
+from .config import get_config
 
 
-def compute(input_data, program, raise_error=False, capture_output=True):
+def compute(input_data, program, raise_error=False, capture_output=True, local_options=None):
     """Executes a single quantum chemistry program given a QC Schema input.
 
     The full specification can be found at:
@@ -24,6 +25,8 @@ def compute(input_data, program, raise_error=False, capture_output=True):
         Determines if compute should raise an error or not.
     capture_output : bool, optional
         Determines if stdout/stderr should be captured.
+    local_options : dict, optional
+        A dictionary of local configuration options
 
     Returns
     -------
@@ -32,21 +35,23 @@ def compute(input_data, program, raise_error=False, capture_output=True):
 
     """
     input_data = copy.deepcopy(input_data)
+    config = get_config(local_options=local_options)
 
     # Run the program
-    with util.compute_wrapper(capture_output=capture_output) as metadata:
+    with compute_wrapper(capture_output=capture_output) as metadata:
         output_data = input_data
         try:
-            output_data = programs.get_program(program)(input_data)
+            output_data = get_program(program)(input_data, config)
         except KeyError as e:
             output_data["success"] = False
-            output_data["error_message"] = "QCEngine Call Error:\nProgram {} not understood.\nError Message: {}".format(
-                program, str(e))
+            output_data[
+                "error_message"] = "QCEngine Call Error:\nProgram {} not understood.\nError Message: {}".format(
+                    program, str(e))
 
-    return util.handle_output_metadata(output_data, metadata, raise_error=raise_error)
+    return handle_output_metadata(output_data, metadata, raise_error=raise_error)
 
 
-def compute_procedure(input_data, procedure, raise_error=False, capture_output=True):
+def compute_procedure(input_data, procedure, raise_error=False, capture_output=True, local_options=None):
     """Runs a procedure (a collection of the quantum chemistry executions)
 
     Parameters
@@ -59,6 +64,8 @@ def compute_procedure(input_data, procedure, raise_error=False, capture_output=T
         Determines if compute should raise an error or not.
     capture_output : bool, optional
         Determines if stdout/stderr should be captured.
+    local_options : dict, optional
+        A dictionary of local configuration options
 
     Returns
     ------
@@ -67,14 +74,15 @@ def compute_procedure(input_data, procedure, raise_error=False, capture_output=T
     """
 
     input_data = copy.deepcopy(input_data)
+    config = get_config(local_options=local_options)
 
     # Run the procedure
-    with util.compute_wrapper(capture_output=capture_output) as metadata:
+    with compute_wrapper(capture_output=capture_output) as metadata:
         output_data = input_data
         if procedure == "geometric":
-            output_data = util.get_module_function("geometric", "run_json.geometric_run_json")(input_data)
+            output_data = get_module_function("geometric", "run_json.geometric_run_json")(input_data)
         else:
             output_data["success"] = False
             output_data["error_message"] = "QCEngine Call Error:\nProcedure {} not understood".format(program)
 
-    return util.handle_output_metadata(output_data, metadata, raise_error=raise_error)
+    return handle_output_metadata(output_data, metadata, raise_error=raise_error)

--- a/qcengine/config.py
+++ b/qcengine/config.py
@@ -57,7 +57,7 @@ class NodeDescriptor(pydantic.BaseModel):
 
     # Specifications
     jobs_per_node: int = 2
-    memory_safety_factor: int = 10 # Percentage of memory as a safety factor
+    memory_safety_factor: int = 10  # Percentage of memory as a safety factor
     memory_per_job: Union[int, str] = "auto"  # Amount of memory in Gb per node
     nthreads_per_job: Union[int, str] = "auto"  # Number of nthreads per job
     scratch_directory: str = None  # What location to use as scratch
@@ -94,7 +94,7 @@ class NodeDescriptor(pydantic.BaseModel):
 
         if self.memory_per_job == "auto":
             memory_coeff = (1 - self.memory_safety_factor / 100)
-            self.memory_per_job = round(self.available_memory * memory_coeff / self.jobs_per_node , 3)
+            self.memory_per_job = round(self.available_memory * memory_coeff / self.jobs_per_node, 3)
 
 
 class JobConfig(pydantic.BaseModel):

--- a/qcengine/config.py
+++ b/qcengine/config.py
@@ -62,6 +62,9 @@ class NodeDescriptor(pydantic.BaseModel):
     nthreads_per_job: Union[int, str] = "auto"  # Number of nthreads per job
     scratch_directory: Optional[str] = None  # What location to use as scratch
 
+    class Config:
+        ignore_extra = False
+
     def __init__(self, **kwargs):
         """
         Initalize the pydantic class after processing options
@@ -101,8 +104,11 @@ class JobConfig(pydantic.BaseModel):
 
     # Specifications
     nthreads: int  # Number of nthreads per job
-    memory: str  # Amount of memory in Gb per node
+    memory: int  # Amount of memory in GiB per node
     scratch_directory: Optional[str]  # What location to use as scratch
+
+    class Config:
+        ignore_extra = False
 
 
 def _load_defaults():

--- a/qcengine/programs/__init__.py
+++ b/qcengine/programs/__init__.py
@@ -2,6 +2,8 @@
 Imports the various compute backends
 """
 
+__all__ = ["register_program", "get_program", "get_programs"]
+
 programs = {}
 
 def register_program(name, entry_point):

--- a/qcengine/programs/psi4.py
+++ b/qcengine/programs/psi4.py
@@ -22,7 +22,6 @@ def psi4(input_data, config):
     Runs Psi4 in API mode
     """
 
-
     try:
         import psi4
     except ImportError:
@@ -30,7 +29,7 @@ def psi4(input_data, config):
 
     # Setup the job
     input_data["nthreads"] = config.nthreads
-    input_data["memory"] = int(config.memory *1024 * 1024 * 1024 * 0.95) # Memory in bytes
+    input_data["memory"] = int(config.memory * 1024 * 1024 * 1024 * 0.95)  # Memory in bytes
     input_data["success"] = False
 
     scratch = config.scratch_directory

--- a/qcengine/programs/psi4.py
+++ b/qcengine/programs/psi4.py
@@ -17,15 +17,11 @@ def _parse_psi_version(version):
     return parse_version(version)
 
 
-def psi4(input_data):
+def psi4(input_data, config):
     """
     Runs Psi4 in API mode
     """
 
-    # Insert API path if needed
-    psiapi = config.get_config("psi_path")
-    if (psiapi is not None) and (psiapi not in sys.path):
-        sys.path.insert(1, psiapi)
 
     try:
         import psi4
@@ -33,11 +29,11 @@ def psi4(input_data):
         raise ImportError("Could not find Psi4 in the Python path.")
 
     # Setup the job
-    input_data["nthreads"] = config.get_config("nthreads_per_job")
-    input_data["memory"] = int(config.get_config("memory_per_job") * 1024 * 1024 * 1024 * 0.95)
+    input_data["nthreads"] = config.nthreads
+    input_data["memory"] = int(config.memory *1024 * 1024 * 1024 * 0.95) # Memory in bytes
     input_data["success"] = False
 
-    scratch = config.get_config("scratch_directory")
+    scratch = config.scratch_directory
     if scratch is not None:
         input_data["scratch_location"] = scratch
 

--- a/qcengine/programs/psi4.py
+++ b/qcengine/programs/psi4.py
@@ -43,16 +43,7 @@ def psi4(input_data):
 
     psi_version = _parse_psi_version(psi4.__version__)
 
-    if psi_version > parse_version("1.2rc2.dev500"):
-
-        # Handle slight RC2 weirdness
-        psi_12rc2_tweak = (psi_version == parse_version("1.2rc2"))
-        psi_12rc2_tweak &= psi4.metadata.version_formatter("") != '(inplace)'
-
-        if psi_12rc2_tweak:
-            input_data["schema_name"] = "QC_JSON"
-            input_data["schema_version"] = 0
-            psi4.set_num_threads(input_data["nthreads"], quiet=True)
+    if psi_version > parse_version("1.2"):
 
         mol = psi4.core.Molecule.from_schema(input_data)
         if mol.multiplicity() != 1:
@@ -60,13 +51,8 @@ def psi4(input_data):
 
         output_data = psi4.json_wrapper.run_json(input_data)
 
-        # Handle slight RC2 weirdness once more
-        if psi_12rc2_tweak:
-            output_data["schema_name"] = "qc_schema_output"
-            output_data["schema_version"] = 1
-
     else:
-        raise TypeError("Psi4 version '{}' not understood".format(psi_version))
+        raise TypeError("Psi4 version '{}' not understood.".format(psi_version))
 
     # Dispatch errors, PSIO Errors are not recoverable for future runs
     if output_data["success"] is False:

--- a/qcengine/programs/rdkit.py
+++ b/qcengine/programs/rdkit.py
@@ -49,7 +49,7 @@ def rdkit(ret_data):
     for line in range(natom):
         conf.SetAtomPosition(line, (bohr2ang * jmol["geometry"][line * 3],
                                     bohr2ang * jmol["geometry"][line * 3 + 1],
-                                    bohr2ang * jmol["geometry"][line * 3 + 2]))
+                                    bohr2ang * jmol["geometry"][line * 3 + 2])) # yapf: disable
 
     mol.AddConformer(conf)
     Chem.rdmolops.SanitizeMol(mol)

--- a/qcengine/programs/rdkit.py
+++ b/qcengine/programs/rdkit.py
@@ -5,14 +5,17 @@ Calls the Psi4 executable.
 from qcengine.units import ureg
 
 
-def rdkit(ret_data):
+def rdkit(ret_data, config):
     """
     Runs RDKit in FF typing
     """
 
-    import rdkit
-    from rdkit import Chem
-    from rdkit.Chem import AllChem
+    try:
+        import rdkit
+        from rdkit import Chem
+        from rdkit.Chem import AllChem
+    except ImportError:
+        raise ImportError("Could not find RDKit in the Python path.")
 
     # Failure flag
     ret_data["success"] = False

--- a/qcengine/programs/rdkit.py
+++ b/qcengine/programs/rdkit.py
@@ -2,7 +2,7 @@
 Calls the Psi4 executable.
 """
 
-from qcengine import units
+from qcengine.units import ureg
 
 
 def rdkit(ret_data):
@@ -45,10 +45,11 @@ def rdkit(ret_data):
     # Write out the conformer
     natom = len(jmol["symbols"])
     conf = Chem.Conformer(natom)
+    bohr2ang = ureg.conversion_factor("bohr", "angstrom")
     for line in range(natom):
-        conf.SetAtomPosition(line, (units.bohr_to_angstrom * jmol["geometry"][line * 3],
-                                    units.bohr_to_angstrom * jmol["geometry"][line * 3 + 1],
-                                    units.bohr_to_angstrom * jmol["geometry"][line * 3 + 2]))
+        conf.SetAtomPosition(line, (bohr2ang * jmol["geometry"][line * 3],
+                                    bohr2ang * jmol["geometry"][line * 3 + 1],
+                                    bohr2ang * jmol["geometry"][line * 3 + 2]))
 
     mol.AddConformer(conf)
     Chem.rdmolops.SanitizeMol(mol)
@@ -66,12 +67,12 @@ def rdkit(ret_data):
 
     ff.Initialize()
 
-    ret_data["properties"] = {"return_energy": ff.CalcEnergy() / units.hartree_to_kj_mol}
+    ret_data["properties"] = {"return_energy": ff.CalcEnergy() * ureg.conversion_factor("kJ / mol", "hartree")}
 
     if ret_data["driver"] == "energy":
         ret_data["return_result"] = ret_data["properties"]["return_energy"]
     elif ret_data["driver"] == "gradient":
-        coef = 1 / (units.bohr_to_angstrom * units.hartree_to_kj_mol)
+        coef = ureg.conversion_factor("kJ / mol", "hartree") * ureg.conversion_factor("angstrom", "bohr")
         ret_data["return_result"] = [x * coef for x in ff.CalcGrad()]
     else:
         ret_data["error_message"] = "run_rdkit did not understand driver method '{}'.".format(ret_data["driver"])

--- a/qcengine/programs/torchani.py
+++ b/qcengine/programs/torchani.py
@@ -28,14 +28,20 @@ def get_model(name):
         return False
 
 
-def torchani(ret_data):
+def torchani(ret_data, config):
     """
     Runs TorchANI in FF typing
     """
 
     import numpy as np
-    import torch
-    import torchani
+    try:
+        import torch
+    except ImportError:
+        raise ImportError("Could not find PyTorch in the Python path.")
+    try:
+        import torchani
+    except ImportError:
+        raise ImportError("Could not find TorchANI in the Python path.")
 
     device = torch.device('cpu')
     builtin = torchani.neurochem.Builtins()

--- a/qcengine/programs/torchani.py
+++ b/qcengine/programs/torchani.py
@@ -2,7 +2,7 @@
 Calls the Psi4 executable.
 """
 
-from qcengine import units
+from qcengine.units import ureg
 
 _CACHE = {}
 
@@ -60,7 +60,7 @@ def torchani(ret_data):
     species = builtin.consts.species_to_tensor(species).to(device).unsqueeze(0)
 
     # Build coord array
-    geom_array = np.array(ret_data["molecule"]["geometry"]).reshape(1, -1, 3) * units.bohr_to_angstrom
+    geom_array = np.array(ret_data["molecule"]["geometry"]).reshape(1, -1, 3) * ureg.conversion_factor("bohr", "angstrom")
     coordinates = torch.tensor(geom_array.tolist(), requires_grad=True, device=device)
 
     _, energy = model((species, coordinates))
@@ -70,7 +70,7 @@ def torchani(ret_data):
         ret_data["return_result"] = ret_data["properties"]["return_energy"]
     elif ret_data["driver"] == "gradient":
         derivative = torch.autograd.grad(energy.sum(), coordinates)[0].squeeze()
-        ret_data["return_result"] = np.asarray(derivative / units.bohr_to_angstrom).ravel().tolist()
+        ret_data["return_result"] = np.asarray(derivative * ureg.conversion_factor("angstrom", "bohr")).ravel().tolist()
     else:
         ret_data["error_message"] = "run_torchani did not understand driver method '{}'.".format(ret_data["driver"])
         return ret_data

--- a/qcengine/testing.py
+++ b/qcengine/testing.py
@@ -1,0 +1,24 @@
+"""
+Utilities for the testing suite.
+"""
+
+import os
+
+from contextlib import contextmanager
+
+
+@contextmanager
+def environ_context(env):
+    """Temporarily set environment variables inside the context manager and
+    fully restore previous environment afterwards
+    """
+    original_env = {key: os.getenv(key) for key in env}
+    os.environ.update(env)
+    try:
+        yield
+    finally:
+        for key, value in original_env.items():
+            if value is None:
+                del os.environ[key]
+            else:
+                os.environ[key] = value

--- a/qcengine/tests/test_compute.py
+++ b/qcengine/tests/test_compute.py
@@ -27,7 +27,7 @@ def test_psi4_task():
     json_data["keywords"] = {"scf_type": "df"}
     json_data["return_output"] = False
 
-    ret = dc.compute(json_data, "psi4")
+    ret = dc.compute(json_data, "psi4", raise_error=True)
 
     assert ret["driver"] == "energy"
     assert "provenance" in ret
@@ -47,7 +47,7 @@ def test_psi4_ref_switch():
     json_data["keywords"] = {"scf_type": "df"}
     json_data["return_output"] = False
 
-    ret = dc.compute(json_data, "psi4")
+    ret = dc.compute(json_data, "psi4", raise_error=True)
 
     assert ret["success"] is True
 
@@ -61,7 +61,7 @@ def test_rdkit_task():
     json_data["keywords"] = {}
     json_data["return_output"] = False
 
-    ret = dc.compute(json_data, "rdkit")
+    ret = dc.compute(json_data, "rdkit", raise_error=True)
 
     assert ret["success"] is True
 
@@ -92,7 +92,7 @@ def test_torchani_task():
     json_data["keywords"] = {}
     json_data["return_output"] = False
 
-    ret = dc.compute(json_data, "torchani")
+    ret = dc.compute(json_data, "torchani", raise_error=True)
 
     assert ret["success"] is True
     assert ret["driver"] == "gradient"

--- a/qcengine/tests/test_config.py
+++ b/qcengine/tests/test_config.py
@@ -16,7 +16,7 @@ from qcengine.testing import environ_context
 def test_node_blank():
     node = qcengine.config.NodeDescriptor(name="something", hostname_pattern="*")
 
-    assert node.nthreads_per_job > 1
+    assert node.nthreads_per_job > 0
     assert node.available_memory > 0.1
     assert node.memory_per_job > 0.1
 

--- a/qcengine/tests/test_procedures.py
+++ b/qcengine/tests/test_procedures.py
@@ -75,6 +75,7 @@ def test_geometric_local_options():
     assert "_qcengine_local_config" not in ret["input_specification"]
     assert "_qcengine_local_config" not in ret["trajectory"][0]
 
+
 @addons.using_rdkit
 @addons.using_geometric
 def test_geometric_stdout():

--- a/qcengine/tests/test_procedures.py
+++ b/qcengine/tests/test_procedures.py
@@ -57,6 +57,24 @@ def test_geometric_psi4():
     geom = ret["final_molecule"]["geometry"]
     assert pytest.approx(_bond_dist(geom, 0, 1), 1.e-4) == 1.3459150737
 
+
+@addons.using_psi4
+@addons.using_geometric
+def test_geometric_local_options():
+    inp = copy.deepcopy(_base_json)
+
+    inp["initial_molecule"] = dc.get_molecule("hydrogen")
+    inp["input_specification"]["model"] = {"method": "HF", "basis": "sto-3g"}
+    inp["keywords"]["program"] = "psi4"
+
+    # Set some extremely large number to test
+    ret = dc.compute_procedure(inp, "geometric", raise_error=True, local_options={"memory": "5000"})
+    assert pytest.approx(ret["trajectory"][0]["provenance"]["memory"], 1) == 4900
+
+    # Make sure we cleaned up
+    assert "_qcengine_local_config" not in ret["input_specification"]
+    assert "_qcengine_local_config" not in ret["trajectory"][0]
+
 @addons.using_rdkit
 @addons.using_geometric
 def test_geometric_stdout():
@@ -74,6 +92,7 @@ def test_geometric_stdout():
     with pytest.raises(ValueError):
         ret = dc.compute_procedure(inp, "rdkit", raise_error=True)
 
+
 @addons.using_rdkit
 @addons.using_geometric
 def test_geometric_rdkit_error():
@@ -90,6 +109,7 @@ def test_geometric_rdkit_error():
 
     with pytest.raises(ValueError):
         ret = dc.compute_procedure(inp, "rdkit", raise_error=True)
+
 
 @addons.using_torchani
 @addons.using_geometric

--- a/qcengine/tests/test_procedures.py
+++ b/qcengine/tests/test_procedures.py
@@ -51,7 +51,7 @@ def test_geometric_psi4():
     inp["input_specification"]["model"] = {"method": "HF", "basis": "sto-3g"}
     inp["keywords"]["program"] = "psi4"
 
-    ret = dc.compute_procedure(inp, "geometric")
+    ret = dc.compute_procedure(inp, "geometric", raise_error=True)
     assert 10 > len(ret["trajectory"]) > 1
 
     geom = ret["final_molecule"]["geometry"]
@@ -66,7 +66,7 @@ def test_geometric_stdout():
     inp["input_specification"]["model"] = {"method": "UFF", "basis": ""}
     inp["keywords"]["program"] = "rdkit"
 
-    ret = dc.compute_procedure(inp, "geometric")
+    ret = dc.compute_procedure(inp, "geometric", raise_error=True)
     assert ret["success"] is True
     assert "Converged!" in ret["stdout"]
     assert ret["stderr"] == "No stderr recieved."
@@ -100,7 +100,7 @@ def test_geometric_torchani():
     inp["input_specification"]["model"] = {"method": "ANI1", "basis": None}
     inp["keywords"]["program"] = "torchani"
 
-    ret = dc.compute_procedure(inp, "geometric")
+    ret = dc.compute_procedure(inp, "geometric", raise_error=True)
     assert ret["success"] is True
     assert "Converged!" in ret["stdout"]
     assert ret["stderr"] == "No stderr recieved."

--- a/qcengine/units.py
+++ b/qcengine/units.py
@@ -1,6 +1,7 @@
 """
-Not another units package
+Pinning point for QCElemental units
 """
 
-bohr_to_angstrom = 0.52917724900001
-hartree_to_kj_mol = 2625.499638
+# Pin Codata
+import qcelemental as qcel
+ureg = qcel.PhysicalConstantsContext("CODATA2014")

--- a/qcengine/util.py
+++ b/qcengine/util.py
@@ -102,6 +102,9 @@ def handle_output_metadata(output_data, metadata, raise_error=False):
 
     # Raise an error if one exists and a user requested a raise
     if raise_error and (output_data["success"] is not True):
+        msg = "stdout:\n" + output_data["stdout"]
+        msg += "\nstderr:\n" + output_data["stderr"]
+        print(msg)
         raise ValueError(output_data["error_message"])
 
     # Fill out provenance datadata

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,8 @@ if __name__ == "__main__":
             'pyyaml',
             'py-cpuinfo',
             'psutil',
+            'qcelemental>=0.1.3',
+            'pydantic'
         ],
         entry_points={"console_scripts": [
             "qcengine=qcengine.cli:main",


### PR DESCRIPTION
This PR accomplishes the following:
 - Adds QCElemental and pydantic as dependancies (requires Py3.6+).
 - Converts all units over to QCElemental CODATA2014 units.
 - Overhauls the options to have a separate NodeDescriptor area which can effectively match a node name to a preset description. Closes #12.
 - Allows individual configuration to be build from a NodeDescriptor to create a on-the-fly JobConfig.
 - A JobConfig is alterable with a new `local_options` command. Closes #3.