### PR TITLE
Molpro update

### DIFF
--- a/qcengine/programs/gamess/runner.py
+++ b/qcengine/programs/gamess/runner.py
@@ -169,7 +169,6 @@ Hydrogen   1.0   -0.82884     0.7079   0.0
 #
 #        optstash.restore()
 
-        # TODO Should only return True if Molpro calculation terminated properly
         output_data['success'] = True
 
         return Result(**{**input_model.dict(), **output_data})

--- a/qcengine/programs/molpro.py
+++ b/qcengine/programs/molpro.py
@@ -4,7 +4,7 @@ Calls the Molpro executable.
 
 import string
 import xml.etree.ElementTree as ET
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from qcelemental.models import Result
 from qcelemental.util import parse_version, safe_version, which
@@ -72,6 +72,7 @@ class MolproHarness(ProgramHarness):
         # Run Molpro
         proc = self.execute(job_inputs)
 
+        # Return proc if it is type UnknownError for error propagation otherwise process the output
         if isinstance(proc, UnknownError):
             return proc
         else:
@@ -80,34 +81,40 @@ class MolproHarness(ProgramHarness):
             return result
 
     def execute(self,
-                inputs,
-                extra_infiles=None,
-                extra_outfiles=None,
+                inputs: Dict[str, Any],
+                extra_infiles: Optional[List[str]] = None,
+                extra_outfiles: Optional[List[str]] = None,
+                as_binary: Optional[List[str]] = None,
                 extra_commands=None,
-                scratch_name=None,
-                scratch_messy=False,
-                timeout=None):
+                scratch_name: Optional[str] = None,
+                scratch_messy: bool = False,
+                timeout: Optional[int] = None):
         """
         For option documentation go look at qcengine/util.execute
         """
 
+        # Collect all input files and update with extra_infiles
         infiles = inputs["infiles"]
         if extra_infiles is not None:
             infiles.update(extra_infiles)
 
+        # Collect all output files and update with extra_outfiles
         outfiles = ["dispatch.out", "dispatch.xml", "dispatch.wfu"]
         if extra_outfiles is not None:
             outfiles.extend(extra_outfiles)
 
+        # Replace commands with extra_commands if present
         commands = inputs["commands"]
         if extra_commands is not None:
             commands = extra_commands
 
+        # Run the Molpro program
         exe_success, proc = execute(commands,
                                     infiles=infiles,
                                     outfiles=outfiles,
-                                    scratch_directory=inputs["scratch_directory"],
+                                    as_binary=as_binary,
                                     scratch_name=scratch_name,
+                                    scratch_directory=inputs["scratch_directory"],
                                     scratch_messy=scratch_messy,
                                     timeout=timeout)
 

--- a/qcengine/programs/molpro.py
+++ b/qcengine/programs/molpro.py
@@ -25,15 +25,27 @@ class MolproHarness(ProgramHarness):
     }
     version_cache: Dict[str, str] = {}
 
