### PR TITLE
0.11 Changelog and GitHub Templates

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,42 @@
+# How to contribute
+
+We welcome contributions from external contributors, and this document
+describes how to merge code changes into this project_name. 
+
+## Getting Started
+
+* Make sure you have a [GitHub account](https://github.com/signup/free).
+* [Fork](https://help.github.com/articles/fork-a-repo/) this repository on GitHub.
+* On your local machine,
+  [clone](https://help.github.com/articles/cloning-a-repository/) your fork of
+  the repository.
+
+## Making Changes
+
+* Add some really awesome code to your local fork.  It's usually a [good
+  idea](http://blog.jasonmeridth.com/posts/do-not-issue-pull-requests-from-your-master-branch/)
+  to make changes on a
+  [branch](https://help.github.com/articles/creating-and-deleting-branches-within-your-repository/)
+  with the branch name relating to the feature you are going to add.
+* When you are ready for others to examine and comment on your new feature,
+  navigate to your fork of project_name on GitHub and open a [pull
+  request](https://help.github.com/articles/using-pull-requests/) (PR). Note that
+  after you launch a PR from one of your fork's branches, all
+  subsequent commits to that branch will be added to the open pull request
+  automatically.  Each commit added to the PR will be validated for
+  mergability, compilation and test suite compliance; the results of these tests
+  will be visible on the PR page.
+* If you're providing a new feature, you must add test cases and documentation.
+* When the code is ready to go, make sure you run the test suite using pytest.
+* When you're ready to be considered for merging, check the "Ready to go"
+  box on the PR page to let the project_name devs know that the changes are complete.
+  The code will not be merged until this box is checked, the continuous
+  integration returns checkmarks,
+  and multiple core developers give "Approved" reviews.
+
+# Additional Resources
+
+* [General GitHub documentation](https://help.github.com/)
+* [PR best practices](http://codeinthehole.com/writing/pull-requests-and-other-good-practices-for-teams-using-github/)
+* [A guide to contributing to software packages](http://www.contribution-guide.org)
+* [Thinkful PR example](http://www.thinkful.com/learn/github-pull-request-tutorial/#Time-to-Submit-Your-First-PR)

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,19 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Code to reproduce the behavior:
+
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+## Description
+Provide a brief description of the PR's purpose here.
+
+## Todos
+Notable points that this PR has either accomplished or will accomplish.
+  - [ ] TODO 1
+
+## Questions
+- [ ] Question1
+
+## Status
+- [ ] Changelog updated
+- [ ] Ready to go

--- a/devtools/conda-envs/base.yaml
+++ b/devtools/conda-envs/base.yaml
@@ -7,7 +7,7 @@ dependencies:
   - pyyaml
   - py-cpuinfo
   - psutil
-  - qcelemental >=0.7.0
+  - qcelemental >=0.9.0
   - pydantic >=0.30.1
 
     # Testing

--- a/devtools/conda-envs/psi-nightly.yaml
+++ b/devtools/conda-envs/psi-nightly.yaml
@@ -14,7 +14,7 @@ dependencies:
   - pyyaml
   - py-cpuinfo
   - psutil
-  - qcelemental >=0.7.0
+  - qcelemental >=0.9.0
   - pydantic >=0.30.1
   - msgpack-python
 

--- a/devtools/conda-envs/psi.yaml
+++ b/devtools/conda-envs/psi.yaml
@@ -13,7 +13,7 @@ dependencies:
   - pyyaml
   - py-cpuinfo
   - psutil
-  - qcelemental >=0.7.0
+  - qcelemental >=0.9.0
   - pydantic >=0.30.1
 
     # Testing

--- a/devtools/conda-envs/rdkit.yaml
+++ b/devtools/conda-envs/rdkit.yaml
@@ -10,7 +10,7 @@ dependencies:
   - pyyaml
   - py-cpuinfo
   - psutil
-  - qcelemental >=0.7.0
+  - qcelemental >=0.9.0
   - pydantic >=0.30.1
 
     # Testing

--- a/devtools/conda-envs/torchani.yaml
+++ b/devtools/conda-envs/torchani.yaml
@@ -9,7 +9,7 @@ dependencies:
   - pyyaml
   - py-cpuinfo
   - psutil
-  - qcelemental >=0.7.0
+  - qcelemental >=0.9.0
   - pydantic >=0.30.1
 
     # Testing

--- a/docs/requirements.yml
+++ b/docs/requirements.yml
@@ -11,8 +11,8 @@ dependencies:
     
       # QCEngine depends
     - numpy
-    - pydantic >=0.20.0
-    - qcelemental >=0.4.0
+    - pydantic >=0.30.1
+    - qcelemental >=0.9.0
 
     - pip:
       - git+git://github.com/MolSSI/qcarchive-sphinx-theme#egg=qcarchive_sphinx_theme

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -13,7 +13,7 @@ Changelog
 .. Bug Fixes
 .. +++++++++
 
-v0.11.0 / 2019-09-30
+v0.11.0 / 2019-10-01
 --------------------
 
 New Features
@@ -39,11 +39,13 @@ Enhancements
   calculations, and the initial support for parsing local correlation calculations.
 - (:pr:`158`) Entos' output parsing has been improved to read the json dictionary produced by the program
   directly. Also updates the input file generation.
+- (:pr:`161`) Updates MOPAC to have more sensible quantum-chemistry like keywords by default.
 
 Bug Fixes
 +++++++++
 - (:pr:`156`) Fixed a compatibility bug in specific version of Intel-OpenMP by skipping version
   2019.5-281.
+- (:pr:`161`) Improved error handling in MOPAC if the execution was incorrect.
 
 
 v0.10.0 / 2019-08-25

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -13,7 +13,40 @@ Changelog
 .. Bug Fixes
 .. +++++++++
 
-v0.10.0 / 2019-09-25
+v0.11.0 / 2019-09-30
+--------------------
+
+New Features
+++++++++++++
+
+- (:pr:`162`) Adds a test to take advantage of Elemental's `Protocols <https://github.com/MolSSI/QCElemental/pull/140>`_.
+  Although this PR does not technically change anything in Engine, bumping the minor version here allows
+  upstream programs to note when this feature was available because the minimum version dependency on Elemental
+  has been bumped as well.
+
+
+Enhancements
+++++++++++++
+
+- (:pr:`143`) Updates to Entos and Molpro to allow Entos to execute functions from the Molpro Harness. Also helps
+  the two drivers to conform to :pr:`86`.
+- (:pr:`145`, :pr:`148`) Initial CLI tests have been added to help further ensure Engine is running proper.
+- (:pr:`149`) The GAMESS Harness has been improved by adding testing.
+- (:pr:`150`, :pr:`153`) TorchANI has been improved by adding a Hessian driver to it and additional information
+  is returned in the ``extra`` field when ``energy`` is the driver.
+  This also bumped the minimum version of TorchANI Engine supports from 0.5 to 0.9.
+- (:pr:`154`) Molpro's harness has been improved to support ``callinfo_X`` properties, unrestricted HF and DFT
+  calculations, and the initial support for parsing local correlation calculations.
+- (:pr:`158`) Entos' output parsing has been improved to read the json dictionary produced by the program
+  directly. Also updates the input file generation.
+
+Bug Fixes
++++++++++
+- (:pr:`156`) Fixed a compatibility bug in specific version of Intel-OpenMP by skipping version
+  2019.5-281.
+
+
+v0.10.0 / 2019-08-25
 --------------------
 
 New Features
@@ -26,6 +59,7 @@ New Features
 
 Enhancements
 ++++++++++++
+
 - (:pr:`138`) Documentation on Azure triggers.
 - (:pr:`139`) Overhauls install documentation and clearly defines dev install vs production installs.
 

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ if __name__ == "__main__":
             'pyyaml',
             'py-cpuinfo',
             'psutil',
-            'qcelemental>=0.7.0',
+            'qcelemental>=0.9.0',
             'pydantic>=0.30.1'
         ],
         entry_points={"console_scripts": [


### PR DESCRIPTION
This updates the change log to 0.11.0.

Updates the Elemental pins to 0.9 (not yet released), so I don't suspect this will pass or even run until then.

I realized I have the month wrong on 0.10's release, so the link on the GitHub releases page for that release change log needs to be edited. This does not change the release itself, its just the URL link.