### PR TITLE
fix cased testing of psi4 keywords

### DIFF
--- a/qcengine/programs/psi4.py
+++ b/qcengine/programs/psi4.py
@@ -76,7 +76,8 @@ class Psi4Executor(ProgramExecutor):
 
         if parse_version(self.get_version()) > parse_version("1.2"):
 
-            if (input_model.molecule.molecular_multiplicity != 1) and ("reference" not in input_data["keywords"]):
+            caseless_keywords = {k.lower(): v for k, v in input_model["keywords"].items()}
+            if (input_model.molecule.molecular_multiplicity != 1) and ("reference" not in caseless_keywords):
                 input_data["keywords"]["reference"] = "uhf"
 
             # Execute the program

--- a/qcengine/programs/psi4.py
+++ b/qcengine/programs/psi4.py
@@ -76,7 +76,7 @@ class Psi4Executor(ProgramExecutor):
 
         if parse_version(self.get_version()) > parse_version("1.2"):
 
-            caseless_keywords = {k.lower(): v for k, v in input_model["keywords"].items()}
+            caseless_keywords = {k.lower(): v for k, v in input_model.keywords.items()}
             if (input_model.molecule.molecular_multiplicity != 1) and ("reference" not in caseless_keywords):
                 input_data["keywords"]["reference"] = "uhf"
 


### PR DESCRIPTION
qcengine not respecting `REFERENCE` in psi4 input for open-shell. for posterity, test script below, but no good reason to inspect it now.

I patched it here, but the greater question is is case something the runners in qcengine need to be careful of or is it something that the qcel model should validate into a uniform case. Certainly one shouldn't mess with the case of keyword _values_, but keyword _names_ are generally uniform wrt case.

```
import pprint

inp = {'driver': 'energy',
# 'return_output': True,  # REMOVE FOR ENGINE
 'schema_name': 'qcschema_input',
 'schema_version': 1,
 'keywords': {'DF_SCF_GUESS': 0, 'REFERENCE': 'ROHF', 'SCF_TYPE': 'PK'},
 #'keywords': {'DF_SCF_GUESS': 0, 'reference': 'ROHF', 'SCF_TYPE': 'PK'},
 'model': {'basis': 'aug-cc-pvqz', 'method': 'scf'},
 'molecule': {'atom_labels': [''],
              'atomic_numbers': [3],
              'fix_com': True,
              'fix_orientation': True,
              'fragment_charges': [0.0],
              'fragment_multiplicities': [2],
              'fragments': [[0]],
              'geometry': [0.0, 0.0, 0.0],
              'mass_numbers': [7],
              'masses': [7.0160034366],
              'molecular_charge': 0.0,
              'molecular_multiplicity': 2,
              'name': 'Li',
              'provenance': {'creator': 'QCElemental',
                             'routine': 'qcelemental.molparse.from_string',
                             'version': 'v0.3.3'},
              'real': [True],
              'symbols': ['Li']},
}

# EITHER run Engine

import qcengine as qcng
ans = qcng.compute(inp, "psi4")
pprint.pprint(ans.dict())
scf = ans.dict()['return_result']
print('ENGINE')
print(qcng.util.which('psi4'), qcng.util.which_import('psi4'))
print(scf)

# Results
# /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/bin/psi4 /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/lib/psi4/__init__.py
# -7.365043815990735


# OR run Psi4

#import psi4
#from psi4.driver import json_wrapper
#ans = psi4.json_wrapper.run_json(inp)
#pprint.pprint(ans)
#scf = ans['return_result']
#print('RUN_JSON')
#print(psi4.__file__)
#print(scf)

# Results
# /home/psilocaluser/gits/hrw-quaternary/objdir37/stage/lib/psi4/__init__.py
# -7.432695429345809
```