### PR TITLE
process error from psi4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,10 @@ install:
       exit 1
     fi
   - source activate test
+  - |
+    if [ $PROG == "PSI4DEV" ]; then
+      conda remove qcengine --force
+    fi
   - pip install git+https://github.com/MolSSI/QCEngineRecords.git#egg=qcenginerecords
   - conda list
 

--- a/qcengine/programs/psi4.py
+++ b/qcengine/programs/psi4.py
@@ -90,7 +90,9 @@ class Psi4Executor(ProgramExecutor):
 
                 output_data["extras"]["local_qcvars"] = output_data.pop("psi4:qcvars", None)
                 if output_data["success"] is False:
-                    output_data["error"] = {"error_type": "internal_error", "error_message": output_data["error"]}
+                    if "error_message" not in output_data["error"]:
+                        # older c. 1.3 message-only run_json
+                        output_data["error"] = {"error_type": "internal_error", "error_message": output_data["error"]}
             else:
                 output_data = input_data
                 output_data["error"] = {"error_type": "execution_error", "error_message": output["stderr"]}


### PR DESCRIPTION
When psi's `run_json` is smart enough to form proper error structure, this PR lets engine use it, instead of throwing a validation error.

```
    except Exception as exc:
        json_data["error"] = {
            'error_type': type(exc).__name__,
            'error_message': ''.join(traceback.format_exception(*sys.exc_info())),
        }
        json_data["success"] = False
```

New travis bit is b/c psi4 now needs qcng, but don't want both last-tagged-release and dev qcengine around. Even if the import statements could keep things straight, pytest isn't happy about two tests named the same thing.