-    # Set of implemented dft functionals in Molpro according to
-    # https://www.molpro.net/info/release/doc/manual/node208.html (version 2019.2)
-    # TODO This isn't extensive because it definitely doesn't include component functionals (e.g. LYP, VWN5)
+    # Set of implemented dft functionals in Molpro according to dfunc.registry (version 2019.2)
     _dft_functionals = {
-        "B", "B-LYP", "BLYP", "B-P", "BP86", "B-VWN", "B3LYP", "B3LYP3", "B3LYP5", "B88X",
-        "B97", "B97R", "BECKE", "BH-LYP", "CS", "D", "HFB", "HFS", "LDA", "LSDAC", "LSDC",
-        "KYP88", "MM05", "MM05-2X", "MM06", "MM06-2X", "MM06-L", "MM06-HF", "PBE", "PBE0",
-        "PBE0MOL", "PBEREV", "PW91", "S", "S-VWN", "SLATER", "VS99", "VWN", "VWN80", "M08-HX",
-        "M08-SO", "M11-L", "TPSS", "TPSSH", "M12HFC", "HJSWPBE", "HJSWPBEH", "TCSWPBE", "PBESOL"
+        "B86MGC", "B86R", "B86", "B88C", "B88", "B95", "B97DF", "B97RDF", "BR", "BRUEG", "BW", "CS1", "CS2",
+        "DIRAC", "ECERFPBE", "ECERF", "EXACT", "EXERFPBE", "EXERF", "G96", "HCTH120", "HCTH147",
+        "HCTH93", "HJSWPBEX", "LTA", "LYP", "M052XC", "M052XX", "M05C", "M05X", "M062XC",
+        "M062XX", "M06C", "M06HFC", "M06HFX", "M06LC", "M06LX", "M06X", "M12C", "MK00B", "MK00",
+        "P86", "PBEC", "PBESOLC", "PBESOLX", "PBEXREV", "PBEX", "PW86", "PW91C", "PW91X", "PW92C",
+        "STEST", "TFKE", "TH1", "TH2", "TH3", "TH4", "THGFCFO", "THGFCO", "THGFC", "THGFL",
+        "TPSSC", "TPSSX", "VSXC", "VW", "VWN3", "VWN5", "XC-M05-2X", "XC-M05", "XC-M06-2X",
+        "XC-M06-HF", "XC-M06-L", "XC-M06", "XC-M08-HX", "XC-M08-SO", "XC-M11-L", "XC-SOGGA11",
+        "XC-SOGGA11-X", "XC-SOGGA", "FRMTST", "LHF", "TLHF", "LXBECKE", "ELP", "NULL", "YTEST",
+        "TREF2", "TREF", "TTEST", "GLE", "GREEN", "SRB88", "SRLYP", "LB94", "EI", "SAOP", "USER",
+        "INE", "ECERF2", "ECERFINTER", "ECERFLOCAL2", "ECERFLOCAL", "EXERFLOCAL", "FC", "FCFO",
+        "FCO", "FL", "XC-M11", "PBEXANAL", "PBECANAL", "PBESOLCANAL", "PBESOLXANAL", "EXSRLDA",
+        "EXSRLPBE", "ECSRLPBE", "ECSRLLPBE", "ECSQRTLPBE", "ECMUDIVLPBE", "EXERFPHS", "ECLERFMUPBE",
+        "ECERFERFCPBE", "ECSQRTLDA", "REVPBEX", "B", "B-LYP", "BLYP", "B-P", "BP86", "B-VWN", "B3LYP",
+        "B3LYP3", "B3LYP5", "B88X", "B97", "B97R", "BECKE", "BH-LYP", "CS", "D", "HFB", "HFS", "LDA",
+        "LSDAC", "LSDC", "KYP88", "MM05", "MM05-2X", "MM06", "MM06-2X", "MM06-L", "MM06-HF", "PBE", "PBE0",
+        "PBE0MOL", "PBEREV", "PW91", "S", "S-VWN", "SLATER", "VS99", "VWN", "VWN80", 'M05',
+        "M05-2X", "M06", "M06-2X", "M06-L", "M06-HF", "M08-HX","M08-SO", "M11-L", "TPSS",
+        "TPSSH", "M12HFC", "HJSWPBE", "HJSWPBEH", "TCSWPBE", "PBESOL"
     }
 
     # Currently supported methods in QCEngine for Molpro
@@ -304,8 +316,7 @@ class MolproHarness(ProgramHarness):
         for variable in molecule.findall('molpro_uri:variables/molpro_uri:variable', name_space):
             var_name = variable.attrib['name']
             if var_name in molpro_var_map:
-                print(var_name, variable[0].text)
-                molpro_var_map[var_name] = float(variable[0].text)
+                properties[molpro_var_map[var_name]] = float(variable[0].text)
 
         # Convert triplet and singlet pair correlation energies to opposite-spin and same-spin correlation energies
         if 'mp2_singlet_pair_energy' in properties and 'mp2_triplet_pair_energy' in properties:

--- a/qcengine/programs/molpro.py
+++ b/qcengine/programs/molpro.py
@@ -171,7 +171,7 @@ class MolproHarness(ProgramHarness):
 
             # Write the basis set
             input_file.append('basis={')
-            input_file.append('default,{}'.format(input_model.model.basis))
+            input_file.append(f'default,{input_model.model.basis}')
             input_file.append('}')
             input_file.append('')
 
@@ -182,9 +182,9 @@ class MolproHarness(ProgramHarness):
                 energy_call.append('{HF}')
             # If DFT call make sure to write {rks,method}
             if input_model.model.method.upper() in self._dft_functionals:
-                energy_call.append('{{rks,{:s}}}'.format(input_model.model.method))
+                energy_call.append(f'{{rks,{input_model.model.method}}}')
             else:
-                energy_call.append('{{{:s}}}'.format(input_model.model.method))
+                energy_call.append(f'{{{input_model.model.method}}}')
 
             # Write appropriate driver call
             if input_model.driver == 'energy':
@@ -194,7 +194,7 @@ class MolproHarness(ProgramHarness):
                 input_file.append('')
                 input_file.append('{force}')
             else:
-                raise InputError('Driver {} not implemented for Molpro.'.format(input_model.driver))
+                raise InputError(f'Driver {input_model.driver} not implemented for Molpro.')
 
             input_file = "\n".join(input_file)
         else:
@@ -358,7 +358,7 @@ class MolproHarness(ProgramHarness):
                 elif method in self._scf_methods:
                     properties[molpro_map['Energy'][method]] = mol_final_energy
             else:
-                raise KeyError("Could not find {:s} total energy".format(method))
+                raise KeyError(f"Could not find {method} total energy")
 
         # Replace return_result with final_energy if gradient wasn't called
         if "return_result" not in output_data:


### PR DESCRIPTION
The MolproHarness has been updated to handle DFT and CCSD(T) energies and gradients. The output parser went through a large change to accommodate reading in CCSD and CCSD(T) quantities at the same time. And now it should be easier to expand the output parser to support more methods in the future. 

On my local machine I've checked that this passes with the PR https://github.com/MolSSI/QCEngineRecords/pull/15 for QCEngineRecords, although it might be good to run this through Travis as well.