### PR TITLE
Entos: Added entos engine

### DIFF
--- a/devtools/conda-envs/psi.yaml
+++ b/devtools/conda-envs/psi.yaml
@@ -19,6 +19,3 @@ dependencies:
   - pytest
   - pytest-cov
   - codecov
-
-    # Optional depends
-  - jinja2

--- a/devtools/conda-envs/psi.yaml
+++ b/devtools/conda-envs/psi.yaml
@@ -19,3 +19,6 @@ dependencies:
   - pytest
   - pytest-cov
   - codecov
+
+    # Optional depends
+  - jinja2

--- a/qcengine/programs/base.py
+++ b/qcengine/programs/base.py
@@ -7,6 +7,7 @@ from ..exceptions import InputError, ResourceError
 
 from .cfour import CFOURHarness
 from .dftd3 import DFTD3Harness
+from .entos import EntosHarness
 from .gamess import GAMESSHarness
 from .nwchem import NWChemHarness
 from .molpro import MolproHarness
@@ -87,3 +88,4 @@ register_program(MP2DHarness())
 #register_program(GAMESSHarness())
 #register_program(NWChemHarness())
 #register_program(CFOURHarness())
+register_program(EntosHarness())

--- a/qcengine/programs/entos.py
+++ b/qcengine/programs/entos.py
@@ -60,15 +60,6 @@ class EntosHarness(ProgramHarness):
         # Run entos
         exe_success, proc = self.execute(job_inputs)
 
-        # # Run entos
-        # exe_success, proc = execute(job_inputs["commands"],
-        #                             infiles=job_inputs["infiles"],
-        #                             outfiles=["dispatch.out"],
-        #                             scratch_location=job_inputs["scratch_location"],
-        #                             timeout=None
-        #                             )
-        # proc["outfiles"]["dispatch.out"] = proc["stdout"]
-
         # Determine whether the calculation succeeded
         output_data = {}
         if not exe_success:
@@ -84,14 +75,24 @@ class EntosHarness(ProgramHarness):
         result = self.parse_output(proc["outfiles"], input_data)
         return result
 
-    # TODO actually use the optional options
     def execute(self, inputs, extra_outfiles=None, extra_commands=None, scratch_name=None, timeout=None):
