### PR TITLE
Extras passthrough

### DIFF
--- a/qcengine/programs/dftd3.py
+++ b/qcengine/programs/dftd3.py
@@ -263,10 +263,7 @@ class DFTD3Harness(ProgramHarness):
             retres = retres.ravel().tolist()
 
         output_data = {
-            'extras': {
-                'local_keywords': input_model.extras['info'],
-                'qcvars': calcinfo,
-            },
+            'extras': input_model.extras,
             'properties': {},
             'provenance': Provenance(creator="DFTD3",
                                      version=self.get_version(),
@@ -274,6 +271,8 @@ class DFTD3Harness(ProgramHarness):
             'return_result': retres,
             'stdout': stdout,
         }  # yapf: disable
+        output_data["extras"]['local_keywords'] = input_model.extras['info']
+        output_data["extras"]['qcvars'] = calcinfo
 
         output_data['success'] = True
         return Result(**{**input_model.dict(), **output_data})

--- a/qcengine/programs/mopac.py
+++ b/qcengine/programs/mopac.py
@@ -243,7 +243,7 @@ class MopacHarness(ProgramHarness):
         output["properties"] = {}
         output["properties"]["return_energy"] = data["heat_of_formation"]
 
-        output["extras"] = data
+        output["extras"].update(data)
 
         if input_model.driver == "energy":
             output["return_result"] = data["heat_of_formation"]

--- a/qcengine/programs/mp2d.py
+++ b/qcengine/programs/mp2d.py
@@ -212,10 +212,7 @@ class MP2DHarness(ProgramHarness):
             retres = retres.ravel().tolist()
 
         output_data = {
-            'extras': {
-                'local_keywords': input_model.extras['info'],
-                'qcvars': calcinfo,
-            },
+            'extras': input_model.extras,
             'properties': {},
             'provenance': Provenance(creator="MP2D",
                                      version=self.get_version(),
@@ -223,6 +220,8 @@ class MP2DHarness(ProgramHarness):
             'return_result': retres,
             'stdout': stdout,
         }  # yapf: disable
+        output_data["extras"]["local_keywords"] = input_model.extras['info']
+        output_data["extras"]["qcvars"] = calcinfo
 
         output_data['success'] = True
         return Result(**{**input_model.dict(), **output_data})

--- a/qcengine/tests/test_procedures.py
+++ b/qcengine/tests/test_procedures.py
@@ -162,6 +162,7 @@ def test_geometric_generic(program, model, bench):
     inp["initial_molecule"] = qcng.get_molecule("water")
     inp["input_specification"]["model"] = model
     inp["keywords"]["program"] = program
+    inp["input_specification"]["extras"] = {"_secret_tags": {"mysecret_tag": "data1"}}
 
     ret = qcng.compute_procedure(inp, "geometric", raise_error=True)
     assert ret.success is True
@@ -173,3 +174,6 @@ def test_geometric_generic(program, model, bench):
     assert pytest.approx(r02, 1.e-4) == bench[0]
     assert pytest.approx(r12, 1.e-4) == bench[1]
     assert pytest.approx(a102, 1.e-4) == bench[2]
+
+    assert "_secret_tags" in ret.trajectory[0].extras
+    assert "data1" == ret.trajectory[0].extras["_secret_tags"]["mysecret_tag"]

--- a/qcengine/tests/test_standard_suite.py
+++ b/qcengine/tests/test_standard_suite.py
@@ -15,13 +15,13 @@ _canonical_methods = [
     ("psi4", {"method": "hf", "basis": "6-31G"}),
     ("rdkit", {"method": "UFF"}),
     ("torchani", {"method": "ANI1x"}),
-]
+    ("mopac", {"method": "PM6"}),
+] # yapf: disable
 
 @pytest.mark.parametrize("program, model", _canonical_methods)
 def test_compute_energy(program, model):
     if not testing.has_program(program):
         pytest.skip("Program '{}' not found.".format(program))
-
 
     inp = ResultInput(molecule=qcng.get_molecule("hydrogen"), driver="energy", model=model)
     ret = qcng.compute(inp, program, raise_error=True)
@@ -35,11 +35,15 @@ def test_compute_gradient(program, model):
     if not testing.has_program(program):
         pytest.skip("Program '{}' not found.".format(program))
 
-    inp = ResultInput(molecule=qcng.get_molecule("hydrogen"), driver="gradient", model=model)
+    inp = ResultInput(molecule=qcng.get_molecule("hydrogen"),
+                      driver="gradient",
+                      model=model,
+                      extras={"mytag": "something"})
     ret = qcng.compute(inp, program, raise_error=True)
 
     assert ret.success is True
     assert isinstance(ret.return_result, list)
+    assert "mytag" in ret.extras, ret.extras
 
 
 @pytest.mark.parametrize("program, model", [
@@ -48,7 +52,8 @@ def test_compute_gradient(program, model):
     ("rdkit", {"method": "bad"}),
     ("torchani", {"method": "bad"}),
     ("dftd3", {"method": "b3lyp-d3", "driver": "hessian"}),
-])
+    ("mopac", {"method": "bad"}),
+]) # yapf: disable
 def test_compute_bad_models(program, model):
     if not testing.has_program(program):
         pytest.skip("Program '{}' not found.".format(program))

--- a/qcengine/tests/test_standard_suite.py
+++ b/qcengine/tests/test_standard_suite.py
@@ -12,10 +12,11 @@ from qcengine import testing
 
 _canonical_methods = [
     ("dftd3", {"method": "b3lyp-d3"}),
+    ("mopac", {"method": "PM6"}),
+    ("mp2d", {"method": "MP2-DMP2"}),
     ("psi4", {"method": "hf", "basis": "6-31G"}),
     ("rdkit", {"method": "UFF"}),
     ("torchani", {"method": "ANI1x"}),
-    ("mopac", {"method": "PM6"}),
 ] # yapf: disable
 
 @pytest.mark.parametrize("program, model", _canonical_methods)
@@ -48,11 +49,12 @@ def test_compute_gradient(program, model):
 
 @pytest.mark.parametrize("program, model", [
     ("dftd3", {"method": "bad"}),
+    ("dftd3", {"method": "b3lyp-d3", "driver": "hessian"}),
+    ("mopac", {"method": "bad"}),
+    ("mp2d", {"method": "bad"}),
     ("psi4", {"method": "bad"}),
     ("rdkit", {"method": "bad"}),
     ("torchani", {"method": "bad"}),
-    ("dftd3", {"method": "b3lyp-d3", "driver": "hessian"}),
-    ("mopac", {"method": "bad"}),
 ]) # yapf: disable
 def test_compute_bad_models(program, model):
     if not testing.has_program(program):


### PR DESCRIPTION
An assumption in the QCA stack is that we can pass through some metadata in a secret `extras` field. This fixes MOPAC and DFTD3 to conform to this standard and adds standard test suits for these items.

Yes, if choose an extra key name that will be overwritten by the program then so be it. Choose wisely (e.g., `__qcfractal_metadata__`).