### PR TITLE
Molpro: Implementing get_version for Molpro engine

### DIFF
--- a/qcengine/testing.py
+++ b/qcengine/testing.py
@@ -55,7 +55,7 @@ _programs = {
     "torchani": which_import("torchani", return_bool=True),
     "mp2d": which('mp2d', return_bool=True),
     "terachem": which("terachem", return_bool=True),
-    "molpro": which("molpro", return_bool=True)
+    "molpro": is_program_new_enough("molpro", "2018.1")
 }
 
 def has_program(name):


### PR DESCRIPTION
The `get_version()` function now works. Currently I'm enforcing that any version of Molpro below 2018.1 won't work with QCEngine (the version of Molpro I've been testing these output parsers on). I haven't tested that extensively. Should I comment out that restriction for now?