### PR TITLE
Psi4: Ensures output always goes to stdout field

### DIFF
--- a/devtools/conda-envs/psi.yaml
+++ b/devtools/conda-envs/psi.yaml
@@ -9,7 +9,7 @@ dependencies:
   - pyyaml
   - py-cpuinfo
   - psutil
-  - qcelemental >=0.2.2
+  - qcelemental >=0.2.6
   - pydantic >=0.18.1
 
     # Testing

--- a/devtools/conda-envs/rdkit.yaml
+++ b/devtools/conda-envs/rdkit.yaml
@@ -9,7 +9,7 @@ dependencies:
   - pyyaml
   - py-cpuinfo
   - psutil
-  - qcelemental >=0.2.2
+  - qcelemental >=0.2.6
   - pydantic >=0.18.1
 
     # Testing

--- a/devtools/conda-envs/torchani.yaml
+++ b/devtools/conda-envs/torchani.yaml
@@ -10,7 +10,7 @@ dependencies:
   - pyyaml
   - py-cpuinfo
   - psutil
-  - qcelemental >=0.2.2
+  - qcelemental >=0.2.6
   - pydantic >=0.18.1
 
     # Testing

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -21,6 +21,7 @@ Enhancements
 
 - (:pr:`24`) Improves load times dramatically by delaying imports and cpuutils.
 - (:pr:`25`) Code base linting.
+- (:pr:`30`) Ensures Psi4 output is already returned and Pydantic v0.20+ changes.
 
 v0.5.1 / 2019-01-29
 -------------------

--- a/qcengine/tests/test_compute.py
+++ b/qcengine/tests/test_compute.py
@@ -29,10 +29,11 @@ def test_psi4_task():
     json_data["keywords"] = {"scf_type": "df"}
     json_data["return_output"] = False
 
-    ret = dc.compute(json_data, "psi4", raise_error=True)
+    ret = dc.compute(json_data, "psi4", raise_error=True, capture_output=False)
 
     assert ret["driver"] == "energy"
     assert "provenance" in ret
+    assert "Final Energy" in ret["stdout"]
 
     for key in ["cpu", "hostname", "username", "wall_time"]:
         assert key in ret["provenance"]
@@ -42,22 +43,21 @@ def test_psi4_task():
 
 @addons.using_psi4
 def test_psi4_ref_switch():
-    inp = ResultInput(
-        **{
-            "molecule": {
-                "symbols": ["Li"],
-                "geometry": [0, 0, 0],
-                "molecular_multiplicity": 2
-            },
-            "driver": "energy",
-            "model": {
-                "method": "SCF",
-                "basis": "sto-3g"
-            },
-            "keywords": {
-                "scf_type": "df"
-            }
-        })
+    inp = ResultInput(**{
+        "molecule": {
+            "symbols": ["Li"],
+            "geometry": [0, 0, 0],
+            "molecular_multiplicity": 2
+        },
+        "driver": "energy",
+        "model": {
+            "method": "SCF",
+            "basis": "sto-3g"
+        },
+        "keywords": {
+            "scf_type": "df"
+        }
+    })
 
     ret = dc.compute(inp, "psi4", raise_error=True, return_dict=False)
 

--- a/qcengine/util.py
+++ b/qcengine/util.py
@@ -128,8 +128,10 @@ def handle_output_metadata(output_data, metadata, raise_error=False, return_dict
     else:
         output_fusion = output_data.dict()
 
-    output_fusion["stdout"] = metadata["stdout"]
-    output_fusion["stderr"] = metadata["stderr"]
+    # Do not override if computer generates
+    output_fusion["stdout"] = output_fusion.pop("stdout", metadata["stdout"])
+    output_fusion["stderr"] = output_fusion.pop("stderr", metadata["stderr"])
+
     if metadata["success"] is not True:
         output_fusion["success"] = False
         output_fusion["error"] = {"error_type": "meta_error", "error_message": metadata["error_message"]}
@@ -142,9 +144,8 @@ def handle_output_metadata(output_data, metadata, raise_error=False, return_dict
         raise ValueError(output_fusion["error"]["error_message"])
 
     # Fill out provenance datadata
-    wall_time = metadata["wall_time"]
     provenance_augments = config.get_provenance_augments()
-    provenance_augments["wall_time"] = wall_time
+    provenance_augments["wall_time"] = metadata["wall_time"]
     if "provenance" in output_fusion:
         output_fusion["provenance"].update(provenance_augments)
     else:

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ if __name__ == "__main__":
             'pyyaml',
             'py-cpuinfo',
             'psutil',
-            'qcelemental>=0.2.2',
+            'qcelemental>=0.2.6',
             'pydantic>=0.18.0'
         ],
         entry_points={"console_scripts": [


### PR DESCRIPTION
All other codes currently collect stdout by default besides Psi4. Canonicalizes Psi4 in this case.