### PR TITLE
Implement the QCElemental Models into QCEngine

### DIFF
--- a/devtools/conda-envs/psi.yaml
+++ b/devtools/conda-envs/psi.yaml
@@ -8,7 +8,8 @@ dependencies:
   - pyyaml
   - py-cpuinfo
   - psutil
-  - qcelemental
+  - qcelemental >=0.2.1
+  - pydantic >=0.18.1
 
     # Testing
   - pytest
@@ -17,5 +18,4 @@ dependencies:
     # Pip depends
   - pip:
     - codecov
-    - pydantic
     - git+https://github.com/leeping/geomeTRIC#egg=geometric

--- a/devtools/conda-envs/psi.yaml
+++ b/devtools/conda-envs/psi.yaml
@@ -1,6 +1,7 @@
 name: test
 channels:
   - psi4
+  - conda-forge
 dependencies:
   - psi4=1.2
 

--- a/devtools/conda-envs/rdkit.yaml
+++ b/devtools/conda-envs/rdkit.yaml
@@ -9,11 +9,10 @@ dependencies:
   - pyyaml
   - py-cpuinfo
   - psutil
-  - qcelemental
+  - qcelemental >=0.2.1
+  - pydantic >=0.18.1
 
     # Testing
   - pytest
   - pytest-cov
   - codecov
-  - pip:
-    - pydantic

--- a/devtools/conda-envs/torchani.yaml
+++ b/devtools/conda-envs/torchani.yaml
@@ -10,12 +10,12 @@ dependencies:
   - pyyaml
   - py-cpuinfo
   - psutil
-  - qcelemental
+  - qcelemental >=0.2.1
+  - pydantic >=0.18.1
 
     # Testing
   - pytest
   - pytest-cov
   - codecov
   - pip:
-    - pydantic
     - git+git://github.com/aiqm/torchani.git@cf192be#egg=torchani

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - py-cpuinfo
     - pyyaml
     - psutil
+    - qcelemental
 
 test:
   requires:

--- a/qcengine/cli.py
+++ b/qcengine/cli.py
@@ -26,6 +26,7 @@ def main(args=None):
         args = parse_args()
 
     ret = compute(json.loads(args["data"]), args["program"])
+    print(json.dumps(ret))
 
 
 if __name__ == '__main__':

--- a/qcengine/compute.py
+++ b/qcengine/compute.py
@@ -6,7 +6,7 @@ from qcelemental.models import ResultInput, ComputeError, OptimizationInput, Opt
 from pydantic import ValidationError
 
 from .programs import get_program
-from .util import compute_wrapper, handle_output_metadata, get_module_function
+from .util import compute_wrapper, handle_output_metadata, get_module_function, model_wrapper
 from .config import get_config
 
 
@@ -39,31 +39,11 @@ def compute(input_data, program, raise_error=False, capture_output=True, local_o
         A FailedOperation returns
 
     """
-    try:
-        if isinstance(input_data, dict):
-            input_data = ResultInput(**input_data)
-    except ValidationError as val_error:
-        failure = FailedOperation(input_data=input_data,
-                                  success=False,
-                                  error=ComputeError(error_type="input_validation_error",
-                                                     error_message="Input could not be validated for the following "
-                                                                   "reasons:\n{}".format(val_error.json())))
+    input_data = model_wrapper(input_data, ResultInput)
+    if isinstance(input_data, FailedOperation):
         if return_dict:
-            return failure.dict()
-
-        return failure
-
-    except Exception as unk_err:
-        failure = FailedOperation(input_data=input_data,
-                                  success=False,
-                                  error=ComputeError(
-                                      error_type="unknown_input_error",
-                                      error_message="Input could not be validated for unknown reasons, "
-                                                    "likely due to invalid input data types:\n{}".format(unk_err)))
-        if return_dict:
-            return failure.dict()
-
-        return failure
+            return input_data.dict()
+        return input_data
 
     if local_options is None:
         local_options = {}
@@ -79,31 +59,16 @@ def compute(input_data, program, raise_error=False, capture_output=True, local_o
 
     # Run the program
     with compute_wrapper(capture_output=capture_output) as metadata:
+        output_data = input_data.copy()  # Initial in case of error handling
         try:
             output_data = get_program(program)(input_data, config)
-
         except KeyError as e:
-            output_data = FailedOperation(input_data=input_data.dict(),
+            output_data = FailedOperation(input_data=output_data.dict(),
                                           success=False,
                                           error=ComputeError(
                                               error_type='program_error',
                                               error_message="QCEngine Call Error:\nProgram {} not understood."
                                                             "\nError Message: {}".format(program, str(e))))
-
-        except ValidationError as e:
-            output_data = FailedOperation(input_data=input_data.dict(),
-                                          success=False,
-                                          error=ComputeError(
-                                             error_type="validation_error",
-                                             error_message=e.json()))
-
-        except Exception as e:
-            output_data = FailedOperation(input_data=input_data.dict(),
-                                          success=False,
-                                          error=ComputeError(
-                                              error_type="runtime_error",
-                                              error_message="QCEngine Error:\nError Message: {}".format(str(e))
-                                          ))
 
     return handle_output_metadata(output_data, metadata, raise_error=raise_error, return_dict=return_dict)
 
@@ -133,82 +98,33 @@ def compute_procedure(input_data, procedure, raise_error=False, capture_output=T
         A QC Schema representation of the requested output, type depends on return_dict key.
     """
 
-    try:
-        if isinstance(input_data, dict):
-            input_data = OptimizationInput(**input_data)
-
-    except ValidationError as val_error:
-        # Fix this more procedure-centric
-        failure = FailedOperation(input_data=input_data,
-                                  success=False,
-                                  error=ComputeError(
-                                      error_type="input_validation_error",
-                                      error_message="Input could not be validated for the following "
-                                                    "reasons:\n{}".format(val_error.json())))
+    input_data = model_wrapper(input_data, OptimizationInput)
+    if isinstance(input_data, FailedOperation):
         if return_dict:
-            return failure.dict()
-        return failure
-
-    except Exception as unk_err:
-        failure = FailedOperation(input_data=input_data,
-                                  success=False,
-                                  error=ComputeError(
-                                      error_type="unknown_input_error",
-                                      error_message="Input could not be validated for unknown reasons, "
-                                                    "likely due to invalid input data types:\n{}".format(unk_err)))
-        if return_dict:
-            return failure.dict()
-
-        return failure
+            return input_data.dict()
+        return input_data
 
     config = get_config(local_options=local_options)
 
     # Run the procedure
     with compute_wrapper(capture_output=capture_output) as metadata:
+        # Create a base output data in case of errors
+        output_data = input_data.copy()
         if procedure == "geometric":
-            try:
-                # Augment the input
-                geometric_input = input_data.dict()
-                geometric_input["input_specification"]["_qcengine_local_config"] = config.dict()
-                output_data = get_module_function(procedure, "run_json.geometric_run_json")(geometric_input)
-                if output_data["schema_name"] == "qc_schema_optimization_output":
-                    output_data["schema_name"] = "qcschema_optimization_output"
-                output_data["input_specification"].pop("_qcengine_local_config", None)
-                output_data = Optimization(**output_data)
-
-            except ModuleNotFoundError:
-                output_data = FailedOperation(input_data=input_data.dict(),
-                                                 success=False,
-                                                 error=ComputeError(
-                                                     error_type="import_error",
-                                                     error_message="Could not import {}".format(procedure)
-                                                 ))
-
-            except ValidationError as e:
-                output_data = FailedOperation(input_data=input_data.dict(),
-                                              success=False,
-                                              error=ComputeError(
-                                                  error_type="validation_error",
-                                                  error_message="Could not form output into Optimization, could be "
-                                                                "bad program outputs, or some other error\n"
-                                                                "Error Message: {}".format(e.json())))
-
-            except Exception as e:
-                output_data = FailedOperation(input_data=input_data.dict(),
-                                              success=False,
-                                              error=ComputeError(
-                                                  error_type="runtime_error",
-                                                  error_message="QCEngine RuntimeError:\n"
-                                                                "Something went wrong in procedure execution, see "
-                                                                "message for details:\n{}".format(str(e))))
-
+            # Augment the input
+            geometric_input = input_data.dict()
+            geometric_input["input_specification"]["_qcengine_local_config"] = config.dict()
+            output_data = get_module_function(procedure, "run_json.geometric_run_json")(geometric_input)
+            if output_data["schema_name"] == "qc_schema_optimization_output":
+                output_data["schema_name"] = "qcschema_optimization_output"
+            output_data["input_specification"].pop("_qcengine_local_config", None)
+            output_data = Optimization(**output_data)
         else:
             output_data = FailedOperation(input_data=input_data.dict(),
                                           success=False,
                                           error=ComputeError(
                                               error_type="program_error",
                                               error_message="QCEngine Call Error:"
-                                                            "\nProcedure {} not understood".format(procedure))
-)
+                                                            "\nProcedure {} not understood".format(procedure)))
 
     return handle_output_metadata(output_data, metadata, raise_error=raise_error, return_dict=return_dict)

