### PR TITLE
Travis: Removes caching and reduces pytorch overhead

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,9 +50,14 @@ install:
       exit 1
     fi
   - source activate test
+
+    # Any kind of post env ceation
   - |
     if [ $PROG == "PSI4DEV" ]; then
       conda remove qcengine --force
+    elif [ $PROG == "ANI" ]; then
+      pip install torch_nightly -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+      pip install torchani
     fi
   - pip install git+https://github.com/MolSSI/QCEngineRecords.git#egg=qcenginerecords
   - conda list
@@ -66,7 +71,7 @@ script:
   - python -c "import qcengine; print(qcengine.config.global_repr())"
 
     # Run canonical tests
-  - pytest -v --cov=qcengine/ qcengine/
+  - pytest -rsx -v --cov=qcengine/ qcengine/
 
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,6 @@ language: generic
 # Run jobs on container-based infrastructure, can be overridden per job
 dist: xenial
 
-cache:
-  timeout: 1000
-  directories:
-    - $HOME/miniconda
-
 matrix:
 
   include:
@@ -72,18 +67,6 @@ script:
 
     # Run canonical tests
   - pytest -v --cov=qcengine/ qcengine/
-
-
-before_cache:
-  - |
-      if [[ $TRAVIS_TEST_RESULT = 0 ]]; then
-        codecov
-      fi
-
-  - conda deactivate
-  - conda remove --name test --all
-  - rm -rf $HOME/miniconda/pkgs/cache/
-  #- conda clean --index-cache --lock --packages --force-pkgs-dirs
 
 
 notifications:

--- a/devtools/conda-envs/psi-nightly.yaml
+++ b/devtools/conda-envs/psi-nightly.yaml
@@ -7,7 +7,6 @@ dependencies:
   - dftd3 3.2.1
   - mp2d <0.2
   - blas=*=mkl  # not needed but an example of disuading solver from openblas and old psi
-  - codecov
 
     # Core
   - python
@@ -20,4 +19,4 @@ dependencies:
     # Testing
   - pytest
   - pytest-cov
-  - codeocv
+  - codecov

--- a/devtools/conda-envs/psi-nightly.yaml
+++ b/devtools/conda-envs/psi-nightly.yaml
@@ -7,6 +7,7 @@ dependencies:
   - dftd3 3.2.1
   - mp2d <0.2
   - blas=*=mkl  # not needed but an example of disuading solver from openblas and old psi
+  - codecov
 
     # Core
   - python
@@ -19,8 +20,4 @@ dependencies:
     # Testing
   - pytest
   - pytest-cov
-
-    # Pip depends
-  - pip:
-    - codecov
-    - git+https://github.com/leeping/geomeTRIC#egg=geometric
+  - codeocv

--- a/devtools/conda-envs/psi.yaml
+++ b/devtools/conda-envs/psi.yaml
@@ -5,6 +5,7 @@ channels:
 dependencies:
   - psi4=1.3
   - dftd3
+  - geometric
 
     # Core
   - python
@@ -17,8 +18,4 @@ dependencies:
     # Testing
   - pytest
   - pytest-cov
-
-    # Pip depends
-  - pip:
-    - codecov
-    - git+https://github.com/leeping/geomeTRIC#egg=geometric
+  - codecov

--- a/devtools/conda-envs/torchani.yaml
+++ b/devtools/conda-envs/torchani.yaml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
   - pytorch
 dependencies:
+  - pytorch-cpu
   - pytorch-nightly-cpu
   - ignite
 

--- a/devtools/conda-envs/torchani.yaml
+++ b/devtools/conda-envs/torchani.yaml
@@ -1,10 +1,7 @@
 name: test
 channels:
   - conda-forge
-  - pytorch
 dependencies:
-  - pytorch-nightly-cpu
-  - ignite
 
     # Core
   - python
@@ -19,5 +16,3 @@ dependencies:
   - pytest
   - pytest-cov
   - codecov
-  - pip:
-    - torchani

--- a/devtools/conda-envs/torchani.yaml
+++ b/devtools/conda-envs/torchani.yaml
@@ -3,12 +3,12 @@ channels:
   - conda-forge
   - pytorch
 dependencies:
-  - pytorch-cpu
   - pytorch-nightly-cpu
   - ignite
 
     # Core
   - python
+  - pip
   - pyyaml
   - py-cpuinfo
   - psutil


### PR DESCRIPTION
Some Travis build are taking over half an hour due to caching issues. This removes caching and reduces pytorch GPU requirements to observe timings.