### PR TITLE
Add stdin CLI tests and add entry point with __main__

### DIFF
--- a/qcengine/__main__.py
+++ b/qcengine/__main__.py
@@ -1,0 +1,3 @@
+import qcengine.cli
+
+qcengine.cli.main()

--- a/qcengine/cli.py
+++ b/qcengine/cli.py
@@ -151,7 +151,3 @@ def main(args=None):
     elif command == "run-procedure":
         ret = compute_procedure(data_arg_helper(args["data"]), args["procedure"])
         print(ret.json())
-
-
-if __name__ == '__main__':
-    main()


### PR DESCRIPTION
This PR adds CLI tests with STDIN in a coverage-compatible manner. (`subprocess.check_output` has an undocumented, or at least hard to find, `input` field that avoids `communicate`, which breaks coverage).

This PR also adds a `__main__.py` so that `python -m qcengine` calls the CLI.

This PR fully resolves issue #135. 