### PR TITLE
Psi4 run from CLI

### DIFF
--- a/qcengine/programs/dftd3/runner.py
+++ b/qcengine/programs/dftd3/runner.py
@@ -17,7 +17,7 @@ import qcelemental as qcel
 from qcelemental.models import FailedOperation, Result
 
 from . import dashparam
-from ...util import execute, which
+from ...util import execute, which, safe_version
 from ..executor import ProgramExecutor
 from ...extras import provenance_stamp
 
@@ -59,7 +59,6 @@ class DFTD3Executor(ProgramExecutor):
         proc = subprocess.run(command, stdout=subprocess.PIPE)
         candidate_version = proc.stdout.decode('utf-8').strip()
 
-        from pkg_resources import safe_version
         return safe_version(candidate_version)
 
     def compute(self, input_data: 'ResultInput', config: 'JobConfig') -> 'Result':

--- a/qcengine/programs/psi4.py
+++ b/qcengine/programs/psi4.py
@@ -1,14 +1,12 @@
 """
 Calls the Psi4 executable.
 """
-from pkg_resources import safe_version, parse_version
+import json
 
 from qcelemental.models import FailedOperation, Result
 
-from ..util import which_import
+from ..util import scratch_directory, execute, which, popen, safe_version, parse_version
 from .executor import ProgramExecutor
-
-from ..util import scratch_directory
 
 
 class Psi4Executor(ProgramExecutor):
@@ -30,7 +28,7 @@ class Psi4Executor(ProgramExecutor):
 
     @staticmethod
     def found(raise_error=False) -> bool:
-        is_found = which_import("psi4", return_bool=True)
+        is_found = which("psi4", return_bool=True)
 
         if not is_found and raise_error:
             raise ModuleNotFoundError("Could not find Psi4 in the Python path.")
@@ -40,8 +38,10 @@ class Psi4Executor(ProgramExecutor):
     def get_version(self) -> str:
         self.found(raise_error=True)
 
-        import psi4
-        candidate_version = psi4.__version__
+        with popen([which('psi4'), '--version']) as exc:
+            exc["proc"].wait(timeout=5)
+
+        candidate_version = exc["stdout"]
         if "undef" in candidate_version:
             raise TypeError(
                 "Using custom build without tags. Please pull git tags with `git pull origin master --tags`.")
@@ -53,36 +53,39 @@ class Psi4Executor(ProgramExecutor):
         Runs Psi4 in API mode
         """
         self.found(raise_error=True)
-        import psi4
 
         # Setup the job
-        input_model = input_model.copy().dict()
-        input_model["nthreads"] = config.ncores
-        input_model["memory"] = int(config.memory * 1024 * 1024 * 1024 * 0.95)  # Memory in bytes
-        input_model["success"] = False
-        input_model["return_output"] = True
+        input_data = input_model.json_dict()
+        input_data["nthreads"] = config.ncores
+        input_data["memory"] = int(config.memory * 1024 * 1024 * 1024 * 0.95)  # Memory in bytes
+        input_data["success"] = False
+        input_data["return_output"] = True
 
-        if input_model["schema_name"] == "qcschema_input":
-            input_model["schema_name"] = "qc_schema_input"
+        if input_data["schema_name"] == "qcschema_input":
+            input_data["schema_name"] = "qc_schema_input"
 
-        scratch = config.scratch_directory
+        if config.scratch_directory:
+            input_data["scratch_location"] = config.scratch_directory
 
         if parse_version(self.get_version()) > parse_version("1.2"):
 
-            mol = psi4.core.Molecule.from_schema(input_model)
-            if (mol.multiplicity() != 1) and ("reference" not in input_model["keywords"]):
-                input_model["keywords"]["reference"] = "uhf"
+            if (input_model.molecule.molecular_multiplicity != 1) and ("reference" not in input_data["keywords"]):
+                input_data["keywords"]["reference"] = "uhf"
 
-            with scratch_directory(parent=scratch) as scrdir:
-                input_model["scratch_location"] = scrdir
-                output_data = psi4.json_wrapper.run_json(input_model)
+            # Execute the program
+            success, output = execute(["psi4", "--json", "data.json"], {"data.json": json.dumps(input_data)}, ["data.json"])
 
-            if "extras" not in output_data:
-                output_data["extras"] = {}
+            if success:
+                output_data = json.loads(output["outfiles"]["data.json"])
+                if "extras" not in output_data:
+                    output_data["extras"] = {}
 
-            output_data["extras"]["local_qcvars"] = output_data.pop("psi4:qcvars", None)
-            if output_data["success"] is False:
-                output_data["error"] = {"error_type": "internal_error", "error_message": output_data["error"]}
+                output_data["extras"]["local_qcvars"] = output_data.pop("psi4:qcvars", None)
+                if output_data["success"] is False:
+                    output_data["error"] = {"error_type": "internal_error", "error_message": output_data["error"]}
+            else:
+                output_data = input_data
+                output_data["error"] = {"error_type": "execution_error", "error_message": output["stderr"]}
 
         else:
             raise TypeError("Psi4 version '{}' not understood.".format(self.get_version()))

--- a/qcengine/util.py
+++ b/qcengine/util.py
@@ -56,7 +56,7 @@ def model_wrapper(input_data: Dict[str, Any], model: 'BaseModel') -> 'BaseModel'
 
 
 @contextmanager
-def compute_wrapper(capture_output: bool = True) -> Dict[str, Any]:
+def compute_wrapper(capture_output: bool=True) -> Dict[str, Any]:
     """Wraps compute for timing, output capturing, and raise protection
     """
 
@@ -123,8 +123,8 @@ def get_module_function(module: str, func_name: str, subpackage=None) -> Callabl
 
 def handle_output_metadata(output_data: Union[Dict[str, Any], 'BaseModel'],
                            metadata: Dict[str, Any],
-                           raise_error: bool = False,
-                           return_dict: bool = True) -> Union[Dict[str, Any], 'BaseModel']:
+                           raise_error: bool=False,
+                           return_dict: bool=True) -> Union[Dict[str, Any], 'BaseModel']:
     """
     Fuses general metadata and output together.
 
