### PR TITLE
Psi4: Gracefully handle internal failures

### DIFF
--- a/qcengine/programs/psi4.py
+++ b/qcengine/programs/psi4.py
@@ -54,7 +54,7 @@ class Psi4Executor(ProgramExecutor):
 
             mol = psi4.core.Molecule.from_schema(input_model)
             if (mol.multiplicity() != 1) and ("reference" not in input_model["keywords"]):
-                input_model["keywords"]["reference"] = "uks"
+                input_model["keywords"]["reference"] = "uhf"
 
             output_data = psi4.json_wrapper.run_json(input_model)
             if "extras" not in output_data:

--- a/qcengine/programs/psi4.py
+++ b/qcengine/programs/psi4.py
@@ -53,14 +53,16 @@ class Psi4Executor(ProgramExecutor):
         if psi_version > self.parse_version("1.2"):
 
             mol = psi4.core.Molecule.from_schema(input_model)
-            if mol.multiplicity() != 1:
+            if (mol.multiplicity() != 1) and ("reference" not in input_model["keywords"]):
                 input_model["keywords"]["reference"] = "uks"
 
             output_data = psi4.json_wrapper.run_json(input_model)
             if "extras" not in output_data:
                 output_data["extras"] = {}
 
-            output_data["extras"]["local_qcvars"] = output_data.pop("psi4:qcvars")
+            output_data["extras"]["local_qcvars"] = output_data.pop("psi4:qcvars", None)
+            if output_data["success"] is False:
+                output_data["error"] = {"error_type": "internal_error", "error_message": output_data["error"]}
 
         else:
             raise TypeError("Psi4 version '{}' not understood.".format(psi_version))
@@ -84,8 +86,9 @@ class Psi4Executor(ProgramExecutor):
             output_data.pop("return_ouput", None)
 
             return Result(**output_data)
-        return FailedOperation(
-            success=output_data.pop("success", False), error=output_data.pop("error"), input_model=output_data)
+        else:
+            return FailedOperation(
+                success=output_data.pop("success", False), error=output_data.pop("error"), input_data=output_data)
 
     def found(self) -> bool:
         try:

--- a/qcengine/programs/tests/test_programs.py
+++ b/qcengine/programs/tests/test_programs.py
@@ -44,6 +44,7 @@ def test_psi4_task():
     assert ret["success"] is True
 
 
+@testing.using_psi4
 def test_psi4_internal_failure():
 
     mol = Molecule.from_data("""0 3
@@ -56,11 +57,12 @@ def test_psi4_internal_failure():
             "method": "ccsd",
             "basis": "6-31g"
         },
+        "keywords": {"reference": "rhf"}
     }
     with pytest.raises(ValueError) as exc:
         ret = qcng.compute(psi4_task, "psi4", raise_error=True)
 
-    assert "not avail" in str(exc.value)
+    assert "reference is only" in str(exc.value)
 
 
 @testing.using_psi4
@@ -73,7 +75,7 @@ def test_psi4_ref_switch():
         },
         "driver": "energy",
         "model": {
-            "method": "SCF",
+            "method": "B3LYP",
             "basis": "sto-3g"
         },
         "keywords": {

--- a/qcengine/programs/tests/test_programs.py
+++ b/qcengine/programs/tests/test_programs.py
@@ -44,6 +44,25 @@ def test_psi4_task():
     assert ret["success"] is True
 
 
+def test_psi4_internal_failure():
+
+    mol = Molecule.from_data("""0 3
+     O    0.000000000000     0.000000000000    -0.068516245955
+    """)
+    psi4_task = {
+        "molecule": mol,
+        "driver": "energy",
+        "model": {
+            "method": "ccsd",
+            "basis": "6-31g"
+        },
+    }
+    with pytest.raises(ValueError) as exc:
+        ret = qcng.compute(psi4_task, "psi4", raise_error=True)
+
+    assert "not avail" in str(exc.value)
+
+
 @testing.using_psi4
 def test_psi4_ref_switch():
     inp = ResultInput(**{
@@ -111,5 +130,3 @@ def test_torchani_task():
 
     assert ret.success is True
     assert ret.driver == "gradient"
-
-


### PR DESCRIPTION
Psi4 internal failures are now handled gracefully. Also does not force `uks` reference when `reference` keyword is present.