### PR TITLE
[DNM] Azure Pipelines Local Pool Worker Discussion

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -1,0 +1,47 @@
+jobs:
+- job: 'Testing'
+  displayName: 'Unit Testing With Programs'
+  pool:
+    name: qcengine
+  timeoutInMinutes: 360
+  strategy:
+    matrix:
+      Python36:
+        python.version: '3.6'
+      Python37:
+        python.version: '3.7'
+    maxParallel: 3
+
+  steps:
+      # Specify to use the python version defined above
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: '$(python.version)'
+        architecture: 'x64'
+
+      # Additional info about the build
+    - script: |
+        uname -a
+        free -m
+        df -h
+        ulimit -a
+
+    # Setup python environment
+    - script: |
+        # Create test environment for package
+        conda env create -n test python=$PYTHON_VER -f devtools/conda-envs/openff.yaml
+        source activate test
+        # Build and install package
+        python setup.py develop --no-deps
+      displayName: "Conda Env Creation"
+
+    # Display MongoDB, Conda Environment, Python version
+    - script: |
+        sleep 5
+        python -V
+        conda list
+      displayName: 'Display'
+
+    # Run tests
+    - script: py.test -v --runslow --cov=qcfractal qcfractal/
+      displayName: 'pytest'

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -34,8 +34,8 @@ jobs:
         WORKER=worker_test$PYTHON_VER
         source $(CONDASOURCE)
         # Create test environment for package
-        conda env create -n WORKER python=$PYTHON_VER -f devtools/conda-envs/psi.yaml
-        conda activate worker_test
+        conda env create -n $WORKER python=$PYTHON_VER -f devtools/conda-envs/psi.yaml
+        conda activate $WORKER
         # Build and install package
         python setup.py develop --no-deps
       displayName: "Conda Env Creation"
@@ -45,6 +45,8 @@ jobs:
         sleep 5
         python -V
         conda list
+        pwd
+        ls -la
       displayName: 'Display'
 
     # Run tests

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -40,7 +40,7 @@ jobs:
         #conda env create -n $WORKER python=$(python.version) -f devtools/conda-envs/psi.yaml
         conda env create -p $ENVPREFIX python=$(python.version) -f devtools/conda-envs/psi.yaml
         #conda activate $WORKER
-        conda activate -p $ENVPREFIX
+        conda activate $ENVPREFIX
         # Build and install package
         python setup.py develop --no-deps
       displayName: "Conda Env Creation"
@@ -50,7 +50,7 @@ jobs:
         sleep 5
         python -V
         source $(CONDASOURCE)
-        conda activate -p $ENVPREFIX
+        conda activate $ENVPREFIX
         conda list
         pwd
         ls -la
@@ -59,7 +59,7 @@ jobs:
     # Run tests
     - script: |
         source $(CONDASOURCE)
-        conda activate -p $ENVPREFIX
+        conda activate $ENVPREFIX
         pytest -rsx -v --cov=qcengine/ qcengine/
       displayName: 'pytest'
 

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -16,14 +16,9 @@ jobs:
     maxParallel: 3
 
   steps:
-      # Specify to use the python version defined above
-#    - task: UsePythonVersion@0
-#      inputs:
-#        versionSpec: '$(python.version)'
-#        architecture: 'x64'
     - script: |
-        echo '##vso[task.setvariable variable=WORKER]worker_test$(python.version)'
-        echo '##vso[task.setvariable variable=ENVPREFIX]$(Agent.TempDirectory)/testnv'
+        echo '##vso[task.setvariable variable=ENVPREFIX]$(Agent.TempDirectory)/testnv$(python.version)'
+      displayName: "Worker Variable Assignment"
 
       # Additional info about the build
     - script: |
@@ -37,9 +32,7 @@ jobs:
     - script: |
         source $(CONDASOURCE)
         # Create test environment for package
-        #conda env create -n $WORKER python=$(python.version) -f devtools/conda-envs/psi.yaml
         conda env create -p $ENVPREFIX python=$(python.version) -f devtools/conda-envs/psi.yaml
-        #conda activate $WORKER
         conda activate $ENVPREFIX
         # Build and install package
         python setup.py develop --no-deps