-        # Run entos
-        exe_success, proc = execute(inputs["commands"],
+
+        if extra_outfiles is not None:
+            outfiles = ["dispatch.out"].extend(extra_outfiles)
+        else:
+            outfiles = ["dispatch.out"]
+
+        if extra_commands is not None:
+            commands = inputs["commands"]
+        else:
+            commands = inputs["commands"]
+
+        exe_success, proc = execute(commands,
                                     infiles=inputs["infiles"],
-                                    outfiles=["dispatch.out"],
+                                    outfiles=outfiles,
                                     scratch_location=inputs["scratch_location"],
-                                    timeout=None
+                                    scratch_name=scratch_name,
+                                    timeout=timeout
                                     )
         proc["outfiles"]["dispatch.out"] = proc["stdout"]
         return exe_success, proc
@@ -105,7 +106,6 @@ class EntosHarness(ProgramHarness):
         # Creat input dictionary
         if template is None:
             input_dict = {}
-            # TODO Is there a way to require keywords?
             if input_model.driver == 'energy':
                 input_dict = {'dft': {
                                 'structure': {

--- a/qcengine/programs/entos.py
+++ b/qcengine/programs/entos.py
@@ -1,0 +1,170 @@
+"""
+Calls the entos executable.
+"""
+
+from typing import Any, Dict, Optional
+
+from qcelemental.models import Result, FailedOperation
+from ..util import execute
+from qcelemental.util import which
+
+from .executor import ProgramExecutor
+
+
+class EntosExecutor(ProgramExecutor):
+    _defaults = {
+        "name": "entos",
+        "scratch": True,
+        "thread_safe": False,
+        "thread_parallel": True,
+        "node_parallel": False,
+        "managed_memory": True,
+    }
+    version_cache: Dict[str, str] = {}
+
+    class Config(ProgramExecutor.Config):
+        pass
+
+    def __init__(self, **kwargs):
+        super().__init__(**{**self._defaults, **kwargs})
+
+    def found(self, raise_error: bool=False) -> bool:
+        return which('entos', return_bool=True, raise_error=raise_error, raise_msg='Please install via XXX')
+
+    def get_version(self) -> str:
+        self.found(raise_error=True)
+
+        #which_prog = which('molpro')
+        #if which_prog not in self.version_cache:
+        #    success, output = execute([which_prog, "v.inp"], {"v.inp": ""})
+
+        #    if success:
+        #        for line in output["stdout"].splitlines():
+        #            if 'GAMESS VERSION' in line:
+        #                branch = ' '.join(line.strip(' *\t').split()[3:])
+        #        self.version_cache[which_prog] = safe_version(branch)
+
+        #return self.version_cache[which_prog]
+
+    def compute(self, input_data: 'ResultInput', config: 'JobConfig') -> 'Result':
+        """
+        Run entos
+        """
+        # Check if entos executable is found
+        self.found(raise_error=True)
+
+        # Check entos version
+        # if parse_version(self.get_version()) < parse_version("2018.1"):
+        #     raise TypeError("entos version '{}' not understood".format(self.get_version()))
+
+        # Setup the job
+        job_inputs = self.build_input(input_data, config)
+
+        # Run entos
+        exe_success, proc = execute(job_inputs["commands"],
+                                    infiles=job_inputs["infiles"],
+                                    outfiles=["dispatch.out"],
+                                    scratch_location=job_inputs["scratch_location"],
+                                    timeout=None
+                                    )
+
+        # Determine whether the calculation succeeded
+        output_data = {}
+        if not exe_success:
+            output_data["success"] = False
+            output_data["error"] = {"error_type": "internal_error",
+                                    "error_message": proc["stderr"]
+                                    }
+            return FailedOperation(
+                success=output_data.pop("success", False), error=output_data.pop("error"), input_data=output_data)
+
+        # If execution succeeded, collect results
+        result = self.parse_output(proc["outfiles"], input_data)
+        return result
+
+    def build_input(self, input_model: 'ResultInput', config: 'JobConfig',
+                    template: Optional[str] = None) -> Dict[str, Any]:
+        input_file = []
+
+        # Write header info
+        input_file.append("!Title")
+        input_file.append("memory,{},M".format(config.memory))
+        input_file.append('')
+
+        # Write the geom
+        input_file.append('geometry={')
+        for sym, geom in zip(input_model.molecule.symbols, input_model.molecule.geometry):
+            s = "{:<4s} {:>{width}.{prec}f} {:>{width}.{prec}f} {:>{width}.{prec}f}".format(
+                sym, *geom, width=14, prec=10)
+            input_file.append(s)
+        input_file.append('}')
+
+        # Write gradient call if asked for
+        if input_model.driver == 'gradient':
+            input_file.append('')
+            input_file.append('{force}')
+
+        input_file = "\n".join(input_file)
+
+        return {
+            "commands": ["entos", "dispatch.in", "-n", str(config.ncores)],
+            "infiles": {
+                "dispatch.in": input_file
+            },
+            "scratch_location": config.scratch_directory,
+            "input_result": input_model.copy(deep=True)
+        }
+
+    def parse_output(self, outfiles: Dict[str, str], input_model: 'ResultInput') -> 'Result':
+
+        output_data = {}
+        properties = {}
+
+        # SCF maps
+        scf_energy_map = {"Energy": "scf_total_energy"}
+        scf_dipole_map = {"Dipole moment": "scf_dipole_moment"}
+        scf_extras = {}
+
+        # MP2 maps
+        mp2_energy_map = {
+            "total energy": "mp2_total_energy",
+            "correlation energy": "mp2_correlation_energy",
+            "singlet pair energy": "mp2_singlet_pair_energy",
+            "triplet pair energy": "mp2_triplet_pair_energy"
+        }
+        mp2_dipole_map = {"Dipole moment": "mp2_dipole_moment"}
+        mp2_extras = {}
+
+        # Compiling the method maps
+        scf_maps = {
+            "energy": scf_energy_map,
+            "dipole": scf_dipole_map,
+            "extras": scf_extras
+        }
+        mp2_maps = {
+            "energy": mp2_energy_map,
+            "dipole": mp2_dipole_map,
+            "extras": mp2_extras
+        }
+        supported_methods = {"HF": scf_maps, "RHF": scf_maps, "MP2": mp2_maps}
+
+        # A slightly more robust way of determining the final energy.
+        # Throws an error if the energy isn't found for the method specified from the input_model.
+        method = input_model.model.method
+        method_energy_map = supported_methods[method]['energy']
+        if 'total energy' in method_energy_map and method_energy_map['total energy'] in properties:
+            final_energy = properties[method_energy_map['total energy']]
+        elif 'Energy' in method_energy_map and method_energy_map['Energy'] in properties:
+            final_energy = properties[method_energy_map['Energy']]
+        else:
+            raise KeyError("Could not find {:s} total energy".format(method))
+
+        # Replace return_result with final_energy if gradient wasn't called
+        if "return_result" not in output_data:
+            output_data["return_result"] = final_energy
+
+        output_data["properties"] = properties
+        output_data['schema_name'] = 'qcschema_output'
+        output_data['success'] = True
+
+        return Result(**{**input_model.dict(), **output_data})

--- a/qcengine/programs/entos.py
+++ b/qcengine/programs/entos.py
@@ -6,10 +6,11 @@ from typing import Any, Dict, Optional, List
 
 from qcelemental.models import Result, FailedOperation
 from ..util import execute, popen
-from qcelemental.util import which, safe_version, parse_version, which_import
+from qcelemental.util import which, safe_version, parse_version
 from ..exceptions import UnknownError
 
 from .model import ProgramHarness
+import string
 
 
 class EntosHarness(ProgramHarness):
@@ -97,11 +98,6 @@ class EntosHarness(ProgramHarness):
     def build_input(self, input_model: 'ResultInput', config: 'JobConfig',
                     template: Optional[str] = None) -> Dict[str, Any]:
 
-        # Ensure (optional dependency) jinja2 exists if template is provided
-        if template is not None and not which_import('jinja2', return_bool=True):
-            raise ModuleNotFoundError("""Python module jinja2 not found. Solve by installing it: `conda install 
-            jinja2` or `pip install jinja2`""")
-
         # Write the geom xyz file with unit au
         xyz_file = input_model.molecule.to_string(dtype='xyz', units='Angstrom')
 
@@ -131,7 +127,6 @@ class EntosHarness(ProgramHarness):
             input_file = self.write_input_recursive(input_dict)
             input_file = "\n".join(input_file)
         else:
-            import jinja2
             # Some of the potential different template options
             # (A) ordinary build_input (need to define a base template)
             # (B) user wants to add stuff after normal template (A)
@@ -146,8 +141,8 @@ class EntosHarness(ProgramHarness):
             # }
 
             # Perform substitution to create input file
-            str_template = jinja2.Template(template)
-            input_file = str_template.render()
+            str_template = string.Template(template)
+            input_file = str_template.substitute()
 
         return {
             "commands": ["entos", "-n", str(config.ncores), "dispatch.in"],

--- a/qcengine/programs/entos.py
+++ b/qcengine/programs/entos.py
@@ -6,10 +6,9 @@ from typing import Any, Dict, Optional, List
 
 from qcelemental.models import Result, FailedOperation
 from ..util import execute, popen
-from qcelemental.util import which, safe_version, parse_version
+from qcelemental.util import which, safe_version, parse_version, which_import
 
 from .model import ProgramHarness
-import jinja2
 
 
 class EntosHarness(ProgramHarness):
@@ -103,6 +102,11 @@ class EntosHarness(ProgramHarness):
     def build_input(self, input_model: 'ResultInput', config: 'JobConfig',
                     template: Optional[str] = None) -> Dict[str, Any]:
 
+        # Ensure (optional dependency) jinja2 exists if template is provided
+        if template is not None and not which_import('jinja2', return_bool=True):
+            raise ModuleNotFoundError("""Python module jinja2 not found. Solve by installing it: `conda install 
+            jinja2` or `pip install jinja2`""")
+
         # Write the geom xyz file with unit au
         xyz_file = input_model.molecule.to_string(dtype='xyz', units='Angstrom')
 
@@ -145,6 +149,7 @@ class EntosHarness(ProgramHarness):
             input_file = self.write_input_recursive(input_dict)
             input_file = "\n".join(input_file)
         else:
+            import jinja2
             # Some of the potential different template options
             # (A) ordinary build_input (need to define a base template)
             # (B) user wants to add stuff after normal template (A)

--- a/qcengine/programs/tests/test_entos.py
+++ b/qcengine/programs/tests/test_entos.py
@@ -1,7 +1,7 @@
 import pytest
 import qcelemental as qcel
 from qcelemental.testing import compare_recursive
-from qcengine.testing import using_entos, using_jinja2
+from qcengine.testing import using_entos
 
 import qcengine as qcng
 
@@ -41,9 +41,8 @@ def test_entos_input_formatter(test_case):
     assert input_file.keys() >= {"commands", "infiles"}
 
 
-@using_jinja2
 @pytest.mark.parametrize('test_case', entos_info.list_test_cases())
-def test_entos_input_formatter_jinja2(test_case):
+def test_entos_input_formatter_template(test_case):
 
     # Get input file data
     data = entos_info.get_test_data(test_case)

--- a/qcengine/programs/tests/test_entos.py
+++ b/qcengine/programs/tests/test_entos.py
@@ -25,7 +25,6 @@ def test_entos_output_parser(test_case):
     output_ref = qcel.models.Result.parse_raw(data["output.json"]).dict()
     output_ref.pop("provenance", None)
 
-    # TODO add `skip` to compare_recursive
     check = compare_recursive(output_ref, output)
     assert check, check
 

--- a/qcengine/programs/tests/test_entos.py
+++ b/qcengine/programs/tests/test_entos.py
@@ -1,7 +1,7 @@
 import pytest
 import qcelemental as qcel
 from qcelemental.testing import compare_recursive
-from qcengine.testing import using_entos
+from qcengine.testing import using_entos, using_jinja2
 
 import qcengine as qcng
 
@@ -19,7 +19,7 @@ def test_entos_output_parser(test_case):
     data = entos_info.get_test_data(test_case)
     inp = qcel.models.ResultInput.parse_raw(data["input.json"])
 
-    output = qcng.get_program('entos').parse_output(data, inp).dict()
+    output = qcng.get_program('entos', check=False).parse_output(data, inp).dict()
     output.pop("provenance", None)
 
     output_ref = qcel.models.Result.parse_raw(data["output.json"]).dict()
@@ -37,7 +37,20 @@ def test_entos_input_formatter(test_case):
     inp = qcel.models.ResultInput.parse_raw(data["input.json"])
 
     # TODO add actual comparison of generated input file
-    input_file = qcng.get_program('entos').build_input(inp, qcng.get_config())
+    input_file = qcng.get_program('entos', check=False).build_input(inp, qcng.get_config())
+    assert input_file.keys() >= {"commands", "infiles"}
+
+
+@using_jinja2
+@pytest.mark.parametrize('test_case', entos_info.list_test_cases())
+def test_entos_input_formatter_jinja2(test_case):
+
+    # Get input file data
+    data = entos_info.get_test_data(test_case)
+    inp = qcel.models.ResultInput.parse_raw(data["input.json"])
+
+    # TODO add actual comparison of generated input file
+    input_file = qcng.get_program('entos',  check=False).build_input(inp, qcng.get_config(), template="Test template")
     assert input_file.keys() >= {"commands", "infiles"}
 
 

--- a/qcengine/programs/tests/test_entos.py
+++ b/qcengine/programs/tests/test_entos.py
@@ -1,0 +1,60 @@
+import pytest
+import qcelemental as qcel
+from qcelemental.testing import compare_recursive
+from qcengine.testing import using_entos
+
+import qcengine as qcng
+
+# qcenginerecords not required, skips whole file
+qcer = pytest.importorskip("qcenginerecords")
+
+# Prep globals
+entos_info = qcer.get_info('entos')
+
+
+@pytest.mark.parametrize('test_case', entos_info.list_test_cases())
+def test_entos_output_parser(test_case):
+
+    # Get output file data
+    data = entos_info.get_test_data(test_case)
+    inp = qcel.models.ResultInput.parse_raw(data["input.json"])
+
+    output = qcng.get_program('entos').parse_output(data, inp).dict()
+    output.pop("provenance", None)
+
+    output_ref = qcel.models.Result.parse_raw(data["output.json"]).dict()
+    output_ref.pop("provenance", None)
+
+    # TODO add `skip` to compare_recursive
+    check = compare_recursive(output_ref, output)
+    assert check, check
+
+
+@pytest.mark.parametrize('test_case', entos_info.list_test_cases())
+def test_entos_input_formatter(test_case):
+
+    # Get input file data
+    data = entos_info.get_test_data(test_case)
+    inp = qcel.models.ResultInput.parse_raw(data["input.json"])
+
+    # TODO add actual comparison of generated input file
+    input_file = qcng.get_program('entos').build_input(inp, qcng.get_config())
+    assert input_file.keys() >= {"commands", "infiles"}
+
+
+@using_entos
+@pytest.mark.parametrize('test_case', entos_info.list_test_cases())
+def test_entos_executor(test_case):
+    # Get input file data
+    data = entos_info.get_test_data(test_case)
+    inp = qcel.models.ResultInput.parse_raw(data["input.json"])
+
+    # Run entos
+    result = qcng.compute(inp, 'entos')
+    assert result.success is True
+
+    # Get output file data
+    output_ref = qcel.models.Result.parse_raw(data["output.json"])
+
+    atol = 1e-6
+    assert compare_recursive(output_ref.return_result, result.return_result, atol=atol)

--- a/qcengine/testing.py
+++ b/qcengine/testing.py
@@ -55,7 +55,7 @@ _programs = {
     "torchani": which_import("torchani", return_bool=True),
     "mp2d": which('mp2d', return_bool=True),
     "terachem": which("terachem", return_bool=True),
-    "molpro": is_program_new_enough("molpro", "2018.1")
+    "molpro": is_program_new_enough("molpro", "2018.1"),
     "entos": is_program_new_enough("entos", "0.5")
 }
 

--- a/qcengine/testing.py
+++ b/qcengine/testing.py
@@ -81,3 +81,7 @@ using_entos = _build_pytest_skip("entos")
 using_dftd3_321 = pytest.mark.skipif(
     is_program_new_enough("dftd3", "3.2.1") is False,
     reason='DFTD3 does not include 3.2.1 features. Update package and add to PATH')
+
+using_jinja2 = pytest.mark.skipif(
+    which_import('jinja2', return_bool=True) is False,
+    reason='Not detecting module jinja2. Install package if necessary and add to envvar PYTHONPATH')

--- a/qcengine/testing.py
+++ b/qcengine/testing.py
@@ -56,6 +56,7 @@ _programs = {
     "mp2d": which('mp2d', return_bool=True),
     "terachem": which("terachem", return_bool=True),
     "molpro": is_program_new_enough("molpro", "2018.1")
+    "entos": which("entos", return_bool=True)
 }
 
 def has_program(name):
@@ -75,6 +76,7 @@ using_torchani = _build_pytest_skip("torchani")
 using_mp2d = _build_pytest_skip("mp2d")
 using_terachem = _build_pytest_skip("terachem")
 using_molpro = _build_pytest_skip("molpro")
+using_entos = _build_pytest_skip("entos")
 
 using_dftd3_321 = pytest.mark.skipif(
     is_program_new_enough("dftd3", "3.2.1") is False,

--- a/qcengine/testing.py
+++ b/qcengine/testing.py
@@ -81,7 +81,3 @@ using_entos = _build_pytest_skip("entos")
 using_dftd3_321 = pytest.mark.skipif(
     is_program_new_enough("dftd3", "3.2.1") is False,
     reason='DFTD3 does not include 3.2.1 features. Update package and add to PATH')
-
-using_jinja2 = pytest.mark.skipif(
-    which_import('jinja2', return_bool=True) is False,
-    reason='Not detecting module jinja2. Install package if necessary and add to envvar PYTHONPATH')

--- a/qcengine/testing.py
+++ b/qcengine/testing.py
@@ -56,7 +56,7 @@ _programs = {
     "mp2d": which('mp2d', return_bool=True),
     "terachem": which("terachem", return_bool=True),
     "molpro": is_program_new_enough("molpro", "2018.1")
-    "entos": which("entos", return_bool=True)
+    "entos": is_program_new_enough("entos", "0.5")
 }
 
 def has_program(name):


### PR DESCRIPTION
I've added entos as an engine. It includes all functions to be run by `qcng.compute()` and the ability to run `entos.build_input()`, `entos.execute()`, and `entos.parse_output()`. I've begun adding support for using Jinja templates so we can cover the different ways might want to provide custom template files. 

(A) ordinary build_input (need to define a base template)
(B) user wants to add stuff after normal template (A)
(C) user knows their domain language (doesn't use any QCSchema quantities)

Right now it only supports option (C). Also right now the output parser does text parsing, but this will be removed eventually since entos plans to output all of their results to a xml or json format. 