### PR TITLE
CLI tests

### DIFF
--- a/qcengine/cli.py
+++ b/qcengine/cli.py
@@ -5,12 +5,13 @@ Provides a CLI for QCEngine
 import argparse
 import os.path
 import sys
-
-from qcelemental.models import ResultInput  # run and run-procedure
+from typing import Any, Dict
+import json
 
 from . import (__version__, compute, compute_procedure, get_procedure, get_program,  # run and run-procedure; info
                list_all_procedures, list_all_programs, list_available_procedures, list_available_programs)
 from .config import global_repr  # info
+
 
 __all__ = ["main"]
 
@@ -113,9 +114,9 @@ def info_cli(args):
         print(global_repr())
 
 
-def data_arg_helper(data_arg: str) -> 'ResultInput':
+def data_arg_helper(data_arg: str) -> Dict[str, Any]:
     """
-    Converts the data argument of run and run-procedure commands to a ResultInput for compute
+    Converts the data argument of run and run-procedure commands to a dict for compute or compute_procedure
 
     Parameters
     ----------
@@ -124,15 +125,15 @@ def data_arg_helper(data_arg: str) -> 'ResultInput':
 
     Returns
     -------
-    ResultInput
-        An input for compute.
+    Dict[str, Any]
+        An input for compute or compute_procedure.
     """
     if data_arg == "-":
-        return ResultInput.parse_raw(sys.stdin.read())
+        return json.load(sys.stdin)
     elif os.path.isfile(data_arg):
-        return ResultInput.parse_file(data_arg)
+        return json.load(open(data_arg))
     else:
-        return ResultInput.parse_raw(data_arg)
+        return json.loads(data_arg)
 
 
 def main(args=None):

--- a/qcengine/cli.py
+++ b/qcengine/cli.py
@@ -15,6 +15,8 @@ from .config import global_repr  # info
 
 __all__ = ["main"]
 
+info_choices = frozenset(["version", "programs", "procedures", "config", "all"])
+
 
 def parse_args():
     parser = argparse.ArgumentParser(description='A CLI for the QCEngine.')
@@ -26,7 +28,7 @@ def parse_args():
     info.add_argument("category",
                       nargs="*",
                       default="all",
-                      choices=["version", "programs", "procedures", "config", "all"],
+                      choices=info_choices,
                       help="The information categories to show.")
 
     run = subparsers.add_parser('run', help="Run a program on a given task. Output is printed as a JSON blob.")