@@ -62,10 +55,3 @@ jobs:
         conda activate $ENVPREFIX
         pytest -rsx -v --cov=qcengine/ qcengine/
       displayName: 'pytest'
-
-    # Cleanup
-    - script: |
-        conda remove -n $WORKER --yes --all -d
-      condition: always()
-      failOnStderr: False
-      displayName: "Conda Env Cleanup"

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -14,10 +14,10 @@ jobs:
 
   steps:
       # Specify to use the python version defined above
-    - task: UsePythonVersion@0
-      inputs:
-        versionSpec: '$(python.version)'
-        architecture: 'x64'
+#    - task: UsePythonVersion@0
+#      inputs:
+#        versionSpec: '$(python.version)'
+#        architecture: 'x64'
 
       # Additional info about the build
     - script: |
@@ -28,9 +28,10 @@ jobs:
 
     # Setup python environment
     - script: |
+        WORKER=worker_test$PYTHON_VER
         # Create test environment for package
-        conda env create -n test python=$PYTHON_VER -f devtools/conda-envs/openff.yaml
-        source activate test
+        conda env create -n WORKER python=$PYTHON_VER -f devtools/conda-envs/openff.yaml
+        conda activate worker_test
         # Build and install package
         python setup.py develop --no-deps
       displayName: "Conda Env Creation"
@@ -45,3 +46,10 @@ jobs:
     # Run tests
     - script: py.test -v --runslow --cov=qcfractal qcfractal/
       displayName: 'pytest'
+
+    # Cleanup
+    - script: |
+        WORKER=worker_test$PYTHON_VER
+        conda remove -n $WORKER --yes --all
+      condition: always()
+      failOnStderr: False

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -1,3 +1,6 @@
+variables:
+  CONDASOURCE: "~/miniconda3/etc/profile.d/conda.sh"
+
 jobs:
 - job: 'Testing'
   displayName: 'Unit Testing With Programs'
@@ -29,8 +32,9 @@ jobs:
     # Setup python environment
     - script: |
         WORKER=worker_test$PYTHON_VER
+        source $(CONDASOURCE)
         # Create test environment for package
-        conda env create -n WORKER python=$PYTHON_VER -f devtools/conda-envs/openff.yaml
+        conda env create -n WORKER python=$PYTHON_VER -f devtools/conda-envs/psi.yaml
         conda activate worker_test
         # Build and install package
         python setup.py develop --no-deps
@@ -44,7 +48,7 @@ jobs:
       displayName: 'Display'
 
     # Run tests
-    - script: py.test -v --runslow --cov=qcfractal qcfractal/
+    - script: pytest -rsx -v --cov=qcengine/ qcengine/
       displayName: 'pytest'
 
     # Cleanup
@@ -53,3 +57,4 @@ jobs:
         conda remove -n $WORKER --yes --all
       condition: always()
       failOnStderr: False
+      displayName: "Conda Env Cleanup"

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -21,6 +21,8 @@ jobs:
 #      inputs:
 #        versionSpec: '$(python.version)'
 #        architecture: 'x64'
+    - script: |
+        echo '##vso[task.setvariable variable=WORKER]worker_test$(python.version)'
 
       # Additional info about the build
     - script: |
@@ -28,13 +30,13 @@ jobs:
         free -m
         df -h
         ulimit -a
+      displayName: "Build Info"
 
     # Setup python environment
     - script: |
-        WORKER=worker_test$PYTHON_VER
         source $(CONDASOURCE)
         # Create test environment for package
-        conda env create -n $WORKER python=$PYTHON_VER -f devtools/conda-envs/psi.yaml
+        conda env create -n $WORKER python=$(python.version) -f devtools/conda-envs/psi.yaml
         conda activate $WORKER
         # Build and install package
         python setup.py develop --no-deps
@@ -44,6 +46,8 @@ jobs:
     - script: |
         sleep 5
         python -V
+        source $(CONDASOURCE)
+        conda activate
         conda list
         pwd
         ls -la
@@ -55,8 +59,7 @@ jobs:
 
     # Cleanup
     - script: |
