### PR TITLE
0.8.2 Docs and bugfix for required kwargs in Fractal's stack

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -13,6 +13,16 @@ Changelog
 .. Bug Fixes
 .. +++++++++
 
+v0.8.2 / 2019-07-25
+-------------------
+
+Bug Fixes
++++++++++
+
+- (:pr:`114`) Make compute and compute_procedure not have required kwargs while debugging
+  a Fractal serialization issue. This is intended to be a temporary change and likely reverted
+  in a later release
+
 v0.8.1 / 2019-07-22
 -------------------
 

--- a/qcengine/compute.py
+++ b/qcengine/compute.py
@@ -28,7 +28,6 @@ def _process_failure_and_return(model, return_dict, raise_error):
 
 def compute(input_data: Union[Dict[str, Any], 'ResultInput'],
             program: str,
-            *,
             raise_error: bool = False,
             local_options: Optional[Dict[str, Any]] = None,
             return_dict: bool = False) -> 'Result':
@@ -95,7 +94,6 @@ def compute(input_data: Union[Dict[str, Any], 'ResultInput'],
 
 def compute_procedure(input_data: Union[Dict[str, Any], 'BaseModel'],
                       procedure: str,
-                      *,
                       raise_error: bool = False,
                       local_options: Optional[Dict[str, str]] = None,
                       return_dict: bool = False) -> 'BaseModel':


### PR DESCRIPTION
Something in what I think is a serialization step in one of our Fractal
Queue Adapters causes the function signature to lose its
`kwargonlydefaults` field which makes the function look like a required
kwarg which has no defaults and so cant be called correctly.