### PR TITLE
Molpro standard suite

### DIFF
--- a/qcengine/programs/molpro.py
+++ b/qcengine/programs/molpro.py
@@ -255,6 +255,14 @@ class MolproHarness(ProgramHarness):
         #       - Be aware of symmetry. Might only be able to support if symmetry,nosym
         #      - orbitals
         #       - Be aware of symmetry. Might only be able to support if symmetry,nosym
+        # NOTE: Spherical basis set ordering in Molpro (with no symmetry)
+        # S -->  0
+        # P --> +1, -1, 0
+        # D -->  0, -2, +1, +2, -1
+        # F --> +1, -1, 0, +3, -2, -3, +2
+        # G -->  0, -2, +1, +4, -1, +2, -4, +3, -3
+        # H --> +1, -1, +2, +3, -4, -3, +4, -5, 0, +5, -2
+        # I --> +6, -2, +5, +4, -5, +2, -6, +3, -4, 0, -3, -1, +1
         properties = {}
         extras = {}
         name_space = {'molpro_uri': 'http://www.molpro.net/schema/molpro-output'}
@@ -436,8 +444,7 @@ class MolproHarness(ProgramHarness):
         if input_model.driver == "energy":
             output_data["return_result"] = final_energy
         elif input_model.driver == "gradient":
-            output_data["return_result"] = properties["gradient"]
-            del properties["gradient"]
+            output_data["return_result"] = properties.pop("gradient")
 
         # Final output_data assignments needed for the Result object
         output_data["properties"] = properties

--- a/qcengine/programs/tests/test_standard_suite_ccsd.py
+++ b/qcengine/programs/tests/test_standard_suite_ccsd.py
@@ -41,6 +41,8 @@ def nh2():
         pytest.param('nwchem', 'aug-cc-pvdz', {'basis__spherical': True, 'qc_module': 'tce'}, marks=testing.using_nwchem),
         pytest.param('psi4', 'aug-cc-pvdz', {}, marks=testing.using_psi4),
         pytest.param('gamess', 'accd', {'ccinp__ncore': 0, 'contrl__ispher': 1}, marks=testing.using_gamess),
+        # TODO Molpro has frozen-core on by default. For this to pass need new keyword frozen_core = False
+        # pytest.param('molpro', 'aug-cc-pvdz', {}, marks=testing.using_molpro),
     ])  # yapf: disable
 def test_sp_ccsd_rhf_full(program, basis, keywords, h2o):
     """cfour/sp-rhf-ccsd/input.dat
@@ -107,6 +109,8 @@ def test_sp_ccsd_uhf_fc_error(program, basis, keywords, nh2, errmsg):
         pytest.param('nwchem', 'AUG-CC-PVDZ', {'BASIS__SPHERICAL': True, 'QC_MODULE': 'TCE', 'SCF__ROHF': True}, marks=testing.using_nwchem),
         pytest.param('psi4', 'AUG-CC-PVDZ', {'REFERENCE': 'ROHF'}, marks=testing.using_psi4),
         pytest.param('gamess', 'ACCD', {'CONTRL__ISPHER': 1, 'CONTRL__SCFTYP': 'ROHF', 'CCINP__NCORE': 0}, marks=testing.using_gamess),
+        # TODO Molpro has frozen-core on by default. For this to pass need new keyword frozen_core = False
+        # pytest.param('molpro', 'aug-cc-pvdz', {}, marks=testing.using_molpro),
     ])  # yapf: disable
 def test_sp_ccsd_rohf_full(program, basis, keywords, nh2):
     resi = {

--- a/qcengine/programs/tests/test_standard_suite_hf.py
+++ b/qcengine/programs/tests/test_standard_suite_hf.py
@@ -27,6 +27,7 @@ def nh2():
  H   0.000000000000000  -1.511214298139000   1.013682596946108
  H   0.000000000000000   1.511214298139000   1.013682596946108
  units au
+ symmetry c1
 """
     return qcel.models.Molecule.from_data(smol)
 
@@ -79,8 +80,7 @@ def test_sp_hf_rhf(program, basis, keywords, h2o):
         pytest.param('nwchem', 'aug-cc-pvdz', {'basis__spherical': True, 'qc_module': 'tce', 'scf__uhf': True}, marks=testing.using_nwchem),
         pytest.param('psi4', 'aug-cc-pvdz', {'reference': 'uhf', 'scf_type': 'direct'}, marks=testing.using_psi4),
         pytest.param('gamess', 'accd', {'contrl__ispher': 1, 'contrl__scftyp': 'uhf'}, marks=testing.using_gamess),