--- a/qcengine/testing.py
+++ b/qcengine/testing.py
@@ -2,12 +2,6 @@
 Utilities for the testing suite.
 """
 
-import os
-import signal
-import sys
-import time
-import subprocess
-from contextlib import contextmanager
 from typing import List
 
 import numpy as np
@@ -143,110 +137,6 @@ def has_program(name):
 def _build_pytest_skip(program):
     import_message = "Not detecting module {}. Install package if necessary to enable tests."
     return pytest.mark.skipif(has_program(program) is False, reason=import_message.format(program))
-
-
-def terminate_process(proc):
-    if proc.poll() is None:
-
-        # Sigint (keyboard interrupt)
-        if sys.platform.startswith('win'):
-            proc.send_signal(signal.CTRL_BREAK_EVENT)
-        else:
-            proc.send_signal(signal.SIGINT)
-
-        try:
-            start = time.time()
-            while (proc.poll() is None) and (time.time() < (start + 15)):
-                time.sleep(0.02)
-        # Flat kill
-        finally:
-            proc.kill()
-
-
-@contextmanager
-def popen(args, **kwargs):
-    """
-    Opens a background task.
-
-    Code and idea from dask.distributed's testing suite
-    https://github.com/dask/distributed
-    """
-    args = list(args)
-
-    # Bin prefix
-    if sys.platform.startswith('win'):
-        bin_prefix = os.path.join(sys.prefix, 'Scripts')
-    else:
-        bin_prefix = os.path.join(sys.prefix, 'bin')
-
-    # Do we prefix with Python?
-    if kwargs.pop("append_prefix", True):
-        args[0] = os.path.join(bin_prefix, args[0])
-
-    # Add coverage testing
-    if kwargs.pop("coverage", False):
-        coverage_dir = os.path.join(bin_prefix, "coverage")
-        if not os.path.exists(coverage_dir):
-            print("Could not find Python coverage, skipping cov.")
-
-        else:
-            src_dir = os.path.dirname(os.path.abspath(__file__))
-            coverage_flags = [coverage_dir, "run", "--append", "--source=" + src_dir]
-
-            # If python script, skip the python bin
-            if args[0].endswith("python"):
-                args.pop(0)
-            args = coverage_flags + args
-
-    # Do we optionally dumpstdout?
-    dump_stdout = kwargs.pop("dump_stdout", False)
-
-    if sys.platform.startswith('win'):
-        # Allow using CTRL_C_EVENT / CTRL_BREAK_EVENT
-        kwargs['creationflags'] = subprocess.CREATE_NEW_PROCESS_GROUP
-
-    kwargs['stdout'] = subprocess.PIPE
-    kwargs['stderr'] = subprocess.PIPE
-    proc = subprocess.Popen(args, **kwargs)
-    try:
-        yield proc
-    except Exception:
-        dump_stdout = True
-        raise
-
-    finally:
-        try:
-            terminate_process(proc)
-        finally:
-            output, error = proc.communicate()
-            if dump_stdout:
-                print('\n' + '-' * 30)
-                print("\n|| Process command: {}".format(" ".join(args)))
-                print('\n|| Process stderr: \n{}'.format(error.decode()))
-                print('-' * 30)
-                print('\n|| Process stdout: \n{}'.format(output.decode()))
-                print('-' * 30)
-
-
-def run_process(args, **kwargs):
-    """
-    Runs a process in the background until complete.
-
-    Returns True if exit code zero.
-    """
-
-    timeout = kwargs.pop("timeout", 30)
-    terminate_after = kwargs.pop("interupt_after", None)
-    with popen(args, **kwargs) as proc:
-        if terminate_after is None:
-            proc.wait(timeout=timeout)
-        else:
-            time.sleep(terminate_after)
-            terminate_process(proc)
-
-        retcode = proc.poll()
-
-    return retcode == 0
 
 
 # Add flags

--- a/qcengine/tests/test_cli.py
+++ b/qcengine/tests/test_cli.py
@@ -2,6 +2,7 @@ import tempfile
 import os
 
 from qcengine import testing
+from qcengine import util
 from qcengine import cli
 from qcengine import get_molecule
 
@@ -12,10 +13,10 @@ def test_info():
     """Test for qcengine info"""
     for arg in cli.info_choices:
         args = ["qcengine", "info", arg]
-        assert testing.run_process(args)
+        assert util.execute(args)[0] is True
 
     args = ["qcengine", "info"]
-    assert testing.run_process(args)
+    assert util.execute(args)[0] is True
 
 
 @testing.using_psi4
@@ -24,17 +25,12 @@ def test_run_psi4():
     inp = ResultInput(molecule=get_molecule("hydrogen"),
                       driver="energy",
                       model={"method": "hf", "basis": "6-31G"})
-    args = ["qcengine", "run", "psi4", inp.json()]
-    assert testing.run_process(args)
 
-    f = tempfile.NamedTemporaryFile(mode='w', delete=False)
-    try:
-        f.write(inp.json())
-        f.close()
-        args = ["qcengine", "run", "psi4", f.name]
-        assert testing.run_process(args)
-    finally:
-        os.remove(f.name)
+    args = ["qcengine", "run", "psi4", inp.json()]
+    assert util.execute(args)[0] is True
+
+    args = ["qcengine", "run", "psi4", "input.json"]
+    assert util.execute(args, infiles={"input.json": inp.json()})[0] is True
 
 
 @testing.using_geometric
@@ -56,16 +52,11 @@ def test_run_procedure():
                "keywords": {},
            },
            "initial_molecule": get_molecule("hydrogen")}
-
     inp = OptimizationInput(**inp)
-    args = ["qcengine", "run-procedure", "geometric", inp.json()]
-    assert testing.run_process(args)
 
-    f = tempfile.NamedTemporaryFile(mode='w', delete=False)
-    try:
-        f.write(inp.json())
-        f.close()
-        args = ["qcengine", "run-procedure", "geometric", f.name]
-        assert testing.run_process(args)
-    finally:
-        os.remove(f.name)
+    args = ["qcengine", "run-procedure", "geometric", inp.json()]
+    assert util.execute(args)[0] is True
+
+    args = ["qcengine", "run-procedure", "geometric", "input.json"]
+    assert util.execute(args, infiles={"input.json": inp.json()})[0] is True
+

--- a/qcengine/tests/test_cli.py
+++ b/qcengine/tests/test_cli.py
@@ -16,13 +16,13 @@ def run_qcengine_cli(args: List[str]) -> str:
     """
     Runs qcengine via its CLI
 
-    This method was chosen over the more sophisticated util.excecute order to get pytest-cov to work.
+    This method was chosen over the more sophisticated util.execute in order to get pytest-cov to work.
     For the same reason, qcengine is invoked as "python -m qcengine.cli" rather than "qcengine".
 
     Parameters
     ----------
     args: List[str]
