### PR TITLE
stdout shenanigans

### DIFF
--- a/qcengine/programs/tests/test_dftd3.py
+++ b/qcengine/programs/tests/test_dftd3.py
@@ -656,8 +656,8 @@ def test_3():
         #({'first': 'pbe', 'second': 'atm(gr)', 'parent': 'eneyne', 'subject': 'mB', 'lbl': 'ATM'}),
         #({'first': '', 'second': 'ATMgr', 'parent': 'eneyne', 'subject': 'mAgB', 'lbl': 'ATM'}),
         # below two xfail until dftd3 that's only 2-body is out of psi4 proper
-        pytest.param({'first': 'atmgr', 'second': 'atmgr', 'parent': 'eneyne', 'subject': 'gAmB', 'lbl': 'ATM'}, marks=[using_dftd3_321, pytest.mark.xfail]),
-        pytest.param({'first': 'pbe-atmgr', 'second': None, 'parent': 'ne', 'subject': 'atom', 'lbl': 'ATM'}, marks=[using_dftd3_321, pytest.mark.xfail]),
+        pytest.param({'first': 'atmgr', 'second': 'atmgr', 'parent': 'eneyne', 'subject': 'gAmB', 'lbl': 'ATM'}, marks=[using_dftd3_321]),
+        pytest.param({'first': 'pbe-atmgr', 'second': None, 'parent': 'ne', 'subject': 'atom', 'lbl': 'ATM'}, marks=[using_dftd3_321]),
     ])  # yapf: disable
 def test_molecule__run_dftd3__23body(inp, subjects):
     subject = subjects()[inp['parent']][inp['subject']]

--- a/qcengine/tests/test_procedures.py
+++ b/qcengine/tests/test_procedures.py
@@ -30,22 +30,6 @@ _base_json = {
 }
 
 
-def _bond_dist(geom, a1, a2):
-    """
-    Computes a simple bond distance between two rows in a flat (n, 3) list of coordinates
-    """
-    if isinstance(geom, np.ndarray):
-        geom = geom.flatten().tolist()
-    a13 = a1 * 3
-    a23 = a2 * 3
-
-    xd = (geom[a13] - geom[a23])**2
-    yd = (geom[a13 + 1] - geom[a23 + 1])**2
-    zd = (geom[a13 + 2] - geom[a23 + 2])**2
-
-    return (xd + yd + zd)**0.5
-
-
 @testing.using_psi4
 @testing.using_geometric
 def test_geometric_psi4():

--- a/qcengine/util.py
+++ b/qcengine/util.py
@@ -322,12 +322,21 @@ def execute(command: List[str],
         with disk_files(infiles, outfiles, scrdir) as extrafiles:
             with popen(command, popen_kwargs=popen_kwargs) as proc:
 
+                realtime_stdout = ""
+                while True:
+                    output = proc["proc"].stdout.readline()
+                    if output == b'' and proc["proc"].poll() is not None:
+                        break
+                    if output:
+                        realtime_stdout += output.decode('utf-8')
+
                 if interupt_after is None:
                     proc["proc"].wait(timeout=timeout)
                 else:
                     time.sleep(interupt_after)
                     terminate_process(proc["proc"])
 
+            proc["stdout"] = realtime_stdout
             retcode = proc["proc"].poll()
         proc['outfiles'] = extrafiles
     proc['scratch_directory'] = scrdir


### PR DESCRIPTION
fix psi4 hanging on complex inputs, remove old fn and unneeded xfail

EDIT Any more elegant solution welcomed. But it has to run the below against this psi4 branch https://github.com/psi4/psi4/pull/1351

```
def test_simple_psi4():

    import psi4
    dimer = psi4.geometry("""
    He 2 0 0
    --
    He -2 0 0
    """)

    inp = {
        'schema_name': 'qcschema_input',
        'schema_version': 1,
        'molecule': dimer.to_schema(dtype=2),
        'driver': 'gradient',
        'model': {
            'method': 'SCF/cc-pV[D, T]Z',
            'basis': '(auto)',
        },
        'keywords': {
            'function_kwargs': {
                'bsse_type': 'CP',
                'max_nbody': 2,
                'return_total_data': True,
            },
        },
    }

    pp.pprint(inp)
#    ret = psi4.json_wrapper.run_json(inp)
    ret = qcng.compute(inp, "psi4", raise_error=True).dict()
    pp.pprint(ret)

    assert compare_values(-5.72527135604184, ret["extras"]["qcvars"]["CURRENT ENERGY"], atol=1e-5)
    assert compare_values([-3.987697668786454e-07, 1.630927063489103e-23, 0.0, 3.987697668787284e-07, -1.6309270632883992e-23, 0.0],
                          ret["extras"]["qcvars"]["CURRENT GRADIENT"], atol=1e-4)
    print('SUCCESS')
```