-        # TODO Need to turn off symmetry fix_symmetry = "c1" for Molpro to pass
-        # pytest.param('molpro', 'aug-cc-pvdz', {'reference': 'unrestricted'}, marks=testing.using_molpro),
+        pytest.param('molpro', 'aug-cc-pvdz', {'reference': 'unrestricted'}, marks=testing.using_molpro),
     ])  # yapf: disable
 def test_sp_hf_uhf(program, basis, keywords, nh2):
     resi = {

--- a/qcengine/programs/tests/test_standard_suite_hf.py
+++ b/qcengine/programs/tests/test_standard_suite_hf.py
@@ -79,6 +79,7 @@ def test_sp_hf_rhf(program, basis, keywords, h2o):
         pytest.param('nwchem', 'aug-cc-pvdz', {'basis__spherical': True, 'qc_module': 'tce', 'scf__uhf': True}, marks=testing.using_nwchem),
         pytest.param('psi4', 'aug-cc-pvdz', {'reference': 'uhf', 'scf_type': 'direct'}, marks=testing.using_psi4),
         pytest.param('gamess', 'accd', {'contrl__ispher': 1, 'contrl__scftyp': 'uhf'}, marks=testing.using_gamess),
+        pytest.param('molpro', 'aug-cc-pvdz', {'reference': 'unrestricted'}, marks=testing.using_molpro),
     ])  # yapf: disable
 def test_sp_hf_uhf(program, basis, keywords, nh2):
     resi = {
@@ -112,6 +113,7 @@ def test_sp_hf_uhf(program, basis, keywords, nh2):
         pytest.param('nwchem', 'aug-cc-pvdz', {'basis__spherical': True, 'qc_module': 'tce', 'scf__rohf': True}, marks=testing.using_nwchem),
         pytest.param('psi4', 'aug-cc-pvdz', {'reference': 'rohf', 'scf_type': 'direct'}, marks=testing.using_psi4),
         pytest.param('gamess', 'accd', {'contrl__ispher': 1, 'contrl__scftyp': 'rohf'}, marks=testing.using_gamess),
+        pytest.param('molpro', 'aug-cc-pvdz', {}, marks=testing.using_molpro),
     ])  # yapf: disable
 def test_sp_hf_rohf(program, basis, keywords, nh2):
     resi = {

--- a/qcengine/programs/tests/test_standard_suite_hf.py
+++ b/qcengine/programs/tests/test_standard_suite_hf.py
@@ -79,7 +79,8 @@ def test_sp_hf_rhf(program, basis, keywords, h2o):
         pytest.param('nwchem', 'aug-cc-pvdz', {'basis__spherical': True, 'qc_module': 'tce', 'scf__uhf': True}, marks=testing.using_nwchem),
         pytest.param('psi4', 'aug-cc-pvdz', {'reference': 'uhf', 'scf_type': 'direct'}, marks=testing.using_psi4),
         pytest.param('gamess', 'accd', {'contrl__ispher': 1, 'contrl__scftyp': 'uhf'}, marks=testing.using_gamess),
-        pytest.param('molpro', 'aug-cc-pvdz', {'reference': 'unrestricted'}, marks=testing.using_molpro),
+        # TODO Need to turn off symmetry fix_symmetry = "c1" for Molpro to pass
+        # pytest.param('molpro', 'aug-cc-pvdz', {'reference': 'unrestricted'}, marks=testing.using_molpro),
     ])  # yapf: disable
 def test_sp_hf_uhf(program, basis, keywords, nh2):
     resi = {

--- a/qcengine/programs/tests/test_standard_suite_hf.py
+++ b/qcengine/programs/tests/test_standard_suite_hf.py
@@ -40,6 +40,7 @@ def nh2():
         pytest.param('nwchem', 'aug-cc-pvdz', {'basis__spherical': True, 'qc_module': 'tce'}, marks=testing.using_nwchem),
         pytest.param('psi4', 'aug-cc-pvdz', {'scf_type': 'direct'}, marks=testing.using_psi4),
         pytest.param('gamess', 'accd', {'contrl__ispher': 1}, marks=testing.using_gamess),
+        pytest.param('molpro', 'aug-cc-pvdz', {}, marks=testing.using_molpro),
     ])  # yapf: disable
 def test_sp_hf_rhf(program, basis, keywords, h2o):
     """cfour/sp-rhf-hf/input.dat

--- a/qcengine/programs/tests/test_standard_suite_mp2.py
+++ b/qcengine/programs/tests/test_standard_suite_mp2.py
@@ -40,6 +40,7 @@ def nh2():
         pytest.param('nwchem', 'aug-cc-pvdz', {'basis__spherical': True, 'qc_module': 'tce'}, marks=testing.using_nwchem),
         pytest.param('psi4', 'aug-cc-pvdz', {'mp2_type': 'conv'}, marks=testing.using_psi4),
         pytest.param('gamess', 'accd', {'mp2__nacore': 0, 'contrl__ispher': 1}, marks=testing.using_gamess),
+        pytest.param('molpro', 'aug-cc-pvdz', {}, marks=testing.using_molpro),
     ])  # yapf: disable
 def test_sp_mp2_rhf_full(program, basis, keywords, h2o):
     """cfour/sp-rhf-ccsd/input.dat