-        List of CLI arguments
+        List of CLI arguments.
 
     Returns
     -------

--- a/qcengine/tests/test_cli.py
+++ b/qcengine/tests/test_cli.py
@@ -14,19 +14,21 @@ cov_cmds = []
 if cov:
     cov_cmds = [cov, "run", "--append", "--source=" + os.path.dirname(os.path.abspath(__file__))]
 
+qcengine = shutil.which("qcengine")  # qcengine is not in the path of `coverage run`
+
 
 def test_info():
     """Test for qcengine info"""
     outputs = []
     for arg in cli.info_choices:
-        args = ["qcengine", "info", arg]
+        args = [qcengine, "info", arg]
         res = util.execute(args)
         assert res[0] is True
         if arg not in {"all", "config"}:  # output of config changes call-to-call depending e.g. on mem available
             outputs.append(res[1]["stdout"])
         util.execute(cov_cmds + args)
 
-    args = ["qcengine", "info"]
+    args = [qcengine, "info"]
     res = util.execute(args)
     assert res[0] is True
 
@@ -48,11 +50,11 @@ def test_run_psi4():
                       driver="energy",
                       model={"method": "hf", "basis": "6-31G"})
 
-    args = ["qcengine", "run", "psi4", inp.json()]
+    args = [qcengine, "run", "psi4", inp.json()]
     check_result(util.execute(args))
     util.execute(cov_cmds + args)
 
-    args = ["qcengine", "run", "psi4", "input.json"]
+    args = [qcengine, "run", "psi4", "input.json"]
     check_result(util.execute(args, infiles={"input.json": inp.json()}))
     util.execute(cov_cmds + args)
 
@@ -85,11 +87,11 @@ def test_run_procedure():
            "initial_molecule": get_molecule("hydrogen")}
     inp = OptimizationInput(**inp)
 
-    args = ["qcengine", "run-procedure", "geometric", inp.json()]
+    args = [qcengine, "run-procedure", "geometric", inp.json()]
     check_result(util.execute(args))
     util.execute(cov_cmds + args)
 
-    args = ["qcengine", "run-procedure", "geometric", "input.json"]
+    args = [qcengine, "run-procedure", "geometric", "input.json"]
     check_result(util.execute(args, infiles={"input.json": inp.json()}))
     util.execute(cov_cmds + args)
 

--- a/qcengine/tests/test_cli.py
+++ b/qcengine/tests/test_cli.py
@@ -1,0 +1,71 @@
+import tempfile
+import os
+
+from qcengine import testing
+from qcengine import cli
+from qcengine import get_molecule
+
+from qcelemental.models import ResultInput, OptimizationInput
+
+
+def test_info():
+    """Test for qcengine info"""
+    for arg in cli.info_choices:
+        args = ["qcengine", "info", arg]
+        assert testing.run_process(args)
+
+    args = ["qcengine", "info"]
+    assert testing.run_process(args)
+
+
+@testing.using_psi4
+def test_run_psi4():
+    """Tests qcengine run with psi4 and JSON input"""
+    inp = ResultInput(molecule=get_molecule("hydrogen"),
+                      driver="energy",
+                      model={"method": "hf", "basis": "6-31G"})
+    args = ["qcengine", "run", "psi4", inp.json()]
+    assert testing.run_process(args)
+
+    f = tempfile.NamedTemporaryFile(mode='w', delete=False)
+    try:
+        f.write(inp.json())
+        f.close()
+        args = ["qcengine", "run", "psi4", f.name]
+        assert testing.run_process(args)
+    finally:
+        os.remove(f.name)
+
+
+@testing.using_geometric
+@testing.using_psi4
+def test_run_procedure():
+    """Tests qcengine run-procedure with geometric, psi4, and JSON input"""
+    inp = {"schema_name": "qcschema_optimization_input",
+           "schema_version": 1,
+           "keywords": {
+               "coordsys": "tric",
+               "maxiter": 100,
+               "program": "psi4"
+           },
+           "input_specification": {
+               "schema_name": "qcschema_input",
+               "schema_version": 1,
+               "driver": "gradient",
+               "model": {"method": "HF", "basis": "sto-3g"},
+               "keywords": {},
+           },
+           "initial_molecule": get_molecule("hydrogen")}
+
+    inp = OptimizationInput(**inp)
+    args = ["qcengine", "run-procedure", "geometric", inp.json()]
+    assert testing.run_process(args)
+
+    f = tempfile.NamedTemporaryFile(mode='w', delete=False)
+    try:
+        f.write(inp.json())
+        f.close()
+        args = ["qcengine", "run-procedure", "geometric", f.name]
+        assert testing.run_process(args)
+    finally:
+        os.remove(f.name)

