### PR TITLE
Reworks Config

### DIFF
--- a/qcengine/programs/psi4.py
+++ b/qcengine/programs/psi4.py
@@ -28,7 +28,7 @@ def psi4(input_data, config):
         raise ImportError("Could not find Psi4 in the Python path.")
 
     # Setup the job
-    input_data["nthreads"] = config.nthreads
+    input_data["nthreads"] = config.ncores
     input_data["memory"] = int(config.memory * 1024 * 1024 * 1024 * 0.95)  # Memory in bytes
     input_data["success"] = False
 

--- a/qcengine/tests/test_config.py
+++ b/qcengine/tests/test_config.py
@@ -95,7 +95,7 @@ def opt_state_basic():
             "jobs_per_node": 1,
             "memory": 4,
             "memory_safety_factor": 0,
-            "ncores": 2,
+            "ncores": 5,
             "scratch_directory": "$QCA_SCRATCH_DIR"
         }]
         for desc in configs:
@@ -130,19 +130,40 @@ def test_node_env(opt_state_basic):
 
 
 def test_config_default(opt_state_basic):
-    config = qcengine.config.get_config("something")
-    assert config.ncores == 2
+    config = qcengine.config.get_config(hostname="something")
+    assert config.ncores == 5
     assert config.memory == 4
 
-    config = qcengine.config.get_config("dt149")
+    config = qcengine.config.get_config(hostname="dt149")
     assert config.ncores == 6
     assert pytest.approx(config.memory, 0.1) == 54
 
 
-def test_config_local(opt_state_basic):
-    config = qcengine.config.get_config("something", {"ncores": 10})
+def test_config_local_ncores(opt_state_basic):
+    config = qcengine.config.get_config(hostname="something", local_options={"ncores": 10})
     assert config.ncores == 10
     assert config.memory == 4
+
+
+def test_config_local_njobs(opt_state_basic):
+    config = qcengine.config.get_config(hostname="something", local_options={"jobs_per_node": 5})
+    assert config.ncores == 1
+    assert pytest.approx(config.memory) == 0.8
+
+
+def test_config_local_njob_ncore(opt_state_basic):
+    config = qcengine.config.get_config(hostname="something", local_options={"jobs_per_node": 3, "ncores": 1})
+    assert config.ncores == 1
+    assert pytest.approx(config.memory, 0.1) == 1.33
+
+
+def test_config_local_njob_ncore(opt_state_basic):
+    config = qcengine.config.get_config(
+        hostname="something", local_options={"jobs_per_node": 3,
+                                             "ncores": 1,
+                                             "memory": 6})
+    assert config.ncores == 1
+    assert pytest.approx(config.memory, 0.1) == 6
 
 
 def test_config_validation(opt_state_basic):


### PR DESCRIPTION
Another Config rework. Still playing around with this in regard to dealing with multiple queue managers. Effectively this allows to have a bit more control over the actual job execution and lessens the general node descriptions. This is interoperating with Parsl/Fireworks/Dask/Slurm/Torque/Cobalt a bit better.