### PR TITLE
MPI/MultiNode support

### DIFF
--- a/qcengine/config.py
+++ b/qcengine/config.py
@@ -81,7 +81,7 @@ class NodeDescriptor(pydantic.BaseModel):
         extra = "forbid"
 
 
-class JobConfig(pydantic.BaseModel):
+class TaskConfig(pydantic.BaseModel):
 
     # Specifications
     ncores: int  # Number of ncores per task
@@ -200,7 +200,7 @@ def parse_environment(data: Dict[str, Any]) -> Dict[str, Any]:
     return ret
 
 
-def get_config(*, hostname: Optional[str] = None, local_options: Dict[str, Any] = None) -> JobConfig:
+def get_config(*, hostname: Optional[str] = None, local_options: Dict[str, Any] = None) -> TaskConfig:
     """
     Returns the configuration key for qcengine.
     """
@@ -240,7 +240,7 @@ def get_config(*, hostname: Optional[str] = None, local_options: Dict[str, Any] 
     if local_options is not None:
         config.update(local_options)
 
-    return JobConfig(**config)
+    return TaskConfig(**config)
 
 
 def get_provenance_augments() -> Dict[str, str]:

--- a/qcengine/config.py
+++ b/qcengine/config.py
@@ -43,6 +43,7 @@ def get_global(key: Optional[str] = None) -> Union[str, Dict[str, Any]]:
                 cpu_cnt = psutil.cpu_count(logical=True)
 
         _global_values["ncores"] = cpu_cnt
+        _global_values["nnodes"] = 1
 
         _global_values["cpuinfo"] = cpuinfo.get_cpu_info()
         _global_values["cpu_brand"] = _global_values["cpuinfo"]["brand"]
@@ -83,7 +84,8 @@ class NodeDescriptor(pydantic.BaseModel):
 class JobConfig(pydantic.BaseModel):
 
     # Specifications
-    ncores: int  # Number of ncores per job
+    ncores: int  # Number of ncores per task
+    nnodes: int  # Number of nodes per task
     memory: float  # Amount of memory in GiB per node
     scratch_directory: Optional[str]  # What location to use as scratch
     retries: int  # Number of retries on random failures
@@ -233,6 +235,7 @@ def get_config(*, hostname: Optional[str] = None, local_options: Dict[str, Any] 
         raise KeyError("Number of jobs per node exceeds the number of available cores.")
 
     config["ncores"] = ncores
+    config["nnodes"] = local_options.pop("nnodes", 1)
 
     if local_options is not None:
         config.update(local_options)

--- a/qcengine/procedures/geometric.py
+++ b/qcengine/procedures/geometric.py
@@ -24,7 +24,7 @@ class GeometricProcedure(ProcedureHarness):
     def build_input_model(self, data: Union[Dict[str, Any], "OptimizationInput"]) -> "OptimizationInput":
         return self._build_model(data, OptimizationInput)
 
-    def compute(self, input_data: "OptimizationInput", config: "JobConfig") -> "OptimizationResult":
+    def compute(self, input_data: "OptimizationInput", config: "TaskConfig") -> "OptimizationResult":
         try:
             import geometric
         except ModuleNotFoundError:

--- a/qcengine/procedures/model.py
+++ b/qcengine/procedures/model.py
@@ -37,7 +37,7 @@ class ProcedureHarness(BaseModel, abc.ABC):
         """
 
     @abc.abstractmethod
-    def compute(self, input_data: "BaseModel", config: "JobConfig") -> "BaseModel":
+    def compute(self, input_data: "BaseModel", config: "TaskConfig") -> "BaseModel":
         pass
 
     @abc.abstractmethod

--- a/qcengine/programs/cfour/runner.py
+++ b/qcengine/programs/cfour/runner.py
@@ -64,7 +64,7 @@ class CFOURHarness(ProgramHarness):
 
         return self.version_cache[which_prog]
 
-    def compute(self, input_model: "AtomicInput", config: "JobConfig") -> "AtomicResult":
+    def compute(self, input_model: "AtomicInput", config: "TaskConfig") -> "AtomicResult":
         self.found(raise_error=True)
 
         job_inputs = self.build_input(input_model, config)
@@ -76,7 +76,7 @@ class CFOURHarness(ProgramHarness):
             return self.parse_output(dexe["outfiles"], input_model)
 
     def build_input(
-        self, input_model: "AtomicInput", config: "JobConfig", template: Optional[str] = None
+        self, input_model: "AtomicInput", config: "TaskConfig", template: Optional[str] = None
     ) -> Dict[str, Any]:
         cfourrec = {"infiles": {}, "scratch_directory": config.scratch_directory}
 

--- a/qcengine/programs/dftd3.py
+++ b/qcengine/programs/dftd3.py
@@ -61,7 +61,7 @@ class DFTD3Harness(ProgramHarness):
 
         return self.version_cache[which_prog]
 
-    def compute(self, input_model: "AtomicInput", config: "JobConfig") -> "AtomicResult":
+    def compute(self, input_model: "AtomicInput", config: "TaskConfig") -> "AtomicResult":
         self.found(raise_error=True)
 
         job_inputs = self.build_input(input_model, config)
@@ -98,7 +98,7 @@ class DFTD3Harness(ProgramHarness):
         return success, dexe
 
     def build_input(
-        self, input_model: "AtomicInput", config: "JobConfig", template: Optional[str] = None
+        self, input_model: "AtomicInput", config: "TaskConfig", template: Optional[str] = None
     ) -> Dict[str, Any]:
 
         # strip engine hint

--- a/qcengine/programs/entos.py
+++ b/qcengine/programs/entos.py
@@ -7,7 +7,7 @@ import string
 from typing import Any, Dict, List, Optional, Set, Tuple, TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from ..config import JobConfig
+    from ..config import TaskConfig
     from qcelemental.models import AtomicInput
 
 from qcelemental.models import AtomicResult

--- a/qcengine/programs/entos.py
+++ b/qcengine/programs/entos.py
@@ -109,7 +109,7 @@ class EntosHarness(ProgramHarness):
 
         return self.version_cache[which_prog]
 
-    def compute(self, input_data: "AtomicInput", config: "JobConfig") -> "AtomicResult":
+    def compute(self, input_data: "AtomicInput", config: "TaskConfig") -> "AtomicResult":
         """
         Run entos
         """
@@ -180,7 +180,7 @@ class EntosHarness(ProgramHarness):
         return exe_success, proc
 
     def build_input(
-        self, input_model: "AtomicInput", config: "JobConfig", template: Optional[str] = None
+        self, input_model: "AtomicInput", config: "TaskConfig", template: Optional[str] = None
     ) -> Dict[str, Any]:
 
         # Write the geom xyz file with unit au

--- a/qcengine/programs/gamess/runner.py
+++ b/qcengine/programs/gamess/runner.py
@@ -68,7 +68,7 @@ class GAMESSHarness(ProgramHarness):
 
         return self.version_cache[which_prog]
 
-    def compute(self, input_data: "AtomicInput", config: "JobConfig") -> "AtomicResult":
+    def compute(self, input_data: "AtomicInput", config: "TaskConfig") -> "AtomicResult":
         self.found(raise_error=True)
 
         job_inputs = self.build_input(input_data, config)
@@ -83,7 +83,7 @@ class GAMESSHarness(ProgramHarness):
             return self.parse_output(dexe["outfiles"], input_data)
 
     def build_input(
-        self, input_model: "AtomicInput", config: "JobConfig", template: Optional[str] = None
+        self, input_model: "AtomicInput", config: "TaskConfig", template: Optional[str] = None
     ) -> Dict[str, Any]:
         gamessrec = {"infiles": {}, "scratch_directory": config.scratch_directory}
 

--- a/qcengine/programs/model.py
+++ b/qcengine/programs/model.py
@@ -23,7 +23,7 @@ class ProgramHarness(BaseModel, abc.ABC):
         super().__init__(**{**self._defaults, **kwargs})
 
     @abc.abstractmethod
-    def compute(self, input_data: "AtomicInput", config: "JobConfig") -> "AtomicResult":
+    def compute(self, input_data: "AtomicInput", config: "TaskConfig") -> "AtomicResult":
         pass
 
     @staticmethod
@@ -57,7 +57,7 @@ class ProgramHarness(BaseModel, abc.ABC):
     ## Computers
 
     def build_input(
-        self, input_model: "AtomicInput", config: "JobConfig", template: Optional[str] = None
+        self, input_model: "AtomicInput", config: "TaskConfig", template: Optional[str] = None
     ) -> Dict[str, Any]:
         raise ValueError("build_input is not implemented for {}.", self.__class__)
 

--- a/qcengine/programs/molpro.py
+++ b/qcengine/programs/molpro.py
@@ -95,7 +95,7 @@ class MolproHarness(ProgramHarness):
 
         return self.version_cache[which_prog]
 
-    def compute(self, input_data: "AtomicInput", config: "JobConfig") -> "AtomicResult":
+    def compute(self, input_data: "AtomicInput", config: "TaskConfig") -> "AtomicResult":
         """
         Run Molpro
         """
@@ -165,7 +165,7 @@ class MolproHarness(ProgramHarness):
         return exe_success, proc
 
     def build_input(
-        self, input_model: "AtomicInput", config: "JobConfig", template: Optional[str] = None
+        self, input_model: "AtomicInput", config: "TaskConfig", template: Optional[str] = None
     ) -> Dict[str, Any]:
         if template is None:
             input_file = []

--- a/qcengine/programs/mopac.py
+++ b/qcengine/programs/mopac.py
@@ -51,7 +51,7 @@ class MopacHarness(ProgramHarness):
         # Not really possible to pull at the moment, MolSSI will add a version ability
         return "2016"
 
-    def compute(self, input_model: "AtomicInput", config: "JobConfig") -> "AtomicResult":
+    def compute(self, input_model: "AtomicInput", config: "TaskConfig") -> "AtomicResult":
         """
         Runs Psi4 in API mode
         """
@@ -109,7 +109,7 @@ class MopacHarness(ProgramHarness):
         return exe_success, proc
 
     def build_input(
-        self, input_model: "AtomicInput", config: "JobConfig", template: Optional[str] = None
+        self, input_model: "AtomicInput", config: "TaskConfig", template: Optional[str] = None
     ) -> Dict[str, Any]:
 
         if template is not None:

--- a/qcengine/programs/mp2d.py
+++ b/qcengine/programs/mp2d.py
@@ -58,7 +58,7 @@ class MP2DHarness(ProgramHarness):
 
         return self.version_cache[which_prog]
 
-    def compute(self, input_model: "AtomicInput", config: "JobConfig") -> "AtomicResult":
+    def compute(self, input_model: "AtomicInput", config: "TaskConfig") -> "AtomicResult":
         from ..testing import is_program_new_enough
 
         self.found(raise_error=True)
@@ -95,7 +95,7 @@ class MP2DHarness(ProgramHarness):
         return success, dexe
 
     def build_input(
-        self, input_model: "AtomicInput", config: "JobConfig", template: Optional[str] = None
+        self, input_model: "AtomicInput", config: "TaskConfig", template: Optional[str] = None
     ) -> Dict[str, Any]:
 
         # strip engine hint

--- a/qcengine/programs/nwchem/runner.py
+++ b/qcengine/programs/nwchem/runner.py
@@ -13,7 +13,7 @@ import qcelemental as qcel
 from qcelemental.models import AtomicResult, Provenance
 from qcelemental.util import safe_version, which
 
-from qcengine.config import JobConfig, get_config
+from qcengine.config import TaskConfig, get_config
 from qcengine.exceptions import UnknownError
 from ...exceptions import InputError
 from ...util import execute

--- a/qcengine/programs/nwchem/runner.py
+++ b/qcengine/programs/nwchem/runner.py
@@ -82,7 +82,7 @@ class NWChemHarness(ProgramHarness):
 
         return self.version_cache[which_prog]
 
-    def compute(self, input_model: "AtomicInput", config: "JobConfig") -> "AtomicResult":
+    def compute(self, input_model: "AtomicInput", config: "TaskConfig") -> "AtomicResult":
         """
         Runs NWChem in executable mode
         """
@@ -105,7 +105,7 @@ class NWChemHarness(ProgramHarness):
             raise UnknownError(dexe["stderr"])
 
     def build_input(
-        self, input_model: "AtomicInput", config: "JobConfig", template: Optional[str] = None
+        self, input_model: "AtomicInput", config: "TaskConfig", template: Optional[str] = None
     ) -> Dict[str, Any]:
         nwchemrec = {"infiles": {}, "scratch_directory": config.scratch_directory}
 

--- a/qcengine/programs/openmm.py
+++ b/qcengine/programs/openmm.py
@@ -112,7 +112,7 @@ class OpenMMHarness(ProgramHarness):
 
         return (rdkit_found and openmm_found)
 
-    def compute(self, input_data: 'AtomicInput', config: 'JobConfig') -> 'AtomicResult':
+    def compute(self, input_data: 'AtomicInput', config: 'TaskConfig') -> 'AtomicResult':
         """
         Runs OpenMM on given structure, inputs, in vacuum.
         """
@@ -131,7 +131,7 @@ class OpenMMHarness(ProgramHarness):
             basis = self._generate_basis(input_data)
             ret_data['basis'] = basis
 
-        # get number of threads to use from `JobConfig.ncores`; otherwise, try environment variable
+        # get number of threads to use from `TaskConfig.ncores`; otherwise, try environment variable
         nthreads = config.ncores
         if nthreads is None:
             nthreads = os.environ.get('OPENMM_CPU_THREADS')

--- a/qcengine/programs/psi4.py
+++ b/qcengine/programs/psi4.py
@@ -55,7 +55,7 @@ class Psi4Harness(ProgramHarness):
 
         return candidate_version
 
-    def compute(self, input_model: "AtomicInput", config: "JobConfig") -> "AtomicResult":
+    def compute(self, input_model: "AtomicInput", config: "TaskConfig") -> "AtomicResult":
         """
         Runs Psi4 in API mode
         """

--- a/qcengine/programs/qchem.py
+++ b/qcengine/programs/qchem.py
@@ -35,7 +35,7 @@ class QChemHarness(ProgramHarness):
             raise_msg="Please install by visiting the Q-Chem website.",
         )
 
-    def _get_qc_path(self, config: Optional["JobConfig"] = None):
+    def _get_qc_path(self, config: Optional["TaskConfig"] = None):
         paths = os.environ.copy()
         paths["QCSCRATCH"] = tempfile.gettempdir()
         if config and config.scratch_directory:
@@ -67,7 +67,7 @@ class QChemHarness(ProgramHarness):
 
         return self.version_cache[which_prog]
 
-    def compute(self, input_model: "AtomicInput", config: "JobConfig") -> "AtomicResult":
+    def compute(self, input_model: "AtomicInput", config: "TaskConfig") -> "AtomicResult":
         """
         Run qchem
         """
@@ -159,7 +159,7 @@ class QChemHarness(ProgramHarness):
         return exe_success, proc
 
     def build_input(
-        self, input_model: "AtomicInput", config: "JobConfig", template: Optional[str] = None
+        self, input_model: "AtomicInput", config: "TaskConfig", template: Optional[str] = None
     ) -> Dict[str, Any]:
 
         # Check some bounds on what cannot be parsed

--- a/qcengine/programs/rdkit.py
+++ b/qcengine/programs/rdkit.py
@@ -76,7 +76,7 @@ class RDKitHarness(ProgramHarness):
             raise_msg="Please install via `conda install rdkit -c conda-forge`.",
         )
 
-    def compute(self, input_data: 'AtomicInput', config: 'JobConfig') -> 'AtomicResult':
+    def compute(self, input_data: 'AtomicInput', config: 'TaskConfig') -> 'AtomicResult':
         """
         Runs RDKit in FF typing
         """

--- a/qcengine/programs/terachem.py
+++ b/qcengine/programs/terachem.py
@@ -52,7 +52,7 @@ class TeraChemHarness(ProgramHarness):
 
         return self.version_cache[which_prog]
 
-    def compute(self, input_data: "AtomicInput", config: "JobConfig") -> "AtomicResult":
+    def compute(self, input_data: "AtomicInput", config: "TaskConfig") -> "AtomicResult":
         """
         Run TeraChem
         """
@@ -81,7 +81,7 @@ class TeraChemHarness(ProgramHarness):
         return result
 
     def build_input(
-        self, input_model: "AtomicInput", config: "JobConfig", template: Optional[str] = None
+        self, input_model: "AtomicInput", config: "TaskConfig", template: Optional[str] = None
     ) -> Dict[str, Any]:
         # Write the geom xyz file with unit au
         xyz_file = input_model.molecule.to_string(dtype="terachem", units="Bohr")

--- a/qcengine/programs/torchani.py
+++ b/qcengine/programs/torchani.py
@@ -77,7 +77,7 @@ class TorchANIHarness(ProgramHarness):
 
         return self._CACHE[name]
 
-    def compute(self, input_data: "AtomicInput", config: "JobConfig") -> "AtomicResult":
+    def compute(self, input_data: "AtomicInput", config: "TaskConfig") -> "AtomicResult":
         """
         Runs TorchANI in FF typing
         """

--- a/qcengine/programs/turbomole/runner.py
+++ b/qcengine/programs/turbomole/runner.py
@@ -55,7 +55,7 @@ class TurbomoleHarness(ProgramHarness):
             self.version_cache[which_prog] = safe_version(version)
         return self.version_cache[which_prog]
 
-    def compute(self, input_model: "AtomicInput", config: "JobConfig") -> "AtomicResult":
+    def compute(self, input_model: "AtomicInput", config: "TaskConfig") -> "AtomicResult":
         self.found(raise_error=True)
 
         job_inputs = self.build_input(input_model, config)
@@ -71,7 +71,7 @@ class TurbomoleHarness(ProgramHarness):
             return self.parse_output(dexe["outfiles"], input_model)
 
     def build_input(
-        self, input_model: "AtomicInput", config: "JobConfig", template: Optional[str] = None
+        self, input_model: "AtomicInput", config: "TaskConfig", template: Optional[str] = None
     ) -> Dict[str, Any]:
         turbomolrec = {"infiles": {}, "outfiles": {"control": "control"}, "scratch_directory": config.scratch_directory}
 

--- a/qcengine/testing.py
+++ b/qcengine/testing.py
@@ -90,7 +90,7 @@ def failure_engine():
         def found(raise_error: bool = False) -> bool:
             return True
 
-        def compute(self, input_data: "AtomicInput", config: "JobConfig") -> "AtomicResult":
+        def compute(self, input_data: "AtomicInput", config: "TaskConfig") -> "AtomicResult":
             self.ncalls += 1
             mode = self.iter_modes.pop(0)
 

--- a/qcengine/tests/test_config.py
+++ b/qcengine/tests/test_config.py
@@ -28,6 +28,7 @@ def test_node_auto():
     node1 = qcng.config.NodeDescriptor(**desc)
     job1 = qcng.get_config(hostname=node1)
     assert job1.ncores == 4
+    assert job1.nnodes == 1
     assert pytest.approx(job1.memory) == 10.0
 
     desc["jobs_per_node"] = 2
@@ -151,6 +152,11 @@ def test_config_local_njob_ncore_plus_memory(opt_state_basic):
     config = qcng.config.get_config(hostname="something", local_options={"jobs_per_node": 3, "ncores": 1, "memory": 6})
     assert config.ncores == 1
     assert pytest.approx(config.memory, 0.1) == 6
+
+
+def test_config_local_nnodes(opt_state_basic):
+    config = qcng.config.get_config(hostname="something", local_options={"nnodes": 4})
+    assert config.nnodes == 4
 
 
 def test_config_validation(opt_state_basic):

--- a/qcengine/util.py
+++ b/qcengine/util.py
@@ -239,13 +239,13 @@ def popen(
 
 
 @contextmanager
-def environ_context(config: Optional["JobConfig"] = None, env: Optional[Dict[str, str]] = None) -> Dict[str, str]:
+def environ_context(config: Optional["TaskConfig"] = None, env: Optional[Dict[str, str]] = None) -> Dict[str, str]:
     """Temporarily set environment variables inside the context manager and
     fully restore previous environment afterwards.
 
     Parameters
     ----------
-    config : Optional[JobConfig], optional
+    config : Optional[TaskConfig], optional
         Automatically sets MKL/OMP num threads based off the input config.
     env : Optional[Dict[str, str]], optional
         A dictionary of environment variables to update.


### PR DESCRIPTION
## Description
This PR adds some hooks which will allow multimode support.
- [x] Adds `nnodes` to config.
- [x] Renames JobConfig to TaskConfig which matches our general nomenclature much better.
- [ ] Do we need an option to allow non-`mpi` cli options?

@lward

## Status
- [ ] Changelog updated
- [x] Ready to go