### PR TITLE
dftd3 variant error

### DIFF
--- a/qcengine/programs/dftd3.py
+++ b/qcengine/programs/dftd3.py
@@ -189,7 +189,7 @@ class DFTD3Harness(ProgramHarness):
         else:
             if not ((real_nat == 1) and (input_model.driver == "gradient")):
                 raise UnknownError(
-                    f"Unsuccessful run. Possibly -D variant not available in dftd3 version. Model: {input_data.model}"
+                    f"Unsuccessful run. Check input, particularly geometry in [a0]. Model: {input_data.model}"
                 )
 
         # parse gradient output


### PR DESCRIPTION
## Description
I'm not able to reproduce #186 easily. And it's true that that error is always user input these days. The variant not available was true in 2016, but those executables should have aged out. I think the `get_version` may even filter them away. So on the basis of the aforementioned hunch, I'm just reclassifying. 

## Questions
- [ ] Should I have changed the error type or just the message?
- [ ] `make format` changed _a lot_, including breaking black on nwchem/harvester. I've seen those changes in other PRs so didn't include them here.

## Status
- [ ] Changelog updated
- [ ] Ready to go