### PR TITLE
Psi4 Scratch Control

### DIFF
--- a/qcengine/programs/psi4.py
+++ b/qcengine/programs/psi4.py
@@ -2,6 +2,7 @@
 Calls the Psi4 executable.
 """
 import json
+import os
 from typing import Dict
 
 from qcelemental.models import Result
@@ -9,7 +10,7 @@ from qcelemental.util import parse_version, safe_version, which
 
 from .model import ProgramHarness
 from ..exceptions import InputError, RandomError, ResourceError, UnknownError
-from ..util import execute, popen
+from ..util import execute, popen, temporary_directory
 
 
 class Psi4Harness(ProgramHarness):
@@ -31,8 +32,11 @@ class Psi4Harness(ProgramHarness):
         super().__init__(**{**self._defaults, **kwargs})
 
     @staticmethod
-    def found(raise_error: bool=False) -> bool:
-        return which('psi4', return_bool=True, raise_error=raise_error, raise_msg='Please install via `conda install psi4 -c psi4`.')
+    def found(raise_error: bool = False) -> bool:
+        return which('psi4',
+                     return_bool=True,
+                     raise_error=raise_error,
+                     raise_msg='Please install via `conda install psi4 -c psi4`.')
 
     def get_version(self) -> str:
         self.found(raise_error=True)
@@ -57,6 +61,9 @@ class Psi4Harness(ProgramHarness):
         """
         self.found(raise_error=True)
 
+        if parse_version(self.get_version()) < parse_version("1.2"):
+            raise ResourceError("Psi4 version '{}' not understood.".format(self.get_version()))
+
         # Setup the job
         input_data = input_model.json_dict()
         input_data["nthreads"] = config.ncores
@@ -67,18 +74,21 @@ class Psi4Harness(ProgramHarness):
         if input_data["schema_name"] == "qcschema_input":
             input_data["schema_name"] = "qc_schema_input"
 
-        if config.scratch_directory:
-            input_data["scratch_directory"] = config.scratch_directory
+        # Location resolution order config.scratch_dir, $PSI_SCRATCH, /tmp
+        parent = config.scratch_directory
+        if parent is None:
+            parent = os.environ.get("PSI_SCRATCH", None)
 
-        if parse_version(self.get_version()) > parse_version("1.2"):
+        with temporary_directory(parent=parent, suffix="_psi_scratch") as tmpdir:
 
             caseless_keywords = {k.lower(): v for k, v in input_model.keywords.items()}
             if (input_model.molecule.molecular_multiplicity != 1) and ("reference" not in caseless_keywords):
                 input_data["keywords"]["reference"] = "uhf"
 
             # Execute the program
-            success, output = execute([which("psi4"), "--json", "data.json"], {"data.json": json.dumps(input_data)},
-                                      ["data.json"])
+            success, output = execute([which("psi4"), "--scratch", tmpdir, "--json", "data.json"],
+                                      {"data.json": json.dumps(input_data)}, ["data.json"],
+                                      scratch_directory=tmpdir)
 
             if success:
                 output_data = json.loads(output["outfiles"]["data.json"])
@@ -97,13 +107,14 @@ class Psi4Harness(ProgramHarness):
                 if output_data["success"] is False:
                     if "error_message" not in output_data["error"]:
                         # older c. 1.3 message-only run_json
-                        output_data["error"] = {"error_type": "internal_error", "error_message": output_data["error"]}
+                        output_data["error"] = {
+                            "error_type": "internal_error",
+                            "error_message": output_data["error"]
+                        }
             else:
                 output_data = input_data
                 output_data["error"] = {"error_type": "execution_error", "error_message": output["stderr"]}
 
-        else:
-            raise ResourceError("Psi4 version '{}' not understood.".format(self.get_version()))
 
         # Reset the schema if required
         output_data["schema_name"] = "qcschema_output"
@@ -135,6 +146,5 @@ class Psi4Harness(ProgramHarness):
 
         # Delete keys
         output_data.pop("return_output", None)
-        output_data.pop("scratch_directory", None)
 
         return Result(**output_data)

--- a/qcengine/programs/tests/test_dftd3_mp2d.py
+++ b/qcengine/programs/tests/test_dftd3_mp2d.py
@@ -649,7 +649,7 @@ def test_dftd3__from_arrays__supplement():
     assert compare_recursive(ans, res, atol=1.e-4)
     with pytest.raises(qcng.exceptions.InputError) as e:
         empirical_dispersion_resources.from_arrays(name_hint=res['fctldash'], level_hint=res['dashlevel'], param_tweaks=res['dashparams'])
-    assert "Can't guess -D correction level" in str(e)
+    assert "Can't guess -D correction level" in str(e.value)
     res = empirical_dispersion_resources.from_arrays(
         name_hint=res['fctldash'],
         level_hint=res['dashlevel'],


### PR DESCRIPTION
Manages an explicit folder for each Psi4 job to write into and passes the scratch directory via `-s` command line.

Previously the scratch was not correctly set due to a key mismatch in Psi4 `scratch_directory` vs `scratch_location`.