--- a/qcengine/compute.py
+++ b/qcengine/compute.py
@@ -114,9 +114,11 @@ def compute_procedure(input_data, procedure, raise_error=False, capture_output=T
             # Augment the input
             geometric_input = input_data.dict()
             geometric_input["input_specification"]["_qcengine_local_config"] = config.dict()
+
+            # Run the program
             output_data = get_module_function(procedure, "run_json.geometric_run_json")(geometric_input)
-            if output_data["schema_name"] == "qc_schema_optimization_output":
-                output_data["schema_name"] = "qcschema_optimization_output"
+
+            output_data["schema_name"] = "qcschema_optimization_output"
             output_data["input_specification"].pop("_qcengine_local_config", None)
             output_data = Optimization(**output_data)
         else:

--- a/qcengine/compute.py
+++ b/qcengine/compute.py
@@ -2,14 +2,17 @@
 Integrates the computes together
 """
 
-import copy
+from qcelemental.models import ResultInput, QCEngineError, Result, FailedResult
+from qcelemental.models import OptimizationInput, FailedOptimization, Optimization
+from pydantic import ValidationError
 
 from .programs import get_program
 from .util import compute_wrapper, handle_output_metadata, get_module_function
 from .config import get_config
 
 
-def compute(input_data, program, raise_error=False, capture_output=True, local_options=None):
+def compute(input_data, program, raise_error=False, capture_output=True, local_options=None,
+            return_dict=True):
     """Executes a single quantum chemistry program given a QC Schema input.
 
     The full specification can be found at:
@@ -17,8 +20,8 @@ def compute(input_data, program, raise_error=False, capture_output=True, local_o
 
     Parameters
     ----------
-    input_data : dict
-        A QC Schema input specification
+    input_data : dict or qcelemental.models.ResultInput
+        A QC Schema input specification in dictionary or model from QCElemental.models
     program : {"psi4", "rdkit"}
         The program to run the input under
     raise_error : bool, optional
@@ -27,42 +30,86 @@ def compute(input_data, program, raise_error=False, capture_output=True, local_o
         Determines if stdout/stderr should be captured.
     local_options : dict, optional
         A dictionary of local configuration options
+    return_dict : bool, optional, default True
+        Returns a dict instead of qcelemental.models.ResultInput
 
     Returns
     -------
-    ret : dict
-        A QC Schema output
+    ret : dict or qcelemental.models.ResultInput
+        A QC Schema output, type depends on return_dict key
 
     """
-    input_data = copy.deepcopy(input_data)
+    try:
+        if isinstance(input_data, dict):
+            input_data = ResultInput(**input_data)
+    except ValidationError as val_error:
+        failure = FailedResult(**{**input_data,
+                               **{"success": False,
+                                  "error": QCEngineError(error_type="input_validation_error",
+                                                         error_message="Input could not be validated for the following "
+                                                                       "reasons:\n{}".format(val_error.json()))
+                                  }
+                                  })
+        if return_dict:
+            return failure.dict()
+
+        return failure
+
+    except Exception as unk_err:
+        failure = FailedResult(**{**input_data,
+                               **{"success": False,
+                                  "error": QCEngineError(
+                                      error_type="unknown_input_error",
+                                      error_message="Input could not be validated for unknown reasons, "
+                                                    "likely due to invalid input data types:\n{}".format(unk_err))}})
+        if return_dict:
+            return failure.dict()
+
+        return failure
 
     if local_options is None:
         local_options = {}
 
-    local_options = {**local_options, **input_data.pop("_qcengine_local_config", {})}
+    try:
+        input_engine_options = input_data._qcengine_local_config
+        input_data = input_data.copy(exclude={'_qcengine_local_config'})
+    except AttributeError:
+        input_engine_options = {}
+
+    local_options = {**local_options, **input_engine_options}
     config = get_config(local_options=local_options)
 
     # Run the program
     with compute_wrapper(capture_output=capture_output) as metadata:
-        output_data = input_data
         try:
             output_data = get_program(program)(input_data, config)
+
         except KeyError as e:
-            output_data["success"] = False
-            output_data[
-                "error_message"] = "QCEngine Call Error:\nProgram {} not understood.\nError Message: {}".format(
-                    program, str(e))
+            output_data = {"success": False,
+                           "error": QCEngineError(error_type='program_error',
+                                                  error_message="QCEngine Call Error:\nProgram {} not understood."
+                                                                "\nError Message: {}".format(program, str(e)))}
+            output_data = FailedResult(**input_data.dict(), **output_data)
 
-    return handle_output_metadata(output_data, metadata, raise_error=raise_error)
+        except ValidationError as e:
+            output_data = FailedResult(**input_data.dict(),
+                                       success=False,
+                                       error=QCEngineError(
+                                           error_type="validation_error",
+                                           error_message=e.json()
+                                       ))
+
+    return handle_output_metadata(output_data, metadata, raise_error=raise_error, return_dict=return_dict)
 
 
-def compute_procedure(input_data, procedure, raise_error=False, capture_output=True, local_options=None):
+def compute_procedure(input_data, procedure, raise_error=False, capture_output=True, local_options=None,
+                      return_dict=True):
     """Runs a procedure (a collection of the quantum chemistry executions)
 
     Parameters
     ----------
-    input_data : dict
-        A JSON input specific to the procedure executed
+    input_data : dict or qcelemental.models.OptimizationInput
+        A JSON input specific to the procedure executed in dictionary or model from QCElemental.models
     procedure : {"geometric"}
         The name of the procedure to run
     raise_error : bool, option
@@ -71,25 +118,81 @@ def compute_procedure(input_data, procedure, raise_error=False, capture_output=T
         Determines if stdout/stderr should be captured.
     local_options : dict, optional
         A dictionary of local configuration options
+    return_dict : bool, optional, default True
+        Returns a dict instead of qcelemental.models.ResultInput
 
     Returns
     ------
-    dict
-        A QC Schema representation of the requested output.
+    dict or qcelemental.models.Result
+        A QC Schema representation of the requested output, type depends on return_dict key.
     """
 
-    input_data = copy.deepcopy(input_data)
+    try:
+        if isinstance(input_data, dict):
+            input_data = OptimizationInput(**input_data)
+
+    except ValidationError as val_error:
+        # Fix this more procedure-centric
+        failure = FailedOptimization(**{**input_data,
+                                     **{"success": False,
+                                        "error": QCEngineError(
+                                            error_type="input_validation_error",
+                                            error_message="Input could not be validated for the following "
+                                                          "reasons:\n{}".format(val_error.json()))
+                                        }
+                                        })
+        if return_dict:
+            return failure.dict()
+        return failure
+
     config = get_config(local_options=local_options)
 
     # Run the procedure
     with compute_wrapper(capture_output=capture_output) as metadata:
-        output_data = input_data
         if procedure == "geometric":
-            input_data["input_specification"]["_qcengine_local_config"] = config.dict()
-            output_data = get_module_function("geometric", "run_json.geometric_run_json")(input_data)
-            del input_data["input_specification"]["_qcengine_local_config"]
-        else:
-            output_data["success"] = False
-            output_data["error_message"] = "QCEngine Call Error:\nProcedure {} not understood".format(program)
+            try:
+                # Augment the input
+                geometric_input = input_data.dict()
+                geometric_input["input_specification"]["_qcengine_local_config"] = config.dict()
+                output_data = get_module_function(procedure, "run_json.geometric_run_json")(geometric_input)
+                if output_data["schema_name"] == "qc_schema_optimization_output":
+                    output_data["schema_name"] = "qcschema_optimization_output"
+                output_data["input_specification"].pop("_qcengine_local_config", None)
+                output_data = Optimization(**output_data)
 
-    return handle_output_metadata(output_data, metadata, raise_error=raise_error)
+            except ModuleNotFoundError:
+                output_data = FailedOptimization(**input_data.dict(),
+                                                 success=False,
+                                                 error=QCEngineError(
+                                                     error_type="import_error",
+                                                     error_message="Could not import {}".format(procedure)
+                                                 ))
+
+            except ValidationError as e:
+                output_data = FailedOptimization(**input_data.dict(),
+                                                 success=False,
+                                                 error=QCEngineError(
+                                                     error_type="validation_error",
+                                                     error_message=e.json()
+                                                 ))
+
+            except Exception as e:
+                output_data = FailedOptimization(**input_data.dict(),
+                                                 success=False,
+                                                 error=QCEngineError(
+                                                     error_type="runtime_error",
+                                                     error_message="QCEngine RuntimeError:\n"
+                                                                   "Something went wrong in procedure execution, see "
+                                                                   "message for details:\n{}".format(str(e))
+                                                 ))
+
+        else:
+            output_data = FailedOptimization(**input_data.dict(),
+                                             success=False,
+                                             error=QCEngineError(
+                                                 error_type="program_error",
+                                                 error_message="QCEngine Call Error:"
+                                                               "\nProcedure {} not understood".format(procedure))
+                                             )
+
+    return handle_output_metadata(output_data, metadata, raise_error=raise_error, return_dict=return_dict)

--- a/qcengine/config.py
+++ b/qcengine/config.py
@@ -2,14 +2,14 @@
 Creates globals for the qcengine module
 """
 
-import copy
 import fnmatch
 import getpass
 import logging
 import os
 import socket
 
-from typing import Optional, Dict, Union
+from typing import Optional, Union
+from qcelemental.models import Provenance
 
 import cpuinfo
 import psutil
@@ -126,7 +126,7 @@ def global_repr():
     ret += "Host information:\n"
     ret += "-" * 80 + "\n"
 
-    prov = get_provenance()
+    prov = get_provenance().dict()
     for k in ["username", "hostname", "cpu"]:
         ret += "{:<30} {:<30}\n".format(k, prov[k])
 
@@ -228,12 +228,13 @@ def get_config(*, hostname=None, local_options=None):
 
 def get_provenance():
     from qcengine import __version__
-    ret = {
-        "cpu": GLOBALS["cpu"],
-        "hostname": GLOBALS["hostname"],
-        "username": GLOBALS["username"],
-        "qcengine_version": __version__
-    }
+    ret = Provenance(
+        cpu=GLOBALS["cpu"],
+        hostname=GLOBALS["hostname"],
+        username=GLOBALS["username"],
+        version=__version__,
+        creator="QCEngine"
+    )
 
     return ret
 

--- a/qcengine/config.py
+++ b/qcengine/config.py
@@ -16,7 +16,7 @@ import psutil
 import pydantic
 import yaml
 
-__all__ = ["get_config", "get_provenance", "global_repr", "NodeDescriptor"]
+__all__ = ["get_config", "get_provenance_augments", "global_repr", "NodeDescriptor"]
 
 # Start a globals dictionary with small starting values
 CPUINFO = cpuinfo.get_cpu_info()
@@ -126,7 +126,7 @@ def global_repr():
     ret += "Host information:\n"
     ret += "-" * 80 + "\n"
 
-    prov = get_provenance().dict()
+    prov = get_provenance_augments()
     for k in ["username", "hostname", "cpu"]:
         ret += "{:<30} {:<30}\n".format(k, prov[k])
 
@@ -226,17 +226,14 @@ def get_config(*, hostname=None, local_options=None):
     return JobConfig(**config)
 
 
-def get_provenance():
+def get_provenance_augments():
     from qcengine import __version__
-    ret = Provenance(
+    return dict(
         cpu=GLOBALS["cpu"],
         hostname=GLOBALS["hostname"],
         username=GLOBALS["username"],
         qcengine_version=__version__,
-        creator="QCEngine"
     )
-
-    return ret
 
 
 def get_logger():

--- a/qcengine/config.py
+++ b/qcengine/config.py
@@ -7,9 +7,7 @@ import getpass
 import logging
 import os
 import socket
-
-from typing import Optional, Union
-from qcelemental.models import Provenance
+from typing import Optional
 
 import cpuinfo
 import psutil
@@ -99,7 +97,6 @@ def _load_defaults():
             load_path = path
             break
 
-    found_default = False
     if load_path is None:
         LOGGER.info("Could not find 'qcengine.yaml'. Searched the following paths: {}".format(", ".join(test_paths)))
         LOGGER.info("Using default options...")

--- a/qcengine/config.py
+++ b/qcengine/config.py
@@ -232,7 +232,7 @@ def get_provenance():
         cpu=GLOBALS["cpu"],
         hostname=GLOBALS["hostname"],
         username=GLOBALS["username"],
-        version=__version__,
+        qcengine_version=__version__,
         creator="QCEngine"
     )
 

--- a/qcengine/programs/__init__.py
+++ b/qcengine/programs/__init__.py
@@ -2,15 +2,20 @@
 Imports the various compute backends
 """
 
+from . import psi4
+from . import rdkit
+from . import torchani
+
 __all__ = ["register_program", "get_program", "get_programs"]
 
 programs = {}
+
 
 def register_program(name, entry_point):
     if name in programs.keys():
         raise ValueError('{} is already a registered program.'.format(name))
 
-    programs[name] = { 'entry_point': entry_point }
+    programs[name] = {'entry_point': entry_point}
 
 
 def get_program(name):
@@ -21,11 +26,6 @@ def get_programs():
     return programs.keys()
 
 
-from . import psi4
 register_program('psi4', psi4.psi4)
-
-from . import rdkit
 register_program('rdkit', rdkit.rdkit)
-
-from . import torchani
 register_program('torchani', torchani.torchani)

--- a/qcengine/programs/psi4.py
+++ b/qcengine/programs/psi4.py
@@ -65,6 +65,5 @@ def psi4(input_model, config):
         output_data["provenance"]["nthreads"] = input_data["nthreads"]
         del output_data["memory"], input_data["nthreads"]
         return Result(**output_data)
-    return FailedOperation(success=output_data.pop("success", False),
-                           error=output_data.pop("error"),
-                           input_data=output_data)
+    return FailedOperation(
+        success=output_data.pop("success", False), error=output_data.pop("error"), input_data=output_data)

--- a/qcengine/programs/psi4.py
+++ b/qcengine/programs/psi4.py
@@ -3,7 +3,7 @@ Calls the Psi4 executable.
 """
 
 from pkg_resources import parse_version
-from qcelemental.models import Result, FailedResult
+from qcelemental.models import Result, FailedOperation
 
 
 def _parse_psi_version(version):
@@ -65,4 +65,6 @@ def psi4(input_model, config):
         output_data["provenance"]["nthreads"] = input_data["nthreads"]
         del output_data["memory"], input_data["nthreads"]
         return Result(**output_data)
-    return FailedResult(**output_data)
+    return FailedOperation(success=output_data.pop("success", False),
+                           error=output_data.pop("error"),
+                           input_data=output_data)

--- a/qcengine/programs/rdkit.py
+++ b/qcengine/programs/rdkit.py
@@ -3,9 +3,10 @@ Calls the Psi4 executable.
 """
 
 from qcengine.units import ureg
+from qcelemental.models import Result, QCEngineError, Provenance, FailedResult
 
 
-def rdkit(ret_data, config):
+def rdkit(input_data, config):
     """
     Runs RDKit in FF typing
     """
@@ -18,76 +19,83 @@ def rdkit(ret_data, config):
         raise ImportError("Could not find RDKit in the Python path.")
 
     # Failure flag
-    ret_data["success"] = False
+    ret_data = {"success": False}
 
     # Build the Molecule
-    jmol = ret_data["molecule"]
+    jmol = input_data.molecule
 
     # Handle errors
-    if ("molecular_charge" in jmol) and (abs(jmol["molecular_charge"]) < 1.e-6):
-        ret_data["error_message"] = "run_rdkit does not currently support charged molecules"
-        return ret_data
+    if abs(jmol.molecular_charge > 1.e-6):
+        ret_data["error"] = QCEngineError(error_type="input_error",
+                                          error_message="run_rdkit does not currently support charged molecules")
+        return FailedResult(**input_data.dict(), **ret_data)
 
-    if "connectivity" not in jmol:
-        ret_data["error_message"] = "run_rdkit molecule must have a connectivity graph"
-        return ret_data
+    if not jmol.connectivity:  # Check for empty list
+        ret_data["error"] = QCEngineError(error_type="input_error",
+                                          error_message="run_rdkit molecule must have a connectivity graph")
+        return FailedResult(**input_data.dict(), **ret_data)
 
     # Build out the base molecule
     base_mol = Chem.Mol()
     rw_mol = Chem.RWMol(base_mol)
-    for sym in jmol["symbols"]:
+    for sym in jmol.symbols:
         rw_mol.AddAtom(Chem.Atom(sym.title()))
 
     # Add in connectivity
     bond_types = {1: Chem.BondType.SINGLE, 2: Chem.BondType.DOUBLE, 3: Chem.BondType.TRIPLE}
-    for atom1, atom2, bo in jmol["connectivity"]:
+    for atom1, atom2, bo in jmol.connectivity:
         rw_mol.AddBond(atom1, atom2, bond_types[bo])
 
     mol = rw_mol.GetMol()
 
     # Write out the conformer
-    natom = len(jmol["symbols"])
+    natom = len(jmol.symbols)
     conf = Chem.Conformer(natom)
     bohr2ang = ureg.conversion_factor("bohr", "angstrom")
     for line in range(natom):
-        conf.SetAtomPosition(line, (bohr2ang * jmol["geometry"][line * 3],
-                                    bohr2ang * jmol["geometry"][line * 3 + 1],
-                                    bohr2ang * jmol["geometry"][line * 3 + 2])) # yapf: disable
+        conf.SetAtomPosition(line, (bohr2ang * jmol.geometry[line, 0],
+                                    bohr2ang * jmol.geometry[line, 1],
+                                    bohr2ang * jmol.geometry[line, 2]))  # yapf: disable
 
     mol.AddConformer(conf)
     Chem.rdmolops.SanitizeMol(mol)
 
-    if ret_data["model"]["method"] == "UFF":
+    if input_data.model.method == "UFF":
         ff = AllChem.UFFGetMoleculeForceField(mol)
         all_params = AllChem.UFFHasAllMoleculeParams(mol)
     else:
-        ret_data["error_message"] = "run_rdkit can only accepts UFF methods"
-        return ret_data
+        ret_data["error"] = QCEngineError(error_type="input_error",
+                                          error_message="run_rdkit can only accepts UFF methods")
+        return FailedResult(**input_data.dict(), **ret_data)
 
     if all_params is False:
-        ret_data["error_message"] = "run_rdkit did not match all parameters to molecule"
-        return ret_data
+        ret_data["error"] = QCEngineError(error_type="input_error",
+                                          error_message="run_rdkit did not match all parameters to molecule")
+        return FailedResult(**{**input_data.dict(), **ret_data})
 
     ff.Initialize()
 
     ret_data["properties"] = {"return_energy": ff.CalcEnergy() * ureg.conversion_factor("kJ / mol", "hartree")}
 
-    if ret_data["driver"] == "energy":
+    if input_data.driver == "energy":
         ret_data["return_result"] = ret_data["properties"]["return_energy"]
-    elif ret_data["driver"] == "gradient":
+    elif input_data.driver == "gradient":
         coef = ureg.conversion_factor("kJ / mol", "hartree") * ureg.conversion_factor("angstrom", "bohr")
         ret_data["return_result"] = [x * coef for x in ff.CalcGrad()]
     else:
-        ret_data["error_message"] = "run_rdkit did not understand driver method '{}'.".format(ret_data["driver"])
-        return ret_data
+        ret_data["error"] = QCEngineError(error_type="input_error",
+                                          error_message="run_rdkit did not understand driver method "
+                                                      "'{}'.".format(ret_data["driver"]))
+        return FailedResult(**{**input_data.dict(), **ret_data})
 
-    ret_data["provenance"] = {
-        "creator": "rdkit",
-        "version": rdkit.__version__,
-        "routine": "rdkit.Chem.AllChem.UFFGetMoleculeForceField"
-    }
+    ret_data["provenance"] = Provenance(
+        creator="rdkit",
+        version=rdkit.__version__,
+        routine="rdkit.Chem.AllChem.UFFGetMoleculeForceField"
+    )
 
-    ret_data["schema_name"] = "qc_schema_output"
+    ret_data["schema_name"] = "qcschema_output"
     ret_data["success"] = True
 
-    return ret_data
+    # Form up a dict first, then sent to BaseModel to avoid repeat kwargs which don't override each other
+    return Result(**{**input_data.dict(), **ret_data})

--- a/qcengine/programs/rdkit.py
+++ b/qcengine/programs/rdkit.py
@@ -3,7 +3,7 @@ Calls the Psi4 executable.
 """
 
 from qcengine.units import ureg
-from qcelemental.models import Result, QCEngineError, Provenance, FailedResult
+from qcelemental.models import Result, ComputeError, Provenance, FailedOperation
 
 
 def rdkit(input_data, config):
@@ -25,15 +25,15 @@ def rdkit(input_data, config):
     jmol = input_data.molecule
 
     # Handle errors
-    if abs(jmol.molecular_charge > 1.e-6):
-        ret_data["error"] = QCEngineError(error_type="input_error",
-                                          error_message="run_rdkit does not currently support charged molecules")
-        return FailedResult(**input_data.dict(), **ret_data)
+    if abs(jmol.molecular_charge) > 1.e-6:
+        ret_data["error"] = ComputeError(error_type="input_error",
+                                         error_message="run_rdkit does not currently support charged molecules")
+        return FailedOperation(input_data=input_data.dict(), **ret_data)
 
     if not jmol.connectivity:  # Check for empty list
-        ret_data["error"] = QCEngineError(error_type="input_error",
-                                          error_message="run_rdkit molecule must have a connectivity graph")
-        return FailedResult(**input_data.dict(), **ret_data)
+        ret_data["error"] = ComputeError(error_type="input_error",
+                                         error_message="run_rdkit molecule must have a connectivity graph")
+        return FailedOperation(input_data=input_data.dict(), **ret_data)
 
     # Build out the base molecule
     base_mol = Chem.Mol()
@@ -64,14 +64,14 @@ def rdkit(input_data, config):
         ff = AllChem.UFFGetMoleculeForceField(mol)
         all_params = AllChem.UFFHasAllMoleculeParams(mol)
     else:
-        ret_data["error"] = QCEngineError(error_type="input_error",
-                                          error_message="run_rdkit can only accepts UFF methods")
-        return FailedResult(**input_data.dict(), **ret_data)
+        ret_data["error"] = ComputeError(error_type="input_error",
+                                         error_message="run_rdkit can only accepts UFF methods")
+        return FailedOperation(input_data=input_data.dict(), **ret_data)
 
     if all_params is False:
-        ret_data["error"] = QCEngineError(error_type="input_error",
-                                          error_message="run_rdkit did not match all parameters to molecule")
-        return FailedResult(**{**input_data.dict(), **ret_data})
+        ret_data["error"] = ComputeError(error_type="input_error",
+                                         error_message="run_rdkit did not match all parameters to molecule")
+        return FailedOperation(input_data=input_data.dict(), **ret_data)
 
     ff.Initialize()
 
@@ -83,10 +83,10 @@ def rdkit(input_data, config):
         coef = ureg.conversion_factor("kJ / mol", "hartree") * ureg.conversion_factor("angstrom", "bohr")
         ret_data["return_result"] = [x * coef for x in ff.CalcGrad()]
     else:
-        ret_data["error"] = QCEngineError(error_type="input_error",
-                                          error_message="run_rdkit did not understand driver method "
-                                                      "'{}'.".format(ret_data["driver"]))
-        return FailedResult(**{**input_data.dict(), **ret_data})
+        ret_data["error"] = ComputeError(error_type="input_error",
+                                         error_message="run_rdkit did not understand driver method "
+                                                       "'{}'.".format(ret_data["driver"]))
+        return FailedOperation(input_data=input_data.dict(), **ret_data)
 
     ret_data["provenance"] = Provenance(
         creator="rdkit",

--- a/qcengine/programs/rdkit.py
+++ b/qcengine/programs/rdkit.py
@@ -2,8 +2,8 @@
 Calls the Psi4 executable.
 """
 
-from qcengine.units import ureg
 from qcelemental.models import Result, ComputeError, Provenance, FailedOperation
+from qcengine.units import ureg
 
 
 def rdkit(input_data, config):
@@ -26,13 +26,13 @@ def rdkit(input_data, config):
 
     # Handle errors
     if abs(jmol.molecular_charge) > 1.e-6:
-        ret_data["error"] = ComputeError(error_type="input_error",
-                                         error_message="run_rdkit does not currently support charged molecules")
+        ret_data["error"] = ComputeError(
+            error_type="input_error", error_message="run_rdkit does not currently support charged molecules")
         return FailedOperation(input_data=input_data.dict(), **ret_data)
 
     if not jmol.connectivity:  # Check for empty list
-        ret_data["error"] = ComputeError(error_type="input_error",
-                                         error_message="run_rdkit molecule must have a connectivity graph")
+        ret_data["error"] = ComputeError(
+            error_type="input_error", error_message="run_rdkit molecule must have a connectivity graph")
         return FailedOperation(input_data=input_data.dict(), **ret_data)
 
     # Build out the base molecule
@@ -64,13 +64,13 @@ def rdkit(input_data, config):
         ff = AllChem.UFFGetMoleculeForceField(mol)
         all_params = AllChem.UFFHasAllMoleculeParams(mol)
     else:
-        ret_data["error"] = ComputeError(error_type="input_error",
-                                         error_message="run_rdkit can only accepts UFF methods")
+        ret_data["error"] = ComputeError(
+            error_type="input_error", error_message="run_rdkit can only accepts UFF methods")
         return FailedOperation(input_data=input_data.dict(), **ret_data)
 
     if all_params is False:
-        ret_data["error"] = ComputeError(error_type="input_error",
-                                         error_message="run_rdkit did not match all parameters to molecule")
+        ret_data["error"] = ComputeError(
+            error_type="input_error", error_message="run_rdkit did not match all parameters to molecule")
         return FailedOperation(input_data=input_data.dict(), **ret_data)
 
     ff.Initialize()
@@ -83,16 +83,14 @@ def rdkit(input_data, config):
         coef = ureg.conversion_factor("kJ / mol", "hartree") * ureg.conversion_factor("angstrom", "bohr")
         ret_data["return_result"] = [x * coef for x in ff.CalcGrad()]
     else:
-        ret_data["error"] = ComputeError(error_type="input_error",
-                                         error_message="run_rdkit did not understand driver method "
-                                                       "'{}'.".format(ret_data["driver"]))
+        ret_data["error"] = ComputeError(
+            error_type="input_error",
+            error_message="run_rdkit did not understand driver method "
+            "'{}'.".format(ret_data["driver"]))
         return FailedOperation(input_data=input_data.dict(), **ret_data)
 
     ret_data["provenance"] = Provenance(
-        creator="rdkit",
-        version=rdkit.__version__,
-        routine="rdkit.Chem.AllChem.UFFGetMoleculeForceField"
-    )
+        creator="rdkit", version=rdkit.__version__, routine="rdkit.Chem.AllChem.UFFGetMoleculeForceField")
 
     ret_data["schema_name"] = "qcschema_output"
     ret_data["success"] = True

--- a/qcengine/programs/torchani.py
+++ b/qcengine/programs/torchani.py
@@ -3,7 +3,7 @@ Calls the Psi4 executable.
 """
 
 from qcengine.units import ureg
-from qcelemental.models import Result, QCEngineError, Provenance
+from qcelemental.models import Result, ComputeError, Provenance, FailedOperation
 
 _CACHE = {}
 
@@ -53,18 +53,18 @@ def torchani(input_data, config):
     # Build model
     model = get_model(input_data.model.method)
     if model is False:
-        ret_data["error"] = QCEngineError(error_type="input_error",
-                                          error_message="run_torchani only accepts the ANI1 method.")
-        return Result(**{**input_data.dict(), **ret_data})
+        ret_data["error"] = ComputeError(error_type="input_error",
+                                         error_message="run_torchani only accepts the ANI1 method.")
+        return FailedOperation(input_data=input_data.dict(), **ret_data)
 
     # Build species
     species = "".join(input_data.molecule.symbols)
     unknown_sym = set(species) - {"H", "C", "N", "O"}
     if unknown_sym:
-        ret_data["error"] = QCEngineError(error_type="input_error",
-                                          error_message="The '{}' model does not support symbols: {}.".format(
+        ret_data["error"] = ComputeError(error_type="input_error",
+                                         error_message="The '{}' model does not support symbols: {}.".format(
                                             input_data.model.method, unknown_sym))
-        return Result(**{**input_data.dict(), **ret_data})
+        return FailedOperation(input_data=input_data.dict(), **ret_data)
 
     species = builtin.consts.species_to_tensor(species).to(device).unsqueeze(0)
 
@@ -81,10 +81,10 @@ def torchani(input_data, config):
         derivative = torch.autograd.grad(energy.sum(), coordinates)[0].squeeze()
         ret_data["return_result"] = np.asarray(derivative * ureg.conversion_factor("angstrom", "bohr")).ravel().tolist()
     else:
-        ret_data["error"] = QCEngineError(error_type="input_error",
-                                          error_message="run_torchani did not understand driver method '{}'.".format(
+        ret_data["error"] = ComputeError(error_type="input_error",
+                                         error_message="run_torchani did not understand driver method '{}'.".format(
                                             input_data.driver))
-        return Result(**{**input_data.dict(), **ret_data})
+        return FailedOperation(input_data=input_data.dict(), **ret_data)
 
     ret_data["provenance"] = Provenance(
         creator="torchani",

--- a/qcengine/stock_mols.py
+++ b/qcengine/stock_mols.py
@@ -3,6 +3,8 @@ A small list of molecules used to validate and tests computation.
 """
 
 import copy
+from qcelemental.models import Molecule
+
 
 _test_mols = {
     "hydrogen": {
@@ -35,4 +37,4 @@ def get_molecule(name):
     if name not in _test_mols:
         raise KeyError("Molecule name '{}' not found".format(name))
 
-    return copy.deepcopy(_test_mols[name])
+    return copy.deepcopy(Molecule(**_test_mols[name]))

--- a/qcengine/stock_mols.py
+++ b/qcengine/stock_mols.py
@@ -3,8 +3,8 @@ A small list of molecules used to validate and tests computation.
 """
 
 import copy
-from qcelemental.models import Molecule
 
+from qcelemental.models import Molecule
 
 _test_mols = {
     "hydrogen": {

--- a/qcengine/tests/test_compute.py
+++ b/qcengine/tests/test_compute.py
@@ -15,7 +15,7 @@ _base_json = {"schema_name": "qcschema_input", "schema_version": 1}
 def test_missing_key():
     ret = dc.compute({"hello": "hi"}, "bleh")
     assert ret["success"] is False
-    assert "hello" in ret
+    assert "hello" in ret or ("input_data" in ret and "hello" in ret["input_data"])
 
 
 @addons.using_psi4

--- a/qcengine/tests/test_compute.py
+++ b/qcengine/tests/test_compute.py
@@ -9,7 +9,7 @@ import pytest
 import qcengine as dc
 from . import addons
 
-_base_json = {"schema_name": "qc_schema_input", "schema_version": 1}
+_base_json = {"schema_name": "qcschema_input", "schema_version": 1}
 
 
 def test_missing_key():
@@ -69,7 +69,7 @@ def test_rdkit_task():
 @addons.using_rdkit
 def test_rdkit_connectivity_error():
     json_data = copy.deepcopy(_base_json)
-    json_data["molecule"] = dc.get_molecule("water")
+    json_data["molecule"] = dc.get_molecule("water").dict()
     json_data["driver"] = "gradient"
     json_data["model"] = {"method": "UFF", "basis": ""}
     json_data["keywords"] = {}
@@ -78,10 +78,12 @@ def test_rdkit_connectivity_error():
 
     ret = dc.compute(json_data, "rdkit")
     assert ret["success"] is False
-    assert "connectivity" in ret["error_message"]
+    assert "error" in ret
+    assert "connectivity" in ret["error"]["error_message"]
 
     with pytest.raises(ValueError):
-        ret = dc.compute(json_data, "rdkit", raise_error=True)
+        _ = dc.compute(json_data, "rdkit", raise_error=True)
+
 
 @addons.using_torchani
 def test_torchani_task():

--- a/qcengine/util.py
+++ b/qcengine/util.py
@@ -11,7 +11,7 @@ import traceback
 from contextlib import contextmanager
 
 from . import config
-from qcelemental.models import Result
+from qcelemental.models import FailedOperation
 
 __all__ = ["compute_wrapper", "get_module_function"]
 
@@ -131,4 +131,10 @@ def handle_output_metadata(output_data, metadata, raise_error=False, return_dict
     if return_dict:
         return output_fusion
     # We need to return the correct objects; e.g. Results, Procedures; if return_dict it False
-    return Result(**output_fusion)
+    # This is currently not tested
+    if output_fusion["success"]:
+        return output_data.__class__(**output_fusion)
+    # Should only be reachable on failures
+    return FailedOperation(success=output_fusion.pop("success", False),
+                           error=output_fusion.pop("error"),
+                           input_data=output_fusion)

--- a/qcengine/util.py
+++ b/qcengine/util.py
@@ -153,13 +153,17 @@ def handle_output_metadata(output_data, metadata, raise_error=False, return_dict
         provenance_augments["version"] = provenance_augments["qcengine_version"]
         output_fusion["provenance"] = provenance_augments
 
-    if return_dict:
-        return output_fusion
-    # We need to return the correct objects; e.g. Results, Procedures; if return_dict it False
-    # This is currently not tested
+
+    # We need to return the correct objects; e.g. Results, Procedures
     if output_fusion["success"]:
-        return output_data.__class__(**output_fusion)  # This will only execute if everything went well
-    # Should only be reachable on failures
-    return FailedOperation(success=output_fusion.pop("success", False),
-                           error=output_fusion.pop("error"),
+        # This will only execute if everything went well
+        ret = output_data.__class__(**output_fusion)
+    else:
+        # Should only be reachable on failures
+        ret = FailedOperation(success=output_fusion.pop("success", False),
+                               error=output_fusion.pop("error"),
                            input_data=output_fusion)
+    if return_dict:
+        return ret.dict()
+    else:
+        return ret

--- a/qcengine/util.py
+++ b/qcengine/util.py
@@ -11,8 +11,10 @@ import traceback
 from contextlib import contextmanager
 
 from . import config
+from qcelemental.models import Result
 
 __all__ = ["compute_wrapper", "get_module_function"]
+
 
 @contextmanager
 def compute_wrapper(capture_output=True):
@@ -59,6 +61,7 @@ def compute_wrapper(capture_output=True):
         ret["stdout"] = "stdout not captured"
         ret["stderr"] = "stderr not captured"
 
+
 def get_module_function(module, func_name, subpackage=None):
     """Obtains a function from a given string
 
@@ -89,30 +92,43 @@ def get_module_function(module, func_name, subpackage=None):
 
     return operator.attrgetter(func_name)(pkg)
 
-def handle_output_metadata(output_data, metadata, raise_error=False):
+
+def handle_output_metadata(output_data, metadata, raise_error=False, return_dict=True):
     """
     Fuses general metadata and output together.
+
+    Returns
+    -------
+    result : dict or pydantic.models.Result
+        Output type depends on return_dict or a dict if an error was generated in model construction
     """
 
-    output_data["stdout"] = metadata["stdout"]
-    output_data["stderr"] = metadata["stderr"]
+    output_fusion = output_data.dict()
+
+    output_fusion["stdout"] = metadata["stdout"]
+    output_fusion["stderr"] = metadata["stderr"]
     if metadata["success"] is not True:
-        output_data["success"] = False
-        output_data["error_message"] = metadata["error_message"]
+        output_fusion["success"] = False
+        output_fusion["error"] = {"error_type": "meta_error",
+                                  "error_message": metadata["error_message"]}
 
     # Raise an error if one exists and a user requested a raise
-    if raise_error and (output_data["success"] is not True):
-        msg = "stdout:\n" + output_data["stdout"]
-        msg += "\nstderr:\n" + output_data["stderr"]
+    if raise_error and (output_fusion["success"] is not True):
+        msg = "stdout:\n" + output_fusion["stdout"]
+        msg += "\nstderr:\n" + output_fusion["stderr"]
         print(msg)
-        raise ValueError(output_data["error_message"])
+        raise ValueError(output_fusion["error"]["error_message"])
 
     # Fill out provenance datadata
-    if "provenance" in output_data:
-        output_data["provenance"].update(config.get_provenance())
+    wall_time = metadata["wall_time"]
+    base_provenance_dict = config.get_provenance().dict()
+    base_provenance_dict["wall_time"] = wall_time
+    if "provenance" in output_fusion:
+        output_fusion["provenance"].update(base_provenance_dict)
     else:
-        output_data["provenance"] = config.get_provenance()
+        output_fusion["provenance"] = base_provenance_dict
 
-    output_data["provenance"]["wall_time"] = metadata["wall_time"]
-
-    return output_data
+    if return_dict:
+        return output_fusion
+    # We need to return the correct objects; e.g. Results, Procedures; if return_dict it False
+    return Result(**output_fusion)

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,8 @@ if __name__ == "__main__":
             'pyyaml',
             'py-cpuinfo',
             'psutil',
-            'qcelemental>=0.1.3',
-            'pydantic'
+            'qcelemental>=0.2.1',
+            'pydantic>=0.18.0'
         ],
         entry_points={"console_scripts": [
             "qcengine=qcengine.cli:main",


### PR DESCRIPTION
This is an overhaul to the QCEngine program to work with the
Pydantic Models which have been/will be added to the QCElemental package.

Right now, the models are all internal and will always return the
flattened dictionary of near-pure Python objects (numpy arrays being an exception).
The emitted objects should have no Pydantic in them, and right now will not
correctly emit in many casses; errors, procedures; if you try. As we continue
the integration of the QCElemental objects into QCA as a whole, we can
revisit this and get it working correctly.

This will need review since it changes a very large swath of code, all of which
had to be changed to get the tests passing.

Depends on molssi/qcelemental#17