### PR TITLE
Entos: Added subcommands and more keywords

### DIFF
--- a/qcengine/compute.py
+++ b/qcengine/compute.py
@@ -1,9 +1,12 @@
 """
 Integrates the computes together
 """
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Optional, Union, TYPE_CHECKING
 
-from pydantic.main import BaseModel
+if TYPE_CHECKING:
+    from pydantic.main import BaseModel
+    from qcelemental.models import AtomicResult
+
 from qcelemental.models import AtomicInput, FailedOperation, AtomicResult
 
 from .config import get_config

--- a/qcengine/compute.py
+++ b/qcengine/compute.py
@@ -3,7 +3,8 @@ Integrates the computes together
 """
 from typing import Any, Dict, Optional, Union
 
-from qcelemental.models import AtomicInput, FailedOperation
+from pydantic.main import BaseModel
+from qcelemental.models import AtomicInput, FailedOperation, AtomicResult
 
 from .config import get_config
 from .exceptions import InputError, RandomError

--- a/qcengine/programs/entos.py
+++ b/qcengine/programs/entos.py
@@ -1,5 +1,5 @@
 """
-Calls the entos executable.
+The entos QCEngine Harness
 """
 
 import json
@@ -221,7 +221,6 @@ class EntosHarness(ProgramHarness):
             # Additional sub trees
             structure = {"structure": {"file": "geometry.xyz"}}  # Structure sub tree
             print_results = {"print": {"results": True}}  # Print sub tree
-            name_results = {"name": "json_results"}
 
             # Create the input dictionary for a energy call
             if input_model.driver == "energy":
@@ -230,7 +229,6 @@ class EntosHarness(ProgramHarness):
                         **structure,
                         **energy_options[energy_command],
                         **energy_extra_options,
-                        **name_results,
                     },
                     **print_results,
                 }
@@ -240,7 +238,6 @@ class EntosHarness(ProgramHarness):
                     "gradient": {
                         **structure,
                         energy_command: {**energy_options[energy_command], **energy_extra_options},
-                        **name_results,
                     },
                     **print_results,
                 }
@@ -258,7 +255,7 @@ class EntosHarness(ProgramHarness):
                 raise NotImplementedError(f"Driver {input_model.driver} not implemented for entos.")
 
             # Write input file
-            input_file = self.write_input_recursive(input_dict)
+            input_file = ["json_results := "] + self.write_input_recursive(input_dict)
             input_file = "\n".join(input_file)
 
         # Use the template input file if present
@@ -280,7 +277,7 @@ class EntosHarness(ProgramHarness):
             str_template = string.Template(template)
             input_file = str_template.substitute()
 
-        # print(input_file)
+        print(input_file)
         return {
             "commands": ["entos", "-n", str(config.ncores), "-o", "dispatch.out", "--json-results", "dispatch.in"],
             "infiles": {"dispatch.in": input_file, "geometry.xyz": xyz_file},

--- a/qcengine/programs/entos.py
+++ b/qcengine/programs/entos.py
@@ -78,12 +78,8 @@ class EntosHarness(ProgramHarness):
         "energy_threshold",
         "coulomb_method",
         "exchange_method"}
-    _dft_keywords_extra: Set[str] = {
-        *_scf_keywords_extra
-    }
-    _hf_keywords_extra: Set[str] = {
-        *_scf_keywords_extra
-    }
+    _dft_keywords_extra: Set[str] = _scf_keywords_extra.copy()
+    _hf_keywords_extra: Set[str] = _scf_keywords_extra.copy()
     _xtb_keywords_extra: Set[str] = {}
 
     # Energy commands that are currently supported and their available keywords
@@ -319,17 +315,11 @@ class EntosHarness(ProgramHarness):
             "orbitals": "scf_orbitals",
             "fock": "fock",
         }
-        dft_map = {
-            **scf_map
-        }
+        dft_map = scf_map.copy()
 
-        hf_map = {
-            **scf_map
-        }
+        hf_map = scf_map.copy()
 
-        xtb_map = {
-            **scf_map
-        }
+        xtb_map = scf_map.copy()
 
         energy_command_map = {
             "dft": dft_map,

--- a/qcengine/programs/entos.py
+++ b/qcengine/programs/entos.py
@@ -121,7 +121,6 @@ class EntosHarness(ProgramHarness):
 
         # Setup the job
         job_inputs = self.build_input(input_data, config)
-        # print(job_inputs["infiles"]["dispatch.in"])
 
         # Run entos
         exe_success, proc = self.execute(job_inputs)
@@ -177,7 +176,6 @@ class EntosHarness(ProgramHarness):
 
         # Entos does not create an output file and only prints to stdout
         proc["outfiles"]["results.json"] = proc["stdout"]
-        # print(proc["outfiles"]["dispatch.out"])
         return exe_success, proc
 
     def build_input(
@@ -244,7 +242,6 @@ class EntosHarness(ProgramHarness):
                         },
                     },
                 }
-            # TODO Add support for hessians
             elif input_model.driver == 'hessian':
                 input_dict = {
                     "hessian": {
@@ -280,7 +277,6 @@ class EntosHarness(ProgramHarness):
             str_template = string.Template(template)
             input_file = str_template.substitute()
 
-        # print(input_file)
         return {
             "commands": ["entos", "-n", str(config.ncores), "-o", "dispatch.out", "--json-results", "dispatch.in"],
             "infiles": {"dispatch.in": input_file, "geometry.xyz": xyz_file},

--- a/qcengine/programs/entos.py
+++ b/qcengine/programs/entos.py
@@ -116,7 +116,7 @@ class EntosHarness(ProgramHarness):
         self.found(raise_error=True)
 
         # Check entos version
-        if parse_version(self.get_version()) < parse_version("0.7"):
+        if parse_version(self.get_version()) < parse_version("0.7.1"):
             raise TypeError(f"entos version {self.get_version()} not supported")
 
         # Setup the job
@@ -255,7 +255,7 @@ class EntosHarness(ProgramHarness):
                 raise NotImplementedError(f"Driver {input_model.driver} not implemented for entos.")
 
             # Write input file
-            input_file = ["json_results := "] + self.write_input_recursive(input_dict)
+            input_file = [f"entos_policy(version = '{self.get_version()}')", "json_results := "] + self.write_input_recursive(input_dict)
             input_file = "\n".join(input_file)
 
         # Use the template input file if present

--- a/qcengine/programs/tests/test_entos.py
+++ b/qcengine/programs/tests/test_entos.py
@@ -25,6 +25,7 @@ def test_entos_output_parser(test_case):
     assert check, (output, output_ref)
 
 
+@using_entos
 @pytest.mark.parametrize("test_case", entos_info.list_test_cases())
 def test_entos_input_formatter(test_case):
 

--- a/qcengine/programs/tests/test_standard_suite_hf.py
+++ b/qcengine/programs/tests/test_standard_suite_hf.py
@@ -37,6 +37,12 @@ def nh2():
     [
         pytest.param("cfour", "aug-pvdz", {"scf_conv": 12}, marks=testing.using_cfour),
         pytest.param("cfour", "aug-pvdz", {}, marks=testing.using_cfour),
+        pytest.param(
+            "entos",
+            "aug-cc-pVDZ",
+            {"coulomb_method": "direct_4idx", "exchange_method": "direct_4idx"},
+            marks=testing.using_entos
+        ),
         pytest.param("gamess", "accd", {"contrl__ispher": 1}, marks=testing.using_gamess),
         pytest.param("molpro", "aug-cc-pvdz", {}, marks=testing.using_molpro),
         pytest.param("nwchem", "aug-cc-pvdz", {"basis__spherical": True}, marks=testing.using_nwchem),
@@ -78,6 +84,12 @@ def test_sp_hf_rhf(program, basis, keywords, h2o):
             marks=testing.using_cfour,
         ),
         pytest.param("cfour", "aug-pvdz", {"reference": "uhf"}, marks=testing.using_cfour),
+        pytest.param(
+            "entos",
+            "aug-cc-pVDZ",
+            {"ansatz": "u", "coulomb_method": "direct_4idx", "exchange_method": "direct_4idx"},
+            marks=testing.using_entos
+        ),
         pytest.param("gamess", "accd", {"contrl__ispher": 1, "contrl__scftyp": "uhf"}, marks=testing.using_gamess),
         pytest.param("molpro", "aug-cc-pvdz", {"reference": "unrestricted"}, marks=testing.using_molpro),
         pytest.param("nwchem", "aug-cc-pvdz", {"basis__spherical": True, "scf__uhf": True}, marks=testing.using_nwchem),

--- a/qcengine/programs/util/hessparse.py
+++ b/qcengine/programs/util/hessparse.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from qcelemental.util import filter_comments
+from pydantic import ValidationError
 
 
 def load_hessian(shess: str, dtype: str) -> np.ndarray:

--- a/qcengine/programs/util/hessparse.py
+++ b/qcengine/programs/util/hessparse.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from qcelemental.util import filter_comments
-from pydantic import ValidationError
+from qcelemental.exceptions import ValidationError
 
 
 def load_hessian(shess: str, dtype: str) -> np.ndarray:

--- a/qcengine/testing.py
+++ b/qcengine/testing.py
@@ -12,7 +12,7 @@ import qcelemental as qcel
 import qcengine as qcng
 from qcelemental.util import which, which_import
 
-QCENGINE_RECORDS_COMMIT = "f81f0f2"
+QCENGINE_RECORDS_COMMIT = "a18e236"
 
 
 def _check_qcenginerecords(return_data=False):

--- a/qcengine/testing.py
+++ b/qcengine/testing.py
@@ -12,7 +12,7 @@ import qcelemental as qcel
 import qcengine as qcng
 from qcelemental.util import which, which_import
 
-QCENGINE_RECORDS_COMMIT = "cdb75d2"
+QCENGINE_RECORDS_COMMIT = "f81f0f2"
 
 
 def _check_qcenginerecords(return_data=False):
@@ -152,7 +152,7 @@ _programs = {
     "terachem": which("terachem", return_bool=True),
     "molpro": is_program_new_enough("molpro", "2018.1"),
     "mopac": is_program_new_enough("mopac", "2016"),
-    "entos": is_program_new_enough("entos", "0.7"),
+    "entos": is_program_new_enough("entos", "0.7.1"),
     "cfour": which("xcfour", return_bool=True),
     "gamess": which("rungms", return_bool=True),
     "nwchem": which("nwchem", return_bool=True),

--- a/qcengine/testing.py
+++ b/qcengine/testing.py
@@ -23,7 +23,7 @@ def _check_qcenginerecords(return_data=False):
 
         qcer_hash = qcenginerecords.__git_revision__[:7]
         if qcer_hash != QCENGINE_RECORDS_COMMIT[:7]:
-            msg = f"Incorrect QCEngineRecord Git Revsion, found {qcer_hash} need {QCENGINE_RECORDS_COMMIT[:7]}."
+            msg = f"Incorrect QCEngineRecord Git Revision, found {qcer_hash} need {QCENGINE_RECORDS_COMMIT[:7]}."
         else:
             skip = False
             msg = "Works!"
@@ -152,7 +152,7 @@ _programs = {
     "terachem": which("terachem", return_bool=True),
     "molpro": is_program_new_enough("molpro", "2018.1"),
     "mopac": is_program_new_enough("mopac", "2016"),
-    "entos": is_program_new_enough("entos", "0.6"),
+    "entos": is_program_new_enough("entos", "0.7"),
     "cfour": which("xcfour", return_bool=True),
     "gamess": which("rungms", return_bool=True),
     "nwchem": which("nwchem", return_bool=True),

--- a/qcengine/testing.py
+++ b/qcengine/testing.py
@@ -12,7 +12,7 @@ import qcelemental as qcel
 import qcengine as qcng
 from qcelemental.util import which, which_import
 
-QCENGINE_RECORDS_COMMIT = "854d1fe"
+QCENGINE_RECORDS_COMMIT = "cdb75d2"
 
 
 def _check_qcenginerecords(return_data=False):


### PR DESCRIPTION
Added the HF subcommand to the entos harness and performed some general cleanup. 

- Removed soon to be deprecated options in entos
- Added more keywords for the available commands in the entos harness. Keyword names are copied from the https://www.entos.info/manual only applicable to the energy command. Will need more consideration for how to pass keywords to the gradient and hessian drivers.
- Added entos to the standard suite test for HF
