### PR TITLE
Add the python binary directory to `which`'s PATH

### DIFF
--- a/qcengine/compute.py
+++ b/qcengine/compute.py
@@ -8,7 +8,7 @@ from qcelemental.models import ComputeError, FailedOperation, Optimization, Opti
 from .config import get_config
 from .procedures import get_procedure, list_all_procedures, list_available_procedures
 from .programs import get_program, list_all_programs, list_available_programs
-from .util import compute_wrapper, get_module_function, handle_output_metadata, model_wrapper
+from .util import compute_wrapper, handle_output_metadata, model_wrapper
 
 __all__ = ["compute", "compute_procedure"]
 

--- a/qcengine/programs/__init__.py
+++ b/qcengine/programs/__init__.py
@@ -2,7 +2,7 @@
 Imports the various compute backends
 """
 
-from typing import List, Set
+from typing import Set
 
 from .psi4 import Psi4Executor
 from .rdkit import RDKitExecutor

--- a/qcengine/programs/psi4.py
+++ b/qcengine/programs/psi4.py
@@ -7,7 +7,7 @@ from typing import Dict
 
 from qcelemental.models import FailedOperation, Result
 
-from ..util import scratch_directory, execute, which, popen, safe_version, parse_version
+from ..util import execute, which, popen, safe_version, parse_version
 from .executor import ProgramExecutor
 
 

--- a/qcengine/util.py
+++ b/qcengine/util.py
@@ -22,7 +22,8 @@ from qcelemental.models import ComputeError, FailedOperation
 
 from .config import LOGGER, get_provenance_augments
 
-__all__ = ["compute_wrapper", "get_module_function", "model_wrapper", "handle_output_metadata"]
+__all__ = ["compute_wrapper", "get_module_function", "model_wrapper", "handle_output_metadata",
+           "execute", "which", "popen", "safe_version", "parse_version"]
 
 
 def model_wrapper(input_data: Dict[str, Any], model: 'BaseModel') -> 'BaseModel':
@@ -38,7 +39,7 @@ def model_wrapper(input_data: Dict[str, Any], model: 'BaseModel') -> 'BaseModel'
         else:
             raise KeyError("Input type of {} not understood.".format(type(model)))
 
-        # Older QCElemental compat
+        # Older QCElemental compatibility
         try:
             input_data.extras
         except AttributeError:
@@ -471,9 +472,9 @@ def which_import(plug, return_bool=False):
             return plug_spec.path
 
 
-def which(command, return_bool=False):
+def which(command, return_bool=False) -> Union[str, None, bool]:
     # environment is $PATH, less any None values
-    lenv = {'PATH': ':' + os.environ.get('PATH')}
+    lenv = {'PATH': ':' + os.environ.get('PATH') + ":" + os.path.dirname(sys.executable)}
     lenv = {k: v for k, v in lenv.items() if v is not None}
 
     ans = shutil.which(command, mode=os.F_OK | os.X_OK, path=lenv['PATH'])


### PR DESCRIPTION
Appends the directory of the executing Python bin to the path of the
search for `which` function. This should help with a corner case
on clusters which don't export the PATH variable correctly on nodes
of the executing environment since the absolute Python binary's path
ensures proper imports.

Also cleaned up some unused imports and `__all__` statements.