-        WORKER=worker_test$PYTHON_VER
-        conda remove -n $WORKER --yes --all
+        conda remove -n $WORKER --yes --all -d
       condition: always()
       failOnStderr: False
       displayName: "Conda Env Cleanup"

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -23,6 +23,7 @@ jobs:
 #        architecture: 'x64'
     - script: |
         echo '##vso[task.setvariable variable=WORKER]worker_test$(python.version)'
+        echo '##vso[task.setvariable variable=ENVPREFIX]$(Agent.TempDirectory)/testnv'
 
       # Additional info about the build
     - script: |
@@ -36,8 +37,10 @@ jobs:
     - script: |
         source $(CONDASOURCE)
         # Create test environment for package
-        conda env create -n $WORKER python=$(python.version) -f devtools/conda-envs/psi.yaml
-        conda activate $WORKER
+        #conda env create -n $WORKER python=$(python.version) -f devtools/conda-envs/psi.yaml
+        conda env create -p $ENVPREFIX python=$(python.version) -f devtools/conda-envs/psi.yaml
+        #conda activate $WORKER
+        conda activate -p $ENVPREFIX
         # Build and install package
         python setup.py develop --no-deps
       displayName: "Conda Env Creation"
@@ -47,14 +50,17 @@ jobs:
         sleep 5
         python -V
         source $(CONDASOURCE)
-        conda activate
+        conda activate -p $ENVPREFIX
         conda list
         pwd
         ls -la
       displayName: 'Display'
 
     # Run tests
-    - script: pytest -rsx -v --cov=qcengine/ qcengine/
+    - script: |
+        source $(CONDASOURCE)
+        conda activate -p $ENVPREFIX
+        pytest -rsx -v --cov=qcengine/ qcengine/
       displayName: 'pytest'
 
     # Cleanup


### PR DESCRIPTION
** DO NOT MERGE ** Experimental code which will not live inside the repo itself.

I've been experimenting with setting up a local worker for Azure DevOps Pipelines where we can install and do CI testing on code we have access to but cannot put online.

How its setup is what I have been tinkering with, but I wanted to discuss what we want it to do exactly once it is set up, hence the PR with the code. Since we will be running local hardware, it was suggested by @dgasmith to not merge this file in with the main repository and keep the file locked behind the Azure control panel.

The actions taken by the script are as follows:

