### PR TITLE
Cleanup to emulate old style returns

### DIFF
--- a/qcengine/compute.py
+++ b/qcengine/compute.py
@@ -112,7 +112,7 @@ def compute_procedure(input_data,
     # Run the procedure
     with compute_wrapper(capture_output=capture_output) as metadata:
         # Create a base output data in case of errors
-        output_data = input_data.copy()  # lgtm[py/multiple-definition]
+        output_data = input_data.copy()  # lgtm [py/multiple-definition]
         if procedure == "geometric":
             # Augment the input
             geometric_input = input_data.dict()

--- a/qcengine/compute.py
+++ b/qcengine/compute.py
@@ -112,6 +112,7 @@ def compute_procedure(input_data,
     # Run the procedure
     with compute_wrapper(capture_output=capture_output) as metadata:
         # Create a base output data in case of errors
+        output_data = input_data.copy()  # lgtm[py/multiple-definition]
         if procedure == "geometric":
             # Augment the input
             geometric_input = input_data.dict()

--- a/qcengine/util.py
+++ b/qcengine/util.py
@@ -4,6 +4,7 @@ Several import utilities
 
 import importlib
 import io
+import json
 import operator
 import sys
 import time
@@ -161,6 +162,6 @@ def handle_output_metadata(output_data, metadata, raise_error=False, return_dict
         ret = FailedOperation(
             success=output_fusion.pop("success", False), error=output_fusion.pop("error"), input_data=output_fusion)
     if return_dict:
-        return ret.dict()
+        return json.loads(ret.json())  # Use Pydantic to serialize, then reconstruct as Python dict of Python Primals
     else:
         return ret


### PR DESCRIPTION
Ensures the compute dicts are returned as python primatives and let
pydantic serialize the objects

Also ensure output_data exists in all error catching. Told LGTM to
ignore this particular error because its expected

Needed to fix QCFractal 