### PR TITLE
Molpro can now be run by QCEngine

### DIFF
--- a/qcengine/programs/molpro.py
+++ b/qcengine/programs/molpro.py
@@ -6,7 +6,7 @@ import xml.etree.ElementTree as ET
 from typing import Any, Dict, Optional
 
 from qcelemental.models import Result, FailedOperation
-import qcengine.util as uti
+from ..util import execute
 from qcelemental.util import which
 
 from .executor import ProgramExecutor
@@ -46,7 +46,7 @@ class MolproExecutor(ProgramExecutor):
         #        self.version_cache[which_prog] = safe_version(branch)
 
         #return self.version_cache[which_prog]
-        
+
     def compute(self, input_data: 'ResultInput', config: 'JobConfig') -> 'Result':
         """
         Run Molpro
@@ -55,19 +55,19 @@ class MolproExecutor(ProgramExecutor):
         self.found(raise_error=True)
 
         # Check Molpro version
-        # if parse_version(self.get_version()) < parse_version("1.5"):
+        # if parse_version(self.get_version()) < parse_version("2018.1"):
         #     raise TypeError("Molpro version '{}' not understood".format(self.get_version()))
 
         # Setup the job
         job_inputs = self.build_input(input_data, config)
 
         # Run Molpro
-        exe_success, proc = uti.execute(job_inputs["commands"],
-                                        infiles=job_inputs["infiles"],
-                                        outfiles=["dispatch.out", "dispatch.xml"],
-                                        scratch_location=job_inputs["scratch_location"],
-                                        timeout=None
-                                        )
+        exe_success, proc = execute(job_inputs["commands"],
+                                    infiles=job_inputs["infiles"],
+                                    outfiles=["dispatch.out", "dispatch.xml", "dispatch.wfu"],
+                                    scratch_location=job_inputs["scratch_location"],
+                                    timeout=None
+                                    )
 
         # Determine whether the calculation succeeded
         output_data = {}
@@ -85,9 +85,9 @@ class MolproExecutor(ProgramExecutor):
 
     # TODO Additional features
     #   - allow separate xyz file to be provided
-    #   - pass scratch location info to Molpro command (-d option)
-    #   - pass number of cores to Molpro command (-n option)
     #   - add support of wfu files? (-W option)
+    # FIXME Molpro takes xyz input in Angstrom by default, but MolSSI stores xyz in bohr
+    #   - Either need to convert to Angstrom or change Molpro input to read bohr
     def build_input(self, input_model: 'ResultInput', config: 'JobConfig',
                     template: Optional[str] = None) -> Dict[str, Any]:
         input_file = []
@@ -95,8 +95,11 @@ class MolproExecutor(ProgramExecutor):
 
         # Write header info
         input_file.append("!Title")
+        # Memory is in megawords per core for Molpro
         memory_mw_core = int(config.memory * (1024 ** 3) / 8e6 / config.ncores)
         input_file.append("memory,{},M".format(memory_mw_core))
+        # TODO Add specification of wfu file only if asked for
+        # input_file.append('file,2,dispatch.wfu')
         input_file.append('')
 
         # Have no symmetry by default
@@ -137,10 +140,11 @@ class MolproExecutor(ProgramExecutor):
         input_file = "\n".join(input_file)
 
         return {
-            "commands": ["molpro", "dispatch.mol"],
+            "commands": ["molpro", "dispatch.mol", "-d", ".", "-W", ".", "-n", str(config.ncores)],
             "infiles": {
                 "dispatch.mol": input_file
             },
+            "scratch_location": config.scratch_directory,
             "input_result": input_model.copy(deep=True)
         }
 

--- a/qcengine/programs/molpro.py
+++ b/qcengine/programs/molpro.py
@@ -43,8 +43,12 @@ class MolproExecutor(ProgramExecutor):
         job_inputs = self.build_input(input_data, config)
 
         # Run Molpro
-        exe_outputs = self.execute(job_inputs)
-        exe_success, proc = exe_outputs
+        exe_success, proc = uti.execute(job_inputs["commands"],
+                                        infiles=job_inputs["infiles"],
+                                        outfiles=["dispatch.out", "dispatch.xml"],
+                                        scratch_location=job_inputs["scratch_location"],
+                                        timeout=None
+                                        )
 
         # Determine whether the calculation succeeded
         output_data = {}
@@ -200,13 +204,3 @@ class MolproExecutor(ProgramExecutor):
             raise ImportError("Could not find Molpro in PATH.")
         else:
             return is_found
-
-    def execute(self, inputs, extra_outfiles=None, extra_commands=None, scratch_name=None, timeout=None):
-        exe_success, proc = uti.execute(inputs["commands"],
-                                        infiles=inputs["infiles"],
-                                        outfiles=["dispatch.out", "dispatch.xml"],
-                                        scratch_location=inputs["scratch_location"],
-                                        timeout=timeout
-                                        )
-        proc["outfiles"]["tc.out"] = proc["stdout"]
-        return exe_success, proc

--- a/qcengine/programs/tests/test_molpro.py
+++ b/qcengine/programs/tests/test_molpro.py
@@ -17,6 +17,7 @@ molpro_info = qcer.get_info('molpro')
 
 @pytest.mark.parametrize('test_case', molpro_info.list_test_cases())
 def test_molpro_output_parser(test_case):
+
     # Get output file data
     data = molpro_info.get_test_data(test_case)
     inp = qcel.models.ResultInput.parse_raw(data["input.json"])
@@ -34,6 +35,7 @@ def test_molpro_output_parser(test_case):
 
 @pytest.mark.parametrize('test_case', molpro_info.list_test_cases())
 def test_molpro_input_formatter(test_case):
+
     # Get output file data
     data = molpro_info.get_test_data(test_case)
     inp = qcel.models.ResultInput.parse_raw(data["input.json"])

--- a/qcengine/programs/tests/test_molpro.py
+++ b/qcengine/programs/tests/test_molpro.py
@@ -28,7 +28,7 @@ def test_molpro_output_parser(test_case):
     output_ref = qcel.models.Result.parse_raw(data["output.json"]).dict()
     output_ref.pop("provenance", None)
 
-    # TODO add `skip` to compare_recusive
+    # TODO add `skip` to compare_recursive
     check = compare_recursive(output_ref, output)
     assert check, check
 
@@ -36,12 +36,11 @@ def test_molpro_output_parser(test_case):
 @pytest.mark.parametrize('test_case', molpro_info.list_test_cases())
 def test_molpro_input_formatter(test_case):
 
-    # Get output file data
+    # Get input file data
     data = molpro_info.get_test_data(test_case)
     inp = qcel.models.ResultInput.parse_raw(data["input.json"])
 
-    # Just test that it runs for now
-    # TODO add actual comparison
+    # TODO add actual comparison of generated input file
     input_file = qcng.get_program('molpro').build_input(inp, qcng.get_config())
     assert input_file.keys() >= {"commands", "infiles"}
 
@@ -54,13 +53,11 @@ def test_molpro_executor(test_case):
     inp = qcel.models.ResultInput.parse_raw(data["input.json"])
 
     # Run Molpro
-    result = qcng.get_program('terachem').compute(inp, qcng.get_config())
+    result = qcng.compute(inp, 'molpro', local_options={"ncores": 4})
     assert result.success is True
 
     # Get output file data
     output_ref = qcel.models.Result.parse_raw(data["output.json"])
 
-    if result.success:
-        atol = 1e-6
-        assert compare_recursive(output_ref.return_result,
-                                 result.return_result, atol=atol)
+    atol = 1e-6
+    assert compare_recursive(output_ref.return_result, result.return_result, atol=atol)

--- a/qcengine/programs/tests/test_terachem.py
+++ b/qcengine/programs/tests/test_terachem.py
@@ -12,50 +12,48 @@ qcer = pytest.importorskip("qcenginerecords")
 # Prep globals
 terachem_info = qcer.get_info('terachem')
 
+
 @pytest.mark.skipif(qcel.__version__ > "v.0.3.3", reason="qcelemental version is too new")
 @pytest.mark.parametrize('test_case', terachem_info.list_test_cases())
 def test_terachem_output_parser(test_case):
-
-     # Get output file data
-     data = terachem_info.get_test_data(test_case)
-     inp = qcel.models.ResultInput.parse_raw(data["input.json"])
-
-     output = qcng.get_program('terachem').parse_output(data, inp)
-
-     output_ref = qcel.models.Result.parse_raw(data["output.json"])
-
-     assert compare_recursive(output_ref.dict(), output.dict()) 
-
-@pytest.mark.parametrize('test_case', terachem_info.list_test_cases())
-def test_terachem_input_formatter(test_case):
-
-    # Get input file data
-    data = terachem_info.get_test_data(test_case)
-    inp = qcel.models.ResultInput.parse_raw(data["input.json"])
-
-    # Just test that it runs for now
-    input_file = qcng.get_program('terachem').build_input(inp, qcng.get_config())
-    assert input_file.keys() >= {"commands", "infiles"}
-
-@using_terachem
-@pytest.mark.parametrize('test_case', terachem_info.list_test_cases())
-def test_terachem_executer(test_case):
-
-    # Get input file data
-    data = terachem_info.get_test_data(test_case)
-    inp = qcel.models.ResultInput.parse_raw(data["input.json"])
-
-    # Just test that it runs for now
-    result = qcng.get_program('terachem').compute(inp, qcng.get_config())
-    assert result.success == True
-
     # Get output file data
+    data = terachem_info.get_test_data(test_case)
+    inp = qcel.models.ResultInput.parse_raw(data["input.json"])
+
+    output = qcng.get_program('terachem').parse_output(data, inp)
 
     output_ref = qcel.models.Result.parse_raw(data["output.json"])
 
-    if result.success:
-        atol = 1e-6
-        if result.driver == "gradient":
-            atol = 1e-3
-        assert compare_recursive(output_ref.return_result,
-                result.return_result, atol = atol) 
+    assert compare_recursive(output_ref.dict(), output.dict())
+
+
+@pytest.mark.parametrize('test_case', terachem_info.list_test_cases())
+def test_terachem_input_formatter(test_case):
+    # Get input file data
+    data = terachem_info.get_test_data(test_case)
+    inp = qcel.models.ResultInput.parse_raw(data["input.json"])
+
+    # TODO add actual comparison of generated input file
+    input_file = qcng.get_program('terachem').build_input(inp, qcng.get_config())
+    assert input_file.keys() >= {"commands", "infiles"}
+
+
+@using_terachem
+@pytest.mark.parametrize('test_case', terachem_info.list_test_cases())
+def test_terachem_executor(test_case):
+    # Get input file data
+    data = terachem_info.get_test_data(test_case)
+    inp = qcel.models.ResultInput.parse_raw(data["input.json"])
+
+    # Run Terachem
+    result = qcng.compute(inp, 'terachem')
+    # result = qcng.get_program('terachem').compute(inp, qcng.get_config())
+    assert result.success is True
+
+    # Get output file data
+    output_ref = qcel.models.Result.parse_raw(data["output.json"])
+
+    atol = 1e-6
+    if result.driver == "gradient":
+        atol = 1e-3
+    assert compare_recursive(output_ref.return_result, result.return_result, atol=atol)

--- a/qcengine/testing.py
+++ b/qcengine/testing.py
@@ -53,7 +53,8 @@ _programs = {
     "qcdb": which_import("qcdb", return_bool=True),
     "torchani": which_import("torchani", return_bool=True),
     "mp2d": which('mp2d', return_bool=True),
-    "terachem": which("terachem", return_bool=True)
+    "terachem": which("terachem", return_bool=True),
+    "molpro": which("molpro", return_bool=True)
 }
 
 def has_program(name):
@@ -72,6 +73,7 @@ using_qcdb = _build_pytest_skip("qcdb")
 using_torchani = _build_pytest_skip("torchani")
 using_mp2d = _build_pytest_skip("mp2d")
 using_terachem = _build_pytest_skip("terachem")
+using_molpro = _build_pytest_skip("molpro")
 
 using_dftd3_321 = pytest.mark.skipif(
     is_program_new_enough("dftd3", "3.2.1") is False,


### PR DESCRIPTION
Molpro can now be run by QCEngine and it passes the tests in `test_molpro.py` when QCEngineRecords is present. Except for `ccsd_water_gradient` test because the CCSD energy is missing from the xml file (I'm still working on fixing this).