1. Assign a path for a test conda env to be created which the Agent will destroy after each job best it can (won't show up on `conda info --env` either)
2. Show build information 
3. Create the (temp) environment and install QCEngine
3. Display post-install information
4. Run Pytest

Pipeline looks like this when run:

![image](https://user-images.githubusercontent.com/3809383/61321868-66263580-a7da-11e9-929a-34d7a8be06fc.png)

And the report from the Pytest block (cut blocks for space)
```
##[section]Starting: pytest
==============================================================================
Task         : Command line
Description  : Run a command line script using Bash on Linux and macOS and cmd.exe on Windows
Version      : 2.151.1
Author       : Microsoft Corporation
Help         : https://docs.microsoft.com/azure/devops/pipelines/tasks/utility/command-line
==============================================================================
Generating script.
========================== Starting Command Output ===========================
[command]/bin/bash --noprofile --norc /Users/levinaden/sandbox/azagent/osx/_work/_temp/efead106-138e-4efc-90b7-948561d743d2.sh
============================= test session starts ==============================
platform darwin -- Python 3.7.3, pytest-5.0.1, py-1.8.0, pluggy-0.12.0 -- /Users/levinaden/sandbox/azagent/osx/_work/_temp/testnv3.7/bin/python
cachedir: .pytest_cache
rootdir: /Users/levinaden/sandbox/azagent/osx/_work/1/s, inifile: setup.cfg
plugins: cov-2.7.1
collecting ... collected 144 items / 3 skipped / 141 selected

qcengine/programs/tests/test_dftd3_mp2d.py::test_dftd3_task[b3lyp-d3] PASSED [  0%]
...
qcengine/programs/tests/test_programs.py::test_psi4_task PASSED          [ 70%]
qcengine/programs/tests/test_programs.py::test_psi4_internal_failure PASSED [ 70%]
qcengine/programs/tests/test_programs.py::test_psi4_ref_switch PASSED    [ 71%]
qcengine/programs/tests/test_programs.py::test_rdkit_task SKIPPED        [ 72%]
qcengine/programs/tests/test_programs.py::test_rdkit_connectivity_error SKIPPED [ 72%]
qcengine/programs/tests/test_programs.py::test_torchani_task SKIPPED     [ 73%]
...
qcengine/tests/test_program_utils.py::test_check_program_avail[psi4] PASSED [ 86%]
qcengine/tests/test_program_utils.py::test_check_program_avail[torchani] SKIPPED [ 87%]
qcengine/tests/test_program_utils.py::test_check_program_avail[rdkit] SKIPPED [ 88%]
qcengine/tests/test_program_utils.py::test_program_avail_bounce PASSED   [ 88%]
...

=========================== short test summary info ============================
SKIPPED [1] /Users/levinaden/sandbox/azagent/osx/_work/1/s/qcengine/programs/tests/test_entos.py:10: could not import 'qcenginerecords': No module named 'qcenginerecords'
SKIPPED [1] /Users/levinaden/sandbox/azagent/osx/_work/1/s/qcengine/programs/tests/test_molpro.py:13: could not import 'qcenginerecords': No module named 'qcenginerecords'
SKIPPED [1] /Users/levinaden/sandbox/azagent/osx/_work/1/s/qcengine/programs/tests/test_terachem.py:11: could not import 'qcenginerecords': No module named 'qcenginerecords'
SKIPPED [20] /Users/levinaden/sandbox/azagent/osx/_work/1/s/qcengine/programs/tests/test_dftd3_mp2d.py:482: Psi4 requires at least Psi4 v1.3rc2
SKIPPED [20] /Users/levinaden/sandbox/azagent/osx/_work/1/s/qcengine/programs/tests/test_dftd3_mp2d.py:460: Psi4 requires at least Psi4 v1.3rc2
SKIPPED [1] qcengine/programs/tests/test_dftd3_mp2d.py:719: Not detecting module qcdb. Install package if necessary to enable tests.
SKIPPED [18] qcengine/programs/tests/test_dftd3_mp2d.py:741: Not detecting module mp2d. Install package if necessary to enable tests.
SKIPPED [1] qcengine/programs/tests/test_programs.py:96: Not detecting module rdkit. Install package if necessary to enable tests.
SKIPPED [1] qcengine/programs/tests/test_programs.py:109: Not detecting module rdkit. Install package if necessary to enable tests.
SKIPPED [1] qcengine/programs/tests/test_programs.py:126: Not detecting module torchani. Install package if necessary to enable tests.
SKIPPED [1] qcengine/tests/test_procedures.py:78: Not detecting module rdkit. Install package if necessary to enable tests.
SKIPPED [1] qcengine/tests/test_procedures.py:94: Not detecting module rdkit. Install package if necessary to enable tests.
SKIPPED [1] qcengine/tests/test_procedures.py:110: Not detecting module torchani. Install package if necessary to enable tests.
SKIPPED [1] qcengine/tests/test_program_utils.py:17: Not detecting module torchani. Install package if necessary to enable tests.
SKIPPED [1] qcengine/tests/test_program_utils.py:17: Not detecting module rdkit. Install package if necessary to enable tests.
SKIPPED [1] /Users/levinaden/sandbox/azagent/osx/_work/1/s/qcengine/tests/test_standard_suite.py:24: Program 'rdkit' not found.
SKIPPED [1] /Users/levinaden/sandbox/azagent/osx/_work/1/s/qcengine/tests/test_standard_suite.py:24: Program 'torchani' not found.
SKIPPED [1] /Users/levinaden/sandbox/azagent/osx/_work/1/s/qcengine/tests/test_standard_suite.py:37: Program 'rdkit' not found.
SKIPPED [1] /Users/levinaden/sandbox/azagent/osx/_work/1/s/qcengine/tests/test_standard_suite.py:37: Program 'torchani' not found.
SKIPPED [1] /Users/levinaden/sandbox/azagent/osx/_work/1/s/qcengine/tests/test_standard_suite.py:55: Program 'rdkit' not found.
SKIPPED [1] /Users/levinaden/sandbox/azagent/osx/_work/1/s/qcengine/tests/test_standard_suite.py:55: Program 'torchani' not found.
==================== 71 passed, 76 skipped in 17.86 seconds ====================
##[section]Finishing: pytest
```