### PR TITLE
Psi4 QCVars 

### DIFF
--- a/qcengine/programs/psi4.py
+++ b/qcengine/programs/psi4.py
@@ -85,7 +85,15 @@ class Psi4Harness(ProgramHarness):
                 if "extras" not in output_data:
                     output_data["extras"] = {}
 
-                output_data["extras"]["local_qcvars"] = output_data.pop("psi4:qcvars", None)
+                # Check QCVars
+                local_qcvars = output_data.pop("psi4:qcvars", None)
+                if local_qcvars:
+                    # Edge case where we might already have qcvars, should not happen
+                    if "qcvars" in output_data["extras"]:
+                        output_data["extras"]["local_qcvars"] = local_qcvars
+                    else:
+                        output_data["extras"]["qcvars"] = local_qcvars
+
                 if output_data["success"] is False:
                     if "error_message" not in output_data["error"]:
                         # older c. 1.3 message-only run_json

--- a/qcengine/tests/test_procedures.py
+++ b/qcengine/tests/test_procedures.py
@@ -37,6 +37,7 @@ def test_geometric_psi4():
 
     inp["initial_molecule"] = qcng.get_molecule("hydrogen")
     inp["input_specification"]["model"] = {"method": "HF", "basis": "sto-3g"}
+    inp["input_specification"]["keywords"] = {"scf_properties": ["wiberg_lowdin_indices"]}
     inp["keywords"]["program"] = "psi4"
 
     inp = OptimizationInput(**inp)
@@ -47,6 +48,11 @@ def test_geometric_psi4():
     assert pytest.approx(ret.final_molecule.measure([0, 1]), 1.e-4) == 1.3459150737
     assert ret.provenance.creator.lower() == "geometric"
     assert ret.trajectory[0].provenance.creator.lower() == "psi4"
+
+    # Check keywords passing
+    for single in ret.trajectory:
+        assert "scf_properties" in single.keywords
+        assert "WIBERG_LOWDIN_INDICES" in single.extras["qcvars"]
 
 
 @testing.using_psi4


### PR DESCRIPTION
Psi4 natively exports `qcvars` in most version. The redirect is only there for older versions of Psi4, but was causing additional fields to be populated in newer versions of Psi4 with a `None` value. This now correctly assigns `qcvars` in older versions of Psi4 with a decision tree.

Also adds an additional geometric test to ensure keywords are continuously passed through.