--- a/qcengine/tests/test_cli.py
+++ b/qcengine/tests/test_cli.py
@@ -1,5 +1,6 @@
-import tempfile
+import json
 import os
+import shutil
 
 from qcengine import testing
 from qcengine import util
@@ -8,35 +9,65 @@ from qcengine import get_molecule
 
 from qcelemental.models import ResultInput, OptimizationInput
 
+cov = shutil.which('coverage')
+cov_cmds = []
+if cov:
+    cov_cmds = [cov, "run", "--append", "--source=" + os.path.dirname(os.path.abspath(__file__))]
+
 
 def test_info():
     """Test for qcengine info"""
+    outputs = []
     for arg in cli.info_choices:
         args = ["qcengine", "info", arg]
-        assert util.execute(args)[0] is True
+        res = util.execute(args)
+        assert res[0] is True
+        if arg not in {"all", "config"}:  # output of config changes call-to-call depending e.g. on mem available
+            outputs.append(res[1]["stdout"])
+        util.execute(cov_cmds + args)
 
     args = ["qcengine", "info"]
-    assert util.execute(args)[0] is True
+    res = util.execute(args)
+    assert res[0] is True
+
+    for output in outputs:
+        assert output in res[1]["stdout"]
+    util.execute(cov_cmds + args)
 
 
 @testing.using_psi4
 def test_run_psi4():
     """Tests qcengine run with psi4 and JSON input"""
+    def check_result(result):
+        assert result[0] is True
+        output = json.loads(result[1]["stdout"])
+        assert output["provenance"]["creator"].lower() == "psi4"
+        assert output["success"] is True
+
     inp = ResultInput(molecule=get_molecule("hydrogen"),
                       driver="energy",
                       model={"method": "hf", "basis": "6-31G"})
 
     args = ["qcengine", "run", "psi4", inp.json()]
-    assert util.execute(args)[0] is True
+    check_result(util.execute(args))
+    util.execute(cov_cmds + args)
 
     args = ["qcengine", "run", "psi4", "input.json"]
-    assert util.execute(args, infiles={"input.json": inp.json()})[0] is True
+    check_result(util.execute(args, infiles={"input.json": inp.json()}))
+    util.execute(cov_cmds + args)
 
 
 @testing.using_geometric
 @testing.using_psi4
 def test_run_procedure():
     """Tests qcengine run-procedure with geometric, psi4, and JSON input"""
+    def check_result(result):
+        assert result[0] is True
+        output = json.loads(result[1]["stdout"])
+        print(output)
+        assert output["provenance"]["creator"].lower() == "geometric"
+        assert output["success"] is True
+
     inp = {"schema_name": "qcschema_optimization_input",
            "schema_version": 1,
            "keywords": {
@@ -55,8 +86,10 @@ def test_run_procedure():
     inp = OptimizationInput(**inp)
 
     args = ["qcengine", "run-procedure", "geometric", inp.json()]
-    assert util.execute(args)[0] is True
+    check_result(util.execute(args))
+    util.execute(cov_cmds + args)
 
     args = ["qcengine", "run-procedure", "geometric", "input.json"]
-    assert util.execute(args, infiles={"input.json": inp.json()})[0] is True
+    check_result(util.execute(args, infiles={"input.json": inp.json()}))
+    util.execute(cov_cmds + args)
 

--- a/qcengine/tests/test_standard_suite.py
+++ b/qcengine/tests/test_standard_suite.py
@@ -18,7 +18,8 @@ _canonical_methods = [
     ("psi4", {"method": "hf", "basis": "6-31G"}),
     ("rdkit", {"method": "UFF"}),
     ("torchani", {"method": "ANI1x"}),
-] # yapf: disable
+]  # yapf: disable
+
 
 @pytest.mark.parametrize("program, model", _canonical_methods)
 def test_compute_energy(program, model):
@@ -58,7 +59,7 @@ def test_compute_gradient(program, model):
     ("psi4", {"method": "bad"}),
     ("rdkit", {"method": "bad"}),
     ("torchani", {"method": "bad"}),
-]) # yapf: disable
+])  # yapf: disable
 def test_compute_bad_models(program, model):
     if not testing.has_program(program):
         pytest.skip("Program '{}' not found.".format(program))


### PR DESCRIPTION
This PR adds rudimentary tests for the CLI, testing:

- `qcengine info` and its options terminate successfully 
- `qcengine run` and `qcengine run-procedure` terminate successfully for string and filename input, with rudimentary output checks.

A future PR will needed to address piping STDIN for `run` and `run-procedure`, which will need to be done carefully to avoid breaking coverage.

## TODO

- [x] use process running functions from util.py
- [x] add coverage