### PR TITLE
Skip broken intel-openmp 2019.5-281

### DIFF
--- a/devtools/conda-envs/psi-nightly.yaml
+++ b/devtools/conda-envs/psi-nightly.yaml
@@ -7,8 +7,9 @@ dependencies:
   - dftd3 3.2.1
   - mp2d >=1.1
   - blas=*=mkl  # not needed but an example of disuading solver from openblas and old psi
+  - intel-openmp!=2019.5
 
-    # Core
+  # Core
   - python
   - pyyaml
   - py-cpuinfo

--- a/devtools/conda-envs/psi.yaml
+++ b/devtools/conda-envs/psi.yaml
@@ -6,6 +6,7 @@ dependencies:
   - psi4=1.3
   - dftd3
   - geometric
+  - intel-openmp!=2019.5-281
 
     # Core
   - python

--- a/devtools/conda-envs/psi.yaml
+++ b/devtools/conda-envs/psi.yaml
@@ -6,7 +6,7 @@ dependencies:
   - psi4=1.3
   - dftd3
   - geometric
-  - intel-openmp!=2019.5-281
+  - intel-openmp!=2019.5
 
     # Core
   - python

--- a/qcengine/programs/torchani.py
+++ b/qcengine/programs/torchani.py
@@ -151,12 +151,12 @@ class TorchANIHarness(ProgramHarness):
         #   the reliability of the models in an ensemble, and produce more data
         #   points in the regions where this quantity is below a certain
         #   threshold (inclusion criteria)
-        ret_data["extras"] = {
+        ret_data["extras"].update({
             "ensemble_energies": energy_array.detach().numpy(),
             "ensemble_energy_avg": energy.item(),
             "ensemble_energy_std": ensemble_std.item(),
             "ensemble_per_root_atom_disagreement": ensemble_scaled_std.item()
-        }
+        })
 
         ret_data["provenance"] = Provenance(creator="torchani",
                                             version="unknown",

--- a/qcengine/programs/torchani.py
+++ b/qcengine/programs/torchani.py
@@ -151,6 +151,7 @@ class TorchANIHarness(ProgramHarness):
         #   the reliability of the models in an ensemble, and produce more data
         #   points in the regions where this quantity is below a certain
         #   threshold (inclusion criteria)
+        ret_data["extras"] = input_data.extras.copy()
         ret_data["extras"].update({
             "ensemble_energies": energy_array.detach().numpy(),
             "ensemble_energy_avg": energy.item(),


### PR DESCRIPTION
This PR skips intel-openmp version 2019.5-281, which breaks geometric+psi4. See also ContinuumIO/anaconda-issues#11294.