@@ -78,6 +79,7 @@ def test_sp_mp2_rhf_full(program, basis, keywords, h2o):
         pytest.param('nwchem', 'aug-cc-pvdz', {'basis__spherical': True, 'scf__uhf': True, 'mp2__freeze':1}, marks=testing.using_nwchem),
         pytest.param('psi4', 'aug-cc-pvdz', {'reference': 'uhf', 'freeze_core': True, 'mp2_type': 'conv'}, marks=testing.using_psi4),
         pytest.param('gamess', 'accd', {'contrl__ispher': 1, 'contrl__scftyp': 'uhf'}, marks=testing.using_gamess),
+        pytest.param('molpro', 'aug-cc-pvdz', {"reference": "unrestricted"}, marks=testing.using_molpro),
     ])  # yapf: disable
 def test_sp_mp2_uhf_fc(program, basis, keywords, nh2):
     resi = {
@@ -105,6 +107,7 @@ def test_sp_mp2_uhf_fc(program, basis, keywords, nh2):
 
 @pytest.mark.parametrize('program,basis,keywords,errmsg', [
     pytest.param('nwchem', 'aug-cc-pvdz', {'scf__rohf': True}, 'unknown SCFTYPE', marks=testing.using_nwchem),
+    pytest.param('molpro', 'aug-cc-pvdz', {}, 'unknown SCFTYPE', marks=testing.using_molpro),
 ])  # yapf: disable
 def test_sp_mp2_rohf_full_error(program, basis, keywords, nh2, errmsg):
     resi = {

--- a/qcengine/programs/tests/test_standard_suite_mp2.py
+++ b/qcengine/programs/tests/test_standard_suite_mp2.py
@@ -40,7 +40,8 @@ def nh2():
         pytest.param('nwchem', 'aug-cc-pvdz', {'basis__spherical': True, 'qc_module': 'tce'}, marks=testing.using_nwchem),
         pytest.param('psi4', 'aug-cc-pvdz', {'mp2_type': 'conv'}, marks=testing.using_psi4),
         pytest.param('gamess', 'accd', {'mp2__nacore': 0, 'contrl__ispher': 1}, marks=testing.using_gamess),
-        pytest.param('molpro', 'aug-cc-pvdz', {}, marks=testing.using_molpro),
+        # TODO Molpro has frozen-core on by default. For this to pass need keyword frozen_core = False
+        # pytest.param('molpro', 'aug-cc-pvdz', {}, marks=testing.using_molpro),
     ])  # yapf: disable
 def test_sp_mp2_rhf_full(program, basis, keywords, h2o):
     """cfour/sp-rhf-ccsd/input.dat
@@ -79,7 +80,8 @@ def test_sp_mp2_rhf_full(program, basis, keywords, h2o):
         pytest.param('nwchem', 'aug-cc-pvdz', {'basis__spherical': True, 'scf__uhf': True, 'mp2__freeze':1}, marks=testing.using_nwchem),
         pytest.param('psi4', 'aug-cc-pvdz', {'reference': 'uhf', 'freeze_core': True, 'mp2_type': 'conv'}, marks=testing.using_psi4),
         pytest.param('gamess', 'accd', {'contrl__ispher': 1, 'contrl__scftyp': 'uhf'}, marks=testing.using_gamess),
-        pytest.param('molpro', 'aug-cc-pvdz', {"reference": "unrestricted"}, marks=testing.using_molpro),
+        # TODO Molpro needs a new keyword for unrestricted MP2 (otherwise RMP2 by default) and needs symmetry c1
+        # pytest.param('molpro', 'aug-cc-pvdz', {"reference": "unrestricted"}, marks=testing.using_molpro),
     ])  # yapf: disable
 def test_sp_mp2_uhf_fc(program, basis, keywords, nh2):
     resi = {
@@ -107,7 +109,6 @@ def test_sp_mp2_uhf_fc(program, basis, keywords, nh2):
 
 @pytest.mark.parametrize('program,basis,keywords,errmsg', [
     pytest.param('nwchem', 'aug-cc-pvdz', {'scf__rohf': True}, 'unknown SCFTYPE', marks=testing.using_nwchem),
-    pytest.param('molpro', 'aug-cc-pvdz', {}, 'unknown SCFTYPE', marks=testing.using_molpro),
 ])  # yapf: disable
 def test_sp_mp2_rohf_full_error(program, basis, keywords, nh2, errmsg):
     resi = {

--- a/qcengine/tests/test_harness_canonical.py
+++ b/qcengine/tests/test_harness_canonical.py
@@ -13,6 +13,7 @@ from qcengine import testing
 
 _canonical_methods = [
     ("dftd3", {"method": "b3lyp-d3"}),
+    ("molpro", {"method": "hf", "basis": "6-31G"}),
     ("mopac", {"method": "PM6"}),
     ("mp2d", {"method": "MP2-DMP2"}),
     ("psi4", {"method": "hf", "basis": "6-31G"}),


### PR DESCRIPTION
- Added Molpro to some of the standard suite (hf, mp2, ccsd). However, Molpro only works in the hf standard suit right now since, a new keyword to turn off frozen-core will need to implemented for the Molpro Harness to pass the mp2 and ccsd standard suite. I've left those commented out for the time being.
- Added a note in the parse_output function outlining the spherical basis set ordering using in Molpro up to angular momentum i.