### PR TITLE
entos: add hessian and xtb support

### DIFF
--- a/docs/source/program_overview.rst
+++ b/docs/source/program_overview.rst
@@ -1,7 +1,7 @@
 Program Overview
 ================
 
-The general capabalities available through QCEngine for each program can be
+The general capabilities available through QCEngine for each program can be
 found below:
 
 Quantum Chemistry
@@ -12,7 +12,7 @@ Quantum Chemistry
 +============+============+===+===+===+============+==============+
 | CFOUR      | ✘          | ✓ | ✓ | ✘ | ✓          | ✘            |
 +------------+------------+---+---+---+------------+--------------+
-| Entos      | ✘          | ✓ | ✓ | ✘ | ✘          | ✘            |
+| Entos      | ✘          | ✓ | ✓ | ✓ | ✘          | ✘            |
 +------------+------------+---+---+---+------------+--------------+
 | GAMESS     | ✘          | ✓ | ✓ | ✘ | ✓          | ✘            |
 +------------+------------+---+---+---+------------+--------------+
@@ -29,7 +29,7 @@ Quantum Chemistry
 | Turbomole  | ✘          | ✓ | ✓ | ✘ | ✘          | ✘            |
 +------------+------------+---+---+---+------------+--------------+
 
-Semi-Emperical
+Semi-Empirical
 --------------
 
 +------------+------------+---+---+---+------------+--------------+

--- a/qcengine/programs/tests/test_entos.py
+++ b/qcengine/programs/tests/test_entos.py
@@ -22,7 +22,7 @@ def test_entos_output_parser(test_case):
     output_ref.pop("provenance", None)
 
     check = compare_recursive(output_ref, output)
-    assert check, check
+    assert check, (output, output_ref)
 
 
 @pytest.mark.parametrize("test_case", entos_info.list_test_cases())

--- a/qcengine/testing.py
+++ b/qcengine/testing.py
@@ -12,7 +12,7 @@ import qcelemental as qcel
 import qcengine as qcng
 from qcelemental.util import which, which_import
 
-QCENGINE_RECORDS_COMMIT = "fe14d77"
+QCENGINE_RECORDS_COMMIT = "854d1fe"
 
 
 def _check_qcenginerecords(return_data=False):


### PR DESCRIPTION
## Description
This PR adds hessian and xtb support to the entos harness. It is a companion to MolSSI/QCEngineRecords#21.

## Status
- [ ] Changelog updated
- [ ] Ready to go