### PR TITLE
CI: Tries to prevent cache misses due to index updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,8 @@ before_cache:
 
   - conda deactivate
   - conda remove --name test --all
-  - conda clean --index-cache --lock --packages --force-pkg-dirs
+  - conda clean --all
+  #- conda clean --index-cache --lock --packages --force-pkg-dirs
 
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,6 @@ language: generic
 # Run jobs on container-based infrastructure, can be overridden per job
 dist: xenial
 
-before_cache:
-  # if I understand internet correctly, this is equiv to "after_success"
-  - |
-      if [[ $TRAVIS_TEST_RESULT = 0 ]]; then
-        codecov
-      fi
-  - conda deactivate
-  - conda remove --name test --all
 cache:
   timeout: 1000
   directories:
@@ -76,6 +68,18 @@ script:
 
     # Run canonical tests
   - pytest -v --cov=qcengine/ qcengine/
+
+
+before_cache:
+  - |
+      if [[ $TRAVIS_TEST_RESULT = 0 ]]; then
+        codecov
+      fi
+
+  - conda deactivate
+  - conda remove --name test --all
+  - conda clean --index-cache --lock --packages --force-pkg-dirs
+
 
 notifications:
     email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,8 +78,8 @@ before_cache:
 
   - conda deactivate
   - conda remove --name test --all
-  - conda clean --all
-  #- conda clean --index-cache --lock --packages --force-pkg-dirs
+  - rm -rf $HOME/miniconda/pkgs/cache/
+  #- conda clean --index-cache --lock --packages --force-pkgs-dirs
 
 
 notifications:


### PR DESCRIPTION
I have yet to see a case where we have a canonical cache hit without a new upload. This attempts to remove the upload requirements.