### PR TITLE
MOPAC: Error handling and keywords

### DIFF
--- a/qcengine/programs/tests/test_programs.py
+++ b/qcengine/programs/tests/test_programs.py
@@ -146,7 +146,7 @@ def test_mopac_task():
     json_data["molecule"] = qcng.get_molecule("water")
     json_data["driver"] = "gradient"
     json_data["model"] = {"method": "PM6", "basis": None}
-    json_data["keywords"] = {}
+    json_data["keywords"] = {"pulay": False}
 
     ret = qcng.compute(json_data, "mopac", raise_error=True)
     assert ret.extras.keys() >= {"heat_of_formation", "energy_electronic", "dip_vec"}

--- a/qcengine/tests/test_procedures.py
+++ b/qcengine/tests/test_procedures.py
@@ -153,7 +153,7 @@ def test_geometric_retries(failure_engine):
                  [1.82581873750194, 2.866376526793269, 103.4332610730292],
                  marks=testing.using_torchani),
     pytest.param("mopac", {"method": "PM6"},
-                 [1.79305406665072, 2.893333237502448, 107.5722111735350],
+                 [1.7927843431811934, 2.893333237502448, 107.60441967992045],
                  marks=testing.using_mopac),
 ]) # yapf: disable
 def test_geometric_generic(program, model, bench):


### PR DESCRIPTION
Updates MOPAC to have more sensible quantum-chemistry like keywords by default. Also unsure why changing to a Pulay solver changes the answers in some cases.

As a note, I normally don't advocate for this. However, MOPAC is proving to be quite special. In addition, the `&` keywords extension syntax seems to be broken so we cannot currently support arbitrary keywords.

@muammar 