### PR TITLE
travis caching, setup.py test, updates psi4 travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,11 @@ cache:
     - $HOME/miniconda
 
 matrix:
-  allow_failures:
-    - os: linux
-      env:
-        - PYTHON_VER=3.6
-        - PROG=PSI4
+  #allow_failures:
+  #  - os: linux
+  #    env:
+  #      - PYTHON_VER=3.6
+  #      - PROG=PSI4
 
   include:
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,11 @@ language: generic
 dist: xenial
 
 before_cache:
+  # if I understand internet correctly, this is equiv to "after_success"
+  - |
+      if [[ $TRAVIS_TEST_RESULT = 0 ]]; then
+        codecov
+      fi
   - conda deactivate
   - conda remove --name test --all
 cache:
@@ -79,6 +84,3 @@ script:
 
 notifications:
     email: false
-
-after_success:
-  - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,14 @@ language: generic
 # Run jobs on container-based infrastructure, can be overridden per job
 dist: xenial
 
+before_cache:
+  - conda deactivate
+  - conda remove --name test --all
+cache:
+  timeout: 1000
+  directories:
+    - $HOME/miniconda
+
 matrix:
   allow_failures:
     - os: linux
@@ -56,6 +64,7 @@ install:
     fi
   - source activate test
   - pip install git+https://github.com/MolSSI/QCEngineRecords.git#egg=qcenginerecords
+  - conda list
 
     # Build and install package
   - python setup.py develop --no-deps

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ before_install:
   - ulimit -a
 
     # Install the Python environemt
-  - ./devtools/travis-ci/before_install.sh
+  - source devtools/travis-ci/before_install.sh
   - python -V
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,6 @@ cache:
     - $HOME/miniconda
 
 matrix:
-  #allow_failures:
-  #  - os: linux
-  #    env:
-  #      - PYTHON_VER=3.6
-  #      - PROG=PSI4
 
   include:
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ before_install:
   - ulimit -a
 
     # Install the Python environemt
-  - source devtools/travis-ci/before_install.sh
+  - ./devtools/travis-ci/before_install.sh
   - python -V
 
 install:

