### PR TITLE
c4 harvesting and nwc formatting improvements

### DIFF
--- a/qcengine/programs/cfour/harvester.py
+++ b/qcengine/programs/cfour/harvester.py
@@ -395,6 +395,15 @@ def harvest_outfile_pass(outtext):
         psivar['[T] CORRECTION ENERGY'] = mobj.group('bkttcorr')
         psivar['CCSD(T) TOTAL ENERGY'] = mobj.group('ttot')
 
+    mobj = re.search(
+        r'^\s*' + r'(?:CCSD\[T\] correlation energy:)\s+' + r'(?P<bkttcorr>' + NUMBER + ')' + r'\s*'
+        r'^\s*' + r'(?:CCSD\(T\) correlation energy:)\s+' + r'(?P<tcorr>' + NUMBER + ')' + r'\s*$',
+        outtext, re.MULTILINE | re.DOTALL)  # yapf: disable
+    if mobj:
+        print('matched ccsd(t) ncc v2')
+        psivar['(T) CORRECTION ENERGY'] = mobj.group('tcorr')
+        psivar['[T] CORRECTION ENERGY'] = mobj.group('bkttcorr')
+
     # Process DBOC
     mobj = re.search(
         r'^\s*' + r'(?:The total diagonal Born-Oppenheimer correction \(DBOC\) is:)\s+' +

--- a/qcengine/programs/nwchem/keywords.py
+++ b/qcengine/programs/nwchem/keywords.py
@@ -16,6 +16,13 @@ def format_keyword(opt, val, lop_off=True):
 
     elif isinstance(val, list):
         text = ' '.join([str(v) for v in val])
+    elif isinstance(val, dict):
+        text = []
+        for k, v in val.items():
+            merge = [k]
+            merge.extend(str(v) if isinstance(v, (int, float)) else list(map(str,v)))
+            text.append(' '.join(merge))
+        text = ' '.join(text)
     else:
         text = str(val)
 
@@ -28,29 +35,45 @@ def format_keyword(opt, val, lop_off=True):
 def format_keywords(options):
     """From NWCHEM-directed, non-default options dictionary `options`, write a NWCHEM deck."""
 
-    grouped_options = collections.defaultdict(dict)
+    def rec_dd():
+        return collections.defaultdict(rec_dd)
+    grouped_options = rec_dd()
+
     for group_key, val in options.items():
         nesting = group_key.split('__')
         if len(nesting) == 1:
-            group, key = 'aaaglobal', nesting[0]
+            key = nesting[0]
+            grouped_options['aaaglobal'][key] = val
         elif len(nesting) == 2:
-            group, key = nesting
+            g1, key = nesting
+            grouped_options[g1][key] = val
+        elif len(nesting) == 3:
+            g1, g2, key = nesting
+            grouped_options[g1][g2][key] = val
         else:
             print(nesting)
-            raise ValueError('Nesting!')
-        grouped_options[group][key] = val
+            raise ValueError('Nesting N!')
 
     grouped_lines = {}
     for group, opts in sorted(grouped_options.items()):
         lines = []
         group_level_lines = []
         for key, val in grouped_options[group].items():
-            line = ' '.join(format_keyword(key, val, lop_off=False))
-            if group.lower() == 'basis' and any(
-                [word in line for word in ['spherical', 'cartesian', 'print', 'noprint', 'rel']]):
-                group_level_lines.append(line)
+            if isinstance(val, dict):
+                g2_level_lines = []
+                g2_level_lines.append(key.lower())
+                for k2, v2 in val.items():
+                    line2 = ' '.join(format_keyword(k2, v2, lop_off=False))
+                    g2_level_lines.append(line2)
+                g2_level_lines = ' '.join(g2_level_lines)
+                lines.append(g2_level_lines)
             else:
-                lines.append(line)
+                line = ' '.join(format_keyword(key, val, lop_off=False))
+                if group.lower() == 'basis' and any(
+                    [word in line for word in ['spherical', 'cartesian', 'print', 'noprint', 'rel']]):
+                    group_level_lines.append(line)
+                else:
+                    lines.append(line)
         if group == 'aaaglobal':
             grouped_lines[group] = '\n'.join(lines) + '\n'
         else:


### PR DESCRIPTION
## Description
no hurry but no harm merging either

## Todos
  - [x] parse mp2 from c.2018 ncc rohf ccsd(t) in cfour
  - [x] allow second-level nesting formatting for nwchem (e.g., `dft__convergence__energy = 1.e-7`)
  - [x] allow formatting of dictionary values for nwchem (e.g., `dft__grid__lebedev = {'I' (55, 8), 'H': (22, 7)}`)

## Status
- [ ] Changelog updated
- [x] Ready to go