### PR TITLE
Add Hessian driver to torchani.py

### DIFF
--- a/qcengine/programs/torchani.py
+++ b/qcengine/programs/torchani.py
@@ -77,6 +77,7 @@ class TorchANIHarness(ProgramHarness):
             raise ResourceError("QCEngine's TorchANI wrapper requires version 0.9 or greater.")
 
         import torch
+        import torchani
         import numpy as np
 
         device = torch.device('cpu')
@@ -111,7 +112,6 @@ class TorchANIHarness(ProgramHarness):
             ret_data["return_result"] = np.asarray(derivative *
                                                    ureg.conversion_factor("angstrom", "bohr")).ravel().tolist()
         elif input_data.driver == "hessian":
-            import torchani
             hessian = torchani.utils.hessian(coordinates, energies=energy)
             ret_data["return_result"] = np.asarray(hessian)
         else:

--- a/qcengine/programs/torchani.py
+++ b/qcengine/programs/torchani.py
@@ -73,8 +73,8 @@ class TorchANIHarness(ProgramHarness):
 
         # Check if existings and version
         self.found(raise_error=True)
-        if parse_version(self.get_version()) < parse_version("0.5"):
-            raise ResourceError("QCEngine's TorchANI wrapper requires version 0.5 or greater.")
+        if parse_version(self.get_version()) < parse_version("0.9"):
+            raise ResourceError("QCEngine's TorchANI wrapper requires version 0.9 or greater.")
 
         import torch
         import numpy as np
@@ -110,9 +110,13 @@ class TorchANIHarness(ProgramHarness):
             derivative = torch.autograd.grad(energy.sum(), coordinates)[0].squeeze()
             ret_data["return_result"] = np.asarray(derivative *
                                                    ureg.conversion_factor("angstrom", "bohr")).ravel().tolist()
+        elif input_data.driver == "hessian":
+            import torchani
+            hessian = torchani.utils.hessian(coordinates, energies=energy)
+            ret_data["return_result"] = np.asarray(hessian)
         else:
             raise InputError(
-                f"TorchANI can only compute energy and gradient driver methods. Found {input_data.driver}.")
+                f"TorchANI can only compute energy, gradient, and hessian driver methods. Found {input_data.driver}.")
 
         ret_data["provenance"] = Provenance(creator="torchani",
                                             version="unknown",

--- a/qcengine/testing.py
+++ b/qcengine/testing.py
@@ -118,7 +118,7 @@ _programs = {
     "psi4": is_program_new_enough("psi4", "1.2"),
     "rdkit": which_import("rdkit", return_bool=True),
     "qcdb": which_import("qcdb", return_bool=True),
-    "torchani": which_import("torchani", return_bool=True),
+    "torchani": is_program_new_enough("torchani", "0.9"),
     "mp2d": which('mp2d', return_bool=True),
     "terachem": which("terachem", return_bool=True),
     "molpro": is_program_new_enough("molpro", "2018.1"),


### PR DESCRIPTION
- This PR adds `hessian` driver to `torchani.py`

- I have also changed the minimum requirement for TorchANI version from 0.5 to 0.9. 

In [TorchANI 0.8 release](https://github.com/aiqm/torchani/releases/tag/0.8) we fixed the breaking changes recently introduce in PyTorch, and [TorchANI 0.9](https://github.com/aiqm/torchani/releases/tag/0.9) has all the large files removed. This reduces the size of TorchANI installed with pip to ~57MB. We made it optional for users to download the large files via a `download.sh` script.