--- a/devtools/README.md
+++ b/devtools/README.md
@@ -16,16 +16,6 @@ Windows testing if you only plan to deploy on specific platforms. These are just
 * `appveyor`: Windows based testing through [AppVeyor](https://www.appveyor.com/)
   * `install_conda.ps1` Powershell installation script of Conda components
 
-### Conda Recipe:
-
-This directory contains the files to build and deploy on [Conda](https://conda.io/).
-
-* `conda-recipie`: directory containing all the build objects required for Conda. All files in this folder must have their given names
-  * `meta.yaml`: The yaml file needed by Conda to construct the build
-  * `build.sh`: Unix-based instructions for how to install the software interpreted by Conda
-  * `bld.bat`: Windows-based instructions for how to install the software interpreted by Conda
-
-
 ## How to contribute changes
 - Clone the repository if you have write access to the main repo, fork the repository if you are a collaborator.
 - Make a new branch with `git checkout -b {your branch name}`

--- a/devtools/conda-envs/psi-nightly.yaml
+++ b/devtools/conda-envs/psi-nightly.yaml
@@ -5,6 +5,7 @@ channels:
 dependencies:
   - psi4
   - dftd3 3.2.1
+  - blas=*=mkl  # not needed but an example of disuading solver from openblas and old psi
 
     # Core
   - python

--- a/devtools/conda-envs/psi-nightly.yaml
+++ b/devtools/conda-envs/psi-nightly.yaml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
 dependencies:
   - psi4
-  - dftd3 3.2.0
+  - dftd3 3.2.1
 
     # Core
   - python

--- a/devtools/conda-envs/psi.yaml
+++ b/devtools/conda-envs/psi.yaml
@@ -3,8 +3,7 @@ channels:
   - psi4
   - conda-forge
 dependencies:
-  - psi4=1.2
-  - libint=1.2.1=h87b9b30_4
+  - psi4=1.3
   - dftd3
 
     # Core

--- a/devtools/travis-ci/before_install.sh
+++ b/devtools/travis-ci/before_install.sh
@@ -1,4 +1,4 @@
-set -eu -o pipefail
+#set -eu -o pipefail
 
 # Temporarily change directory to $HOME to install software
 pushd .
@@ -43,7 +43,7 @@ else
     export PATH=$MINICONDA_HOME/bin:$PATH
 
     conda config --set always_yes yes --set changeps1 no
-    conda update --q conda
+    conda update -q conda
 
     rm -f $MINICONDA
 fi
@@ -51,4 +51,4 @@ echo "-- Done with latest Miniconda"
 
 # Restore original directory
 popd
-set +u
+#set +u

--- a/devtools/travis-ci/before_install.sh
+++ b/devtools/travis-ci/before_install.sh
@@ -51,3 +51,4 @@ echo "-- Done with latest Miniconda"
 
 # Restore original directory
 popd
+set +u

--- a/devtools/travis-ci/before_install.sh
+++ b/devtools/travis-ci/before_install.sh
@@ -2,7 +2,7 @@ set -eu -o pipefail
 
 # Temporarily change directory to $HOME to install software
 pushd .
-cd $HOME
+cd "$HOME"
 
 # Install Miniconda
 if [ "$TRAVIS_OS_NAME" == "osx" ]; then
@@ -15,20 +15,39 @@ else
     MINICONDA=Miniconda3-latest-Linux-x86_64.sh
 fi
 MINICONDA_HOME=$HOME/miniconda
-MINICONDA_MD5=$(curl -s https://repo.continuum.io/miniconda/ | grep -A3 $MINICONDA | sed -n '4p' | sed -n 's/ *<td>\(.*\)<\/td> */\1/p')
-wget -q https://repo.continuum.io/miniconda/$MINICONDA
-if [[ $MINICONDA_MD5 != $(md5sum $MINICONDA | cut -d ' ' -f 1) ]]; then
-    echo "Miniconda MD5 mismatch"
-    exit 1
-fi
-bash $MINICONDA -b -p $MINICONDA_HOME
 
-# Configure miniconda
-export PIP_ARGS="-U"
-export PATH=$MINICONDA_HOME/bin:$PATH
+echo "-- Installing latest Miniconda"
+if [ -d "$MINICONDA_HOME/bin" ]; then
+    echo "-- Miniconda latest version FOUND in cache"
     
-conda config --set always_yes yes --set changeps1 no
-conda update -q conda
+    # Config settings are not saved in the cache
+    export PIP_ARGS="-U"
+    export PATH=$MINICONDA_HOME/bin:$PATH
+
+    conda config --set always_yes yes --set changeps1 no
+else
+    MINICONDA_MD5=$(curl -s https://repo.continuum.io/miniconda/ | grep -A3 $MINICONDA | sed -n '4p' | sed -n 's/ *<td>\(.*\)<\/td> */\1/p')
+    echo "-- Miniconda latest version NOT FOUND in cache"
+    wget -q https://repo.continuum.io/miniconda/$MINICONDA
+    if [[ $MINICONDA_MD5 != $(md5sum $MINICONDA | cut -d ' ' -f 1) ]]; then
+        echo "Miniconda MD5 mismatch"
+        exit 1
+    fi
+    # Travis creates the cached directories for us.
+    # This is problematic when wanting to install Anaconda for the first time...
+    rm -rf "$MINICONDA_HOME"
+    bash $MINICONDA -b -p "$MINICONDA_HOME"
+
+    # Configure miniconda
+    export PIP_ARGS="-U"
+    export PATH=$MINICONDA_HOME/bin:$PATH
+
+    conda config --set always_yes yes --set changeps1 no
+    conda update --q conda
+
+    rm -f $MINICONDA
+fi
+echo "-- Done with latest Miniconda"
 
 # Restore original directory
 popd

--- a/devtools/travis-ci/before_install.sh
+++ b/devtools/travis-ci/before_install.sh
@@ -1,3 +1,5 @@
+set -eu -o pipefail
+
 # Temporarily change directory to $HOME to install software
 pushd .
 cd $HOME

--- a/devtools/travis-ci/before_install.sh
+++ b/devtools/travis-ci/before_install.sh
@@ -1,5 +1,3 @@
-#set -eu -o pipefail
-
 # Temporarily change directory to $HOME to install software
 pushd .
 cd "$HOME"
@@ -51,4 +49,3 @@ echo "-- Done with latest Miniconda"
 
 # Restore original directory
 popd
-#set +u

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,3 +32,6 @@ style = pep440
 versionfile_source = qcengine/_version.py
 versionfile_build = qcengine/_version.py
 tag_prefix = ''
+
+[aliases]
+test=pytest

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,12 @@
+import sys
 import setuptools
 import versioneer
 
 short_description = "QCEngine provides a wrapper to ingest and produce QCSchema for a variety of quantum chemistry programs."
+
+# from https://github.com/pytest-dev/pytest-runner#conditional-requirement
+needs_pytest = {'pytest', 'test', 'ptr'}.intersection(sys.argv)
+pytest_runner = ['pytest-runner'] if needs_pytest else []
 
 try:
     with open("README.md", "r") as handle:
@@ -20,6 +25,7 @@ if __name__ == "__main__":
         version=versioneer.get_version(),
         cmdclass=versioneer.get_cmdclass(),
         packages=setuptools.find_packages(),
+        setup_requires=[] + pytest_runner,
         install_requires=[
             'pyyaml',
             'py-cpuinfo',


### PR DESCRIPTION
* institute caching of conda pkgs for travis
* allow `python setup.py test` to run pytest
* try dftd3 and psi4 pinnings after v1.3 release