@@ -185,7 +185,7 @@ def handle_output_metadata(output_data: Union[Dict[str, Any], 'BaseModel'],
         return ret
 
 
-def terminate_process(proc: Any, timeout: int = 15) -> None:
+def terminate_process(proc: Any, timeout: int=15) -> None:
     if proc.poll() is None:
 
         # Sigint (keyboard interupt)
@@ -205,8 +205,7 @@ def terminate_process(proc: Any, timeout: int = 15) -> None:
 
 
 @contextmanager
-def popen(args: List[str], append_prefix: bool = False,
-          popen_kwargs: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+def popen(args: List[str], append_prefix: bool=False, popen_kwargs: Optional[Dict[str, Any]]=None) -> Dict[str, Any]:
     """
     Opens a background task
 
@@ -252,16 +251,16 @@ def popen(args: List[str], append_prefix: bool = False,
 
 
 def execute(command: List[str],
-            infiles: Optional[Dict[str, str]] = None,
-            outfiles: Optional[List[str]] = None,
+            infiles: Optional[Dict[str, str]]=None,
+            outfiles: Optional[List[str]]=None,
             *,
-            scratch_name: Optional[str] = None,
-            scratch_location: Optional[str] = None,
-            scratch_messy: bool = False,
-            blocking_files: Optional[List[str]] = None,
-            timeout: Optional[int] = None,
-            interupt_after: Optional[int] = None,
-            environment: Optional[Dict[str, str]] = None) -> Dict[str, str]:
+            scratch_name: Optional[str]=None,
+            scratch_location: Optional[str]=None,
+            scratch_messy: bool=False,
+            blocking_files: Optional[List[str]]=None,
+            timeout: Optional[int]=None,
+            interupt_after: Optional[int]=None,
+            environment: Optional[Dict[str, str]]=None) -> Dict[str, str]:
     """
     Runs a process in the background until complete.
 
@@ -337,7 +336,7 @@ def execute(command: List[str],
 
 
 @contextmanager
-def scratch_directory(child: str = None, parent: str = None, messy: bool = False) -> str:
+def scratch_directory(child: str=None, parent: str=None, messy: bool=False) -> str:
     """Create and cleanup a quarantined working directory with a parent scratch directory.
 
     Parameters
@@ -392,7 +391,7 @@ def scratch_directory(child: str = None, parent: str = None, messy: bool = False
 
 
 @contextmanager
-def disk_files(infiles: Dict[str, str], outfiles: Dict[str, None], cwd: Optional[str] = None) -> Dict[str, str]:
+def disk_files(infiles: Dict[str, str], outfiles: Dict[str, None], cwd: Optional[str]=None) -> Dict[str, str]:
     """
 
     Parameters
@@ -474,3 +473,19 @@ def which(command, return_bool=False):
         return bool(ans)
     else:
         return ans
+
+
+def safe_version(*args, **kwargs):
+    """
+    Package resources is a very slow load
+    """
+    import pkg_resources
+    return pkg_resources.safe_version(*args, **kwargs)
+
+
+def parse_version(*args, **kwargs):
+    """
+    Package resources is a very slow load
+    """
+    import pkg_resources
+    return pkg_resources.parse_version(*args, **kwargs)


### PR DESCRIPTION
Moves Psi4 to run from the CLI to prevent possible multiprocessing issues and fixes a small memory leak after thousands of runs.

This does slow down Psi4 by adding a ~0.5 second startup cost.