### PR TITLE
Blacken and GHA Linting

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,19 +1,17 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-
+label: Bug
 ---
 
 **Describe the bug**
-A clear and concise description of what the bug is.
+<!-- A clear and concise description of what the bug is. -->
 
 **To Reproduce**
-Code to reproduce the behavior:
-
+<!-- Code to reproduce the behavior: -->
 
 **Expected behavior**
-A clear and concise description of what you expected to happen.
-
+<!-- A clear and concise description of what you expected to happen. -->
 
 **Additional context**
-Add any other context about the problem here.
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,17 +1,17 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-
+label: Feature
 ---
 
 **Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
 
 **Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+<!--A clear and concise description of what you want to happen. -->
 
 **Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+<!--A clear and concise description of any alternative solutions or features you've considered. -->
 
 **Additional context**
-Add any other context or screenshots about the feature request here.
+<!--Add any other context or screenshots about the feature request here. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,12 @@
+<!-- Thank you for your contribution! -->
+
 ## Description
-Provide a brief description of the PR's purpose here.
+<!-- Provide a brief description of the PR's purpose here. -->
 
-## Todos
-Notable points that this PR has either accomplished or will accomplish.
-  - [ ] TODO 1
-
-## Questions
-- [ ] Question1
+## Changelog description
+<!-- Provide a brief single sentence for the changelog. -->
 
 ## Status
-- [ ] Changelog updated
+<!-- Please `pip install .[lint]; make format` in the base folder. -->
+- [ ] Code base linted
 - [ ] Ready to go

--- a/.github/workflows/Lint.yml
+++ b/.github/workflows/Lint.yml
@@ -1,0 +1,29 @@
+name: Lint
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7]
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Python Setup
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Create Environment
+      shell: bash
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install -e '.[lint]'
+
+    - name: Lint
+      shell: bash
+      run: black qcelemental --check
+

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,8 @@ install:
 
 .PHONY: format
 format:
-	$(autoflake)
-	$(isort)
+#	$(autoflake)
+#	$(isort)
 	$(black)
 
 .PHONY: lint

--- a/qcengine/config.py
+++ b/qcengine/config.py
@@ -71,14 +71,19 @@ class NodeDescriptor(pydantic.BaseModel):
     memory_safety_factor: int = 10  # Percentage of memory as a safety factor
 
     # Specifications
-    ncores: Optional[int] = pydantic.Field(None, description="""Number of cores accessible to each task on this node
+    ncores: Optional[int] = pydantic.Field(
+        None,
+        description="""Number of cores accessible to each task on this node
     
-    The default value, ``None``, will allow QCEngine to autodetect the number of cores.""")
+    The default value, ``None``, will allow QCEngine to autodetect the number of cores.""",
+    )
     jobs_per_node: int = 2
     retries: int = 0
 
     # Cluster options
-    is_batch_node: bool = pydantic.Field(False, help="""Whether the node running QCEngine is a batch node
+    is_batch_node: bool = pydantic.Field(
+        False,
+        help="""Whether the node running QCEngine is a batch node
     
     Some clusters are configured such that tasks are launched from a special "batch" or "MOM" onto the compute nodes.
     The compute nodes on such clusters often have a different CPU architecture than the batch nodes and 
@@ -89,9 +94,11 @@ class NodeDescriptor(pydantic.BaseModel):
     
     ``is_batch_node`` is used when creating the task configuration as a means of determining whether
     ``mpiexec_command`` must always be used even for serial jobs (e.g., getting the version number)
-    """)
+    """,
+    )
     mpiexec_command: Optional[str] = pydantic.Field(
-        None, description="""Invocation for launching node-parallel tasks with MPI
+        None,
+        description="""Invocation for launching node-parallel tasks with MPI
         
         The invocation need not specify the number of nodes, tasks, or cores per node.
         Information about the task configuration will be added to the command by use of
@@ -112,7 +119,7 @@ class NodeDescriptor(pydantic.BaseModel):
         ``aprun -n {total_ranks} -N {ranks_per_node} -d {cores_per_rank} -j 1``.
         The appropriate number of ranks per node will be determined based on the number of
         cores per node and the number of cores per rank.
-        """
+        """,
     )
 
     def __init__(self, **data: Dict[str, Any]):
@@ -121,10 +128,10 @@ class NodeDescriptor(pydantic.BaseModel):
 
         if self.mpiexec_command is not None:
             # Ensure that the mpiexec_command contains necessary information
-            if not ('{total_ranks}' in self.mpiexec_command or '{nnodes}' in self.mpiexec_command):
-                raise ValueError('mpiexec_command must contain either {total_ranks} or {nnodes}')
-            if '{ranks_per_node}' not in self.mpiexec_command:
-                raise ValueError('mpiexec_command must explicitly state the number of ranks per node')
+            if not ("{total_ranks}" in self.mpiexec_command or "{nnodes}" in self.mpiexec_command):
+                raise ValueError("mpiexec_command must contain either {total_ranks} or {nnodes}")
+            if "{ranks_per_node}" not in self.mpiexec_command:
+                raise ValueError("mpiexec_command must explicitly state the number of ranks per node")
 
     class Config:
         extra = "forbid"
@@ -301,8 +308,10 @@ def get_config(*, hostname: Optional[str] = None, local_options: Dict[str, Any] 
 
     # Make sure mpirun command is defined if needed
     if config["use_mpiexec"] and config["mpiexec_command"] is None:
-        raise ValueError("You need to define the mpiexec command for this node. "
-                         "See: https://qcengine.readthedocs.io/en/stable/environment.html")
+        raise ValueError(
+            "You need to define the mpiexec command for this node. "
+            "See: https://qcengine.readthedocs.io/en/stable/environment.html"
+        )
 
     return TaskConfig(**config)
 

--- a/qcengine/programs/entos.py
+++ b/qcengine/programs/entos.py
@@ -202,7 +202,7 @@ class EntosHarness(ProgramHarness):
             energy_keywords_from_input_model = {
                 "dft": {"xc": input_model.model.method.upper(), **scf_keywords_from_input_model},
                 "hf": {**scf_keywords_from_input_model},
-                "xtb": {"charge": input_model.molecule.molecular_charge,},
+                "xtb": {"charge": input_model.molecule.molecular_charge},
             }
 
             # Resolve keywords (extra options) for the energy command
@@ -222,22 +222,22 @@ class EntosHarness(ProgramHarness):
                         **structure,
                         **energy_keywords_from_input_model[energy_command],
                         **energy_keywords_extra,
-                    },
+                    }
                 }
             # Create the input dictionary for a gradient call
             elif input_model.driver == "gradient":
                 input_dict = {
                     "gradient": {
                         **structure,
-                        energy_command: {**energy_keywords_from_input_model[energy_command], **energy_keywords_extra,},
-                    },
+                        energy_command: {**energy_keywords_from_input_model[energy_command], **energy_keywords_extra},
+                    }
                 }
             elif input_model.driver == "hessian":
                 input_dict = {
                     "hessian": {
                         **structure,
                         energy_command: {**energy_keywords_from_input_model[energy_command], **energy_keywords_extra},
-                    },
+                    }
                 }
             else:
                 raise NotImplementedError(f"Driver {input_model.driver} not implemented for entos.")

--- a/qcengine/programs/nwchem/germinate.py
+++ b/qcengine/programs/nwchem/germinate.py
@@ -170,8 +170,7 @@ def muster_modelchem(method: str, derint: int, use_tce: bool) -> Tuple[str, Dict
 
     elif method == "tce":
         raise InputError(
-            f"Do not specify TCE as a method. Instead specify the desired method "
-            f'as a keyword and "qc_module=True".'
+            f"Do not specify TCE as a method. Instead specify the desired method " f'as a keyword and "qc_module=True".'
         )
 
     elif method in _xc_functionals:

--- a/qcengine/programs/nwchem/harvester.py
+++ b/qcengine/programs/nwchem/harvester.py
@@ -57,7 +57,7 @@ def harvest_outfile_pass(outtext):
     version = ""
     error = ""  # TODO (wardlt): The error string is never used.
 
-    NUMBER = r'(?x:' + regex.NUMBER + ')'
+    NUMBER = r"(?x:" + regex.NUMBER + ")"
     # fmt: off
 
     # Process version
@@ -590,17 +590,21 @@ def harvest_outfile_pass(outtext):
             psivar['NWCHEM ERROR CODE'] = mobj.group(1)
             # TODO process errors into error var
 
+    # fmt: on
+
     # Get the size of the basis sets, etc
-    mobj = re.search(r'No. of atoms\s+:\s+(\d+)', outtext, re.MULTILINE)
+    mobj = re.search(r"No. of atoms\s+:\s+(\d+)", outtext, re.MULTILINE)
     if mobj:
         psivar["N ATOMS"] = mobj.group(1)
-    mobj = re.search(r"No. of electrons\s+:\s+(\d+)\s+Alpha electrons\s+:\s+(\d+)\s+Beta electrons\s+:\s+(\d+)",
-                     outtext, re.MULTILINE)
+    mobj = re.search(
+        r"No. of electrons\s+:\s+(\d+)\s+Alpha electrons\s+:\s+(\d+)\s+Beta electrons\s+:\s+(\d+)",
+        outtext,
+        re.MULTILINE,
+    )
     if mobj:
         psivar["N ALPHA ELECTRONS"] = mobj.group(2)
         psivar["N BETA ELECTRONS"] = mobj.group(3)
-    mobj = re.search(r"AO basis - number of functions:\s+(\d+)\s+number of shells:\s+(\d+)",
-                     outtext, re.MULTILINE)
+    mobj = re.search(r"AO basis - number of functions:\s+(\d+)\s+number of shells:\s+(\d+)", outtext, re.MULTILINE)
     if mobj:
         psivar["N MO"] = mobj.group(2)
         psivar["N BASIS"] = mobj.group(1)
@@ -670,28 +674,30 @@ def extract_formatted_properties(psivars: PreservingDict) -> AtomicResultPropert
     output = dict()
 
     # Extract the Calc Info
-    output.update({
-        'calcinfo_nbasis': psivars.get('N BASIS', None),
-        'calcinfo_nmo': psivars.get('N MO', None),
-        'calcinfo_natom': psivars.get('N ATOMS', None),
-        'calcinfo_nalpha': psivars.get('N ALPHA ELECTRONS', None),
-        'calcinfo_nbeta': psivars.get('N BETA ELECTRONS', None)
-    })
+    output.update(
+        {
+            "calcinfo_nbasis": psivars.get("N BASIS", None),
+            "calcinfo_nmo": psivars.get("N MO", None),
+            "calcinfo_natom": psivars.get("N ATOMS", None),
+            "calcinfo_nalpha": psivars.get("N ALPHA ELECTRONS", None),
+            "calcinfo_nbeta": psivars.get("N BETA ELECTRONS", None),
+        }
+    )
 
     # Get the "canonical" properties
-    output['return_energy'] = psivars['CURRENT ENERGY']
-    output['nuclear_repulsion_energy'] = psivars['NUCLEAR REPULSION ENERGY']
+    output["return_energy"] = psivars["CURRENT ENERGY"]
+    output["nuclear_repulsion_energy"] = psivars["NUCLEAR REPULSION ENERGY"]
 
     # Get the SCF properties
-    output['scf_total_energy'] = psivars.get('HF TOTAL ENERGY', None)
-    output['scf_one_electron_energy'] = psivars.get('ONE-ELECTRON ENERGY', None)
-    output['scf_two_electron_energy'] = psivars.get('ONE-ELECTRON ENERGY', None)
+    output["scf_total_energy"] = psivars.get("HF TOTAL ENERGY", None)
+    output["scf_one_electron_energy"] = psivars.get("ONE-ELECTRON ENERGY", None)
+    output["scf_two_electron_energy"] = psivars.get("ONE-ELECTRON ENERGY", None)
 
     # Get the MP2 properties
-    output['mp2_total_correlation_energy'] = psivars.get('MP2 CORRELATION ENERGY', None)
-    output['mp2_total_energy'] = psivars.get('MP2 TOTAL ENERGY', None)
-    output['mp2_same_spin_correlation_energy'] = psivars.get('MP2 SAME-SPIN CORRELATION ENERGY', None)
-    output['mp2_opposite_spin_correlation_energy'] = psivars.get('MP2 OPPOSITE-SPIN CORRELATION ENERGY', None)
+    output["mp2_total_correlation_energy"] = psivars.get("MP2 CORRELATION ENERGY", None)
+    output["mp2_total_energy"] = psivars.get("MP2 TOTAL ENERGY", None)
+    output["mp2_same_spin_correlation_energy"] = psivars.get("MP2 SAME-SPIN CORRELATION ENERGY", None)
+    output["mp2_opposite_spin_correlation_energy"] = psivars.get("MP2 OPPOSITE-SPIN CORRELATION ENERGY", None)
     return AtomicResultProperties(**output)
 
 

--- a/qcengine/programs/nwchem/runner.py
+++ b/qcengine/programs/nwchem/runner.py
@@ -73,8 +73,7 @@ class NWChemHarness(ProgramHarness):
         command.append("v.nw")
 
         if which_prog not in self.version_cache:
-            success, output = execute(command, {"v.nw": ""},
-                                      scratch_directory=config.scratch_directory)
+            success, output = execute(command, {"v.nw": ""}, scratch_directory=config.scratch_directory)
 
             if success:
                 for line in output["stdout"].splitlines():

--- a/qcengine/programs/qchem.py
+++ b/qcengine/programs/qchem.py
@@ -374,7 +374,11 @@ $end
                     jobtype = keywords.pop("jobtype")
                 else:
                     jobtype = "sp"
-                _jobtype_to_driver = {"sp": "energy", "force": "gradient", "freq": "hessian"}  # optimization intentionally not supported
+                _jobtype_to_driver = {
+                    "sp": "energy",
+                    "force": "gradient",
+                    "freq": "hessian",
+                }  # optimization intentionally not supported
                 try:
                     input_dict["driver"] = _jobtype_to_driver[jobtype]
                 except KeyError:

--- a/qcengine/programs/tests/test_dftd3_mp2d.py
+++ b/qcengine/programs/tests/test_dftd3_mp2d.py
@@ -6,11 +6,11 @@ import qcelemental as qcel
 from qcelemental.testing import compare, compare_recursive, compare_values, tnm
 
 import qcengine as qcng
-from qcengine import testing
+from qcengine.testing import using, is_program_new_enough
 from qcengine.programs import empirical_dispersion_resources
 
 
-@testing.using("dftd3")
+@using("dftd3")
 @pytest.mark.parametrize("method", ["b3lyp-d3", "b3lyp-d3m", "b3lyp-d3bj", "b3lyp-d3mbj"])
 def test_dftd3_task(method):
     json_data = {"molecule": qcng.get_molecule("eneyne"), "driver": "energy", "model": {"method": method}}
@@ -27,7 +27,7 @@ def test_dftd3_task(method):
     assert ret["success"] is True
 
 
-@testing.using("dftd3")
+@using("dftd3")
 def test_dftd3_error():
     json_data = {
         "molecule": qcng.get_molecule("eneyne"),
@@ -638,7 +638,7 @@ Ne 0 0 0
 
 
 def eneyne_ne_qcdbmols():
-    if not testing.is_program_new_enough("psi4", "1.4a1.dev55"):
+    if not is_program_new_enough("psi4", "1.4a1.dev55"):
         pytest.skip("Psi4 requires at least Psi4 v1.3rc2")
     from psi4.driver import qcdb
 
@@ -658,7 +658,7 @@ def eneyne_ne_qcdbmols():
 
 
 def eneyne_ne_psi4mols():
-    if not testing.is_program_new_enough("psi4", "1.4a1.dev55"):
+    if not is_program_new_enough("psi4", "1.4a1.dev55"):
         pytest.skip("Psi4 requires at least Psi4 v1.3rc2")
     import psi4
 
@@ -814,7 +814,7 @@ def test_dftd3__from_arrays__supplement():
     assert compare_recursive(ans, res, tnm() + " idempotent", atol=1.0e-4)
 
 
-@testing.using("dftd3")
+@using("dftd3")
 def test_3():
     sys = qcel.molparse.from_string(seneyne)["qm"]
 
@@ -833,13 +833,13 @@ def test_3():
     assert compare("B3LYP-D3(BJ)", _compute_key(res["extras"]["local_keywords"]), "key")
 
 
-@testing.using("dftd3")
+@using("dftd3")
 @pytest.mark.parametrize(
     "subjects",
     [
-        pytest.param(eneyne_ne_psi4mols, marks=testing.using("psi4")),
+        pytest.param(eneyne_ne_psi4mols, marks=using("psi4")),
         pytest.param(
-            eneyne_ne_qcdbmols, marks=testing.using("psi4")
+            eneyne_ne_qcdbmols, marks=using("psi4")
         ),  # needs qcdb.Molecule, presently more common in psi4 than in qcdb
     ],
     ids=["qmol", "pmol"],
@@ -860,11 +860,11 @@ def test_3():
         # below two xfail until dftd3 that's only 2-body is out of psi4 proper
         pytest.param(
             {"first": "atmgr", "second": "atmgr", "parent": "eneyne", "subject": "gAmB", "lbl": "ATM"},
-            marks=[testing.using("dftd3_321")],
+            marks=[using("dftd3_321")],
         ),
         pytest.param(
             {"first": "pbe-atmgr", "second": None, "parent": "ne", "subject": "atom", "lbl": "ATM"},
-            marks=[testing.using("dftd3_321")],
+            marks=[using("dftd3_321")],
         ),
     ],
 )
@@ -878,7 +878,7 @@ def test_molecule__run_dftd3__23body(inp, subjects):
     assert compare_values(gexpected, G, atol=1.0e-7)
 
 
-@testing.using("qcdb")
+@using("qcdb")
 def test_qcdb__energy_d3():
     eneyne = qcdb.set_molecule(seneyne)
     eneyne.update_geometry()
@@ -904,13 +904,13 @@ def test_qcdb__energy_d3():
     )
 
 
-@testing.using("mp2d")
+@using("mp2d")
 @pytest.mark.parametrize(
     "subjects",
     [
-        pytest.param(eneyne_ne_psi4mols, marks=testing.using("psi4")),
+        pytest.param(eneyne_ne_psi4mols, marks=using("psi4")),
         pytest.param(
-            eneyne_ne_qcdbmols, marks=testing.using("psi4")
+            eneyne_ne_qcdbmols, marks=using("psi4")
         ),  # needs qcdb.Molecule, presently more common in psi4 than in qcdb
         pytest.param(eneyne_ne_qcschemamols),
     ],
@@ -961,13 +961,13 @@ def test_mp2d__run_mp2d__2body(inp, subjects, request):
     )
 
 
-@testing.using("dftd3")
+@using("dftd3")
 @pytest.mark.parametrize(
     "subjects",
     [
-        pytest.param(eneyne_ne_psi4mols, marks=testing.using("psi4")),
+        pytest.param(eneyne_ne_psi4mols, marks=using("psi4")),
         pytest.param(
-            eneyne_ne_qcdbmols, marks=testing.using("psi4")
+            eneyne_ne_qcdbmols, marks=using("psi4")
         ),  # needs qcdb.Molecule, presently more common in psi4 than in qcdb
         pytest.param(eneyne_ne_qcschemamols),
     ],
@@ -1020,13 +1020,13 @@ def test_dftd3__run_dftd3__2body(inp, subjects, request):
     )
 
 
-@testing.using("dftd3_321")
+@using("dftd3_321")
 @pytest.mark.parametrize(
     "subjects",
     [
-        pytest.param(eneyne_ne_psi4mols, marks=testing.using("psi4")),
+        pytest.param(eneyne_ne_psi4mols, marks=using("psi4")),
         pytest.param(
-            eneyne_ne_qcdbmols, marks=testing.using("psi4")
+            eneyne_ne_qcdbmols, marks=using("psi4")
         ),  # needs qcdb.Molecule, presently more common in psi4 than in qcdb
         pytest.param(eneyne_ne_qcschemamols),
     ],

--- a/qcengine/programs/tests/test_programs.py
+++ b/qcengine/programs/tests/test_programs.py
@@ -8,8 +8,7 @@ import pytest
 from qcelemental.models import AtomicInput, Molecule
 
 import qcengine as qcng
-from qcengine import testing
-from qcengine.testing import failure_engine
+from qcengine.testing import failure_engine, using
 
 
 def test_missing_key():
@@ -23,7 +22,7 @@ def test_missing_key_raises():
         ret = qcng.compute({"hello": "hi"}, "bleh", raise_error=True)
 
 
-@testing.using("psi4")
+@using("psi4")
 def test_psi4_task():
     input_data = {
         "molecule": qcng.get_molecule("water"),
@@ -44,8 +43,8 @@ def test_psi4_task():
     assert ret.success is True
 
 
-@testing.using("psi4")
-@testing.using("gcp")
+@using("psi4")
+@using("gcp")
 def test_psi4_hf3c_task():
     input_data = {
         "molecule": qcng.get_molecule("water"),
@@ -60,7 +59,7 @@ def test_psi4_hf3c_task():
     assert ret.model.basis is None
 
 
-@testing.using("psi4_14")
+@using("psi4_14")
 def test_psi4_interactive_task():
     input_data = {
         "molecule": qcng.get_molecule("water"),
@@ -77,7 +76,7 @@ def test_psi4_interactive_task():
     assert ret.extras.pop("psiapi_evaluated", False)
 
 
-@testing.using("psi4_14")
+@using("psi4_14")
 def test_psi4_wavefunction_task():
     input_data = {
         "molecule": qcng.get_molecule("water"),
@@ -92,7 +91,7 @@ def test_psi4_wavefunction_task():
     assert ret.wavefunction.scf_orbitals_a.shape == (7, 7)
 
 
-@testing.using("psi4")
+@using("psi4")
 def test_psi4_internal_failure():
 
     mol = Molecule.from_data(
@@ -113,7 +112,7 @@ def test_psi4_internal_failure():
     assert "reference is only" in str(exc.value)
 
 
-@testing.using("psi4")
+@using("psi4")
 def test_psi4_ref_switch():
     inp = AtomicInput(
         **{
@@ -131,7 +130,7 @@ def test_psi4_ref_switch():
     assert ret.properties.calcinfo_nbeta == 1
 
 
-@testing.using("rdkit")
+@using("rdkit")
 def test_rdkit_task():
     input_data = {
         "molecule": qcng.get_molecule("water"),
@@ -145,7 +144,7 @@ def test_rdkit_task():
     assert ret.success is True
 
 
-@testing.using("rdkit")
+@using("rdkit")
 def test_rdkit_connectivity_error():
     input_data = {
         "molecule": qcng.get_molecule("water").dict(exclude={"connectivity"}),
@@ -162,7 +161,7 @@ def test_rdkit_connectivity_error():
         qcng.compute(input_data, "rdkit", raise_error=True)
 
 
-@testing.using("torchani")
+@using("torchani")
 def test_torchani_task():
     input_data = {
         "molecule": qcng.get_molecule("water"),
@@ -177,7 +176,7 @@ def test_torchani_task():
     assert ret.driver == "gradient"
 
 
-@testing.using("mopac")
+@using("mopac")
 def test_mopac_task():
     input_data = {
         "molecule": qcng.get_molecule("water"),
@@ -240,7 +239,7 @@ def test_random_failure_with_success(failure_engine):
     assert ret.extras["ncalls"] == 2
 
 
-@testing.using("openmm")
+@using("openmm")
 def test_openmm_task_offxml_basis():
     from qcengine.programs.openmm import OpenMMHarness
 
@@ -266,7 +265,7 @@ def test_openmm_task_offxml_basis():
 
 
 @pytest.mark.skip("`basis` must be explicitly specified at this time")
-@testing.using("openmm")
+@using("openmm")
 def test_openmm_task_offxml_nobasis():
     from qcengine.programs.openmm import OpenMMHarness
 
@@ -291,7 +290,7 @@ def test_openmm_task_offxml_nobasis():
     assert ret.success is True
 
 
-@testing.using("openmm")
+@using("openmm")
 def test_openmm_task_url_basis():
     from qcengine.programs.openmm import OpenMMHarness
 
@@ -321,7 +320,7 @@ def test_openmm_task_url_basis():
 
 
 @pytest.mark.skip("`basis` must be explicitly specified at this time")
-@testing.using("openmm")
+@using("openmm")
 def test_openmm_task_url_nobasis():
     from qcengine.programs.openmm import OpenMMHarness
 

--- a/qcengine/programs/tests/test_standard_suite_ccsd(t).py
+++ b/qcengine/programs/tests/test_standard_suite_ccsd(t).py
@@ -3,7 +3,7 @@ import qcelemental as qcel
 from qcelemental.testing import compare_values
 
 import qcengine as qcng
-from qcengine import testing
+from qcengine.testing import using
 
 
 @pytest.fixture
@@ -34,14 +34,12 @@ def nh2():
 @pytest.mark.parametrize(
     "program,basis,keywords",
     [
-        pytest.param("cfour", "aug-pvdz", {"scf_conv": 12, "cc_conv": 12}, marks=testing.using("cfour")),
-        pytest.param("cfour", "aug-pvdz", {}, marks=testing.using("cfour")),
-        pytest.param("nwchem", "aug-cc-pvdz", {"basis__spherical": True}, marks=testing.using("nwchem")),
-        pytest.param(
-            "nwchem", "aug-cc-pvdz", {"basis__spherical": True, "qc_module": "tce"}, marks=testing.using("nwchem")
-        ),
-        pytest.param("psi4", "aug-cc-pvdz", {}, marks=testing.using("psi4")),
-        pytest.param("gamess", "accd", {"ccinp__ncore": 0, "contrl__ispher": 1}, marks=testing.using("gamess")),
+        pytest.param("cfour", "aug-pvdz", {"scf_conv": 12, "cc_conv": 12}, marks=using("cfour")),
+        pytest.param("cfour", "aug-pvdz", {}, marks=using("cfour")),
+        pytest.param("nwchem", "aug-cc-pvdz", {"basis__spherical": True}, marks=using("nwchem")),
+        pytest.param("nwchem", "aug-cc-pvdz", {"basis__spherical": True, "qc_module": "tce"}, marks=using("nwchem")),
+        pytest.param("psi4", "aug-cc-pvdz", {}, marks=using("psi4")),
+        pytest.param("gamess", "accd", {"ccinp__ncore": 0, "contrl__ispher": 1}, marks=using("gamess")),
     ],
 )
 def test_sp_ccsd_t_rhf_full(program, basis, keywords, h2o):
@@ -72,14 +70,14 @@ def test_sp_ccsd_t_rhf_full(program, basis, keywords, h2o):
             "aug-cc-pvdz",
             {"ccsd__freeze": 1, "scf__uhf": True},
             "ccsd: nopen is not zero",
-            marks=testing.using("nwchem"),
+            marks=using("nwchem"),
         ),
         pytest.param(
             "gamess",
             "accd",
             {"contrl__scftyp": "uhf"},
             "CCTYP IS PROGRAMMED ONLY FOR SCFTYP=RHF OR ROHF",
-            marks=testing.using("gamess"),
+            marks=using("gamess"),
         ),
     ],
 )
@@ -99,11 +97,11 @@ def test_sp_ccsd_t_uhf_fc_error(program, basis, keywords, nh2, errmsg):
             "cfour",
             "aug-pvdz",
             {"reference": "rohf", "occupation": [[3, 1, 1, 0], [3, 0, 1, 0]], "scf_conv": 12, "cc_conv": 12},
-            marks=testing.using("cfour"),
+            marks=using("cfour"),
         ),
-        pytest.param("cfour", "aug-pvdz", {"reference": "rohf"}, marks=testing.using("cfour")),
-        # pytest.param('nwchem', 'aug-cc-pvdz', {'basis__spherical': True, 'qc_module': 'tce', 'scf__rohf': True}, marks=testing.using("nwchem")),
-        pytest.param("psi4", "aug-cc-pvdz", {"reference": "rohf"}, marks=testing.using("psi4")),
+        pytest.param("cfour", "aug-pvdz", {"reference": "rohf"}, marks=using("cfour")),
+        # pytest.param('nwchem', 'aug-cc-pvdz', {'basis__spherical': True, 'qc_module': 'tce', 'scf__rohf': True}, marks=using("nwchem")),
+        pytest.param("psi4", "aug-cc-pvdz", {"reference": "rohf"}, marks=using("psi4")),
     ],
 )
 def test_sp_ccsd_t_rohf_full(program, basis, keywords, nh2):

--- a/qcengine/programs/tests/test_standard_suite_ccsd.py
+++ b/qcengine/programs/tests/test_standard_suite_ccsd.py
@@ -3,7 +3,7 @@ import qcelemental as qcel
 from qcelemental.testing import compare_values
 
 import qcengine as qcng
-from qcengine import testing
+from qcengine.testing import using
 
 
 @pytest.fixture
@@ -35,17 +35,15 @@ def nh2():
 @pytest.mark.parametrize(
     "program,basis,keywords",
     [
-        pytest.param("cfour", "aug-pvdz", {"SCF_CONV": 12, "CC_CONV": 12}, marks=testing.using("cfour")),
-        pytest.param("cfour", "aug-pvdz", {}, marks=testing.using("cfour")),
-        pytest.param("gamess", "accd", {"ccinp__ncore": 0, "contrl__ispher": 1}, marks=testing.using("gamess")),
-        pytest.param("nwchem", "aug-cc-pvdz", {"basis__spherical": True}, marks=testing.using("nwchem")),
-        pytest.param(
-            "nwchem", "aug-cc-pvdz", {"basis__spherical": True, "qc_module": "tce"}, marks=testing.using("nwchem")
-        ),
-        pytest.param("psi4", "aug-cc-pvdz", {}, marks=testing.using("psi4")),
-        # pytest.param("qchem", "aug-cc-pvdz", {"N_FROZEN_CORE": 0}, marks=testing.using("qchem")),
+        pytest.param("cfour", "aug-pvdz", {"SCF_CONV": 12, "CC_CONV": 12}, marks=using("cfour")),
+        pytest.param("cfour", "aug-pvdz", {}, marks=using("cfour")),
+        pytest.param("gamess", "accd", {"ccinp__ncore": 0, "contrl__ispher": 1}, marks=using("gamess")),
+        pytest.param("nwchem", "aug-cc-pvdz", {"basis__spherical": True}, marks=using("nwchem")),
+        pytest.param("nwchem", "aug-cc-pvdz", {"basis__spherical": True, "qc_module": "tce"}, marks=using("nwchem")),
+        pytest.param("psi4", "aug-cc-pvdz", {}, marks=using("psi4")),
+        # pytest.param("qchem", "aug-cc-pvdz", {"N_FROZEN_CORE": 0}, marks=using("qchem")),
         # TODO Molpro has frozen-core on by default. For this to pass need new keyword frozen_core = False
-        # pytest.param('molpro', 'aug-cc-pvdz', {}, marks=testing.using("molpro")),
+        # pytest.param('molpro', 'aug-cc-pvdz', {}, marks=using("molpro")),
     ],
 )
 def test_sp_ccsd_rhf_full(program, basis, keywords, h2o):
@@ -84,14 +82,14 @@ def test_sp_ccsd_rhf_full(program, basis, keywords, h2o):
             "aug-cc-pvdz",
             {"ccsd__freeze": 1, "scf__uhf": True},
             "ccsd: nopen is not zero",
-            marks=testing.using("nwchem"),
+            marks=using("nwchem"),
         ),
         pytest.param(
             "gamess",
             "accd",
             {"contrl__scftyp": "uhf"},
             "CCTYP IS PROGRAMMED ONLY FOR SCFTYP=RHF OR ROHF",
-            marks=testing.using("gamess"),
+            marks=using("gamess"),
         ),
     ],
 )
@@ -111,25 +109,22 @@ def test_sp_ccsd_uhf_fc_error(program, basis, keywords, nh2, errmsg):
             "cfour",
             "AUG-PVDZ",
             {"refERENCE": "ROhf", "OCCUPATION": [[3, 1, 1, 0], [3, 0, 1, 0]], "SCF_CONV": 12, "CC_CONV": 12},
-            marks=testing.using("cfour"),
+            marks=using("cfour"),
         ),
-        pytest.param("cfour", "AUG-PVDZ", {"REFERENCE": "ROHF"}, marks=testing.using("cfour")),
+        pytest.param("cfour", "AUG-PVDZ", {"REFERENCE": "ROHF"}, marks=using("cfour")),
         pytest.param(
-            "gamess",
-            "ACCD",
-            {"CONTRL__ISPHER": 1, "CONTRL__SCFTYP": "ROHF", "CCINP__NCORE": 0},
-            marks=testing.using("gamess"),
+            "gamess", "ACCD", {"CONTRL__ISPHER": 1, "CONTRL__SCFTYP": "ROHF", "CCINP__NCORE": 0}, marks=using("gamess")
         ),
         pytest.param(
             "nwchem",
             "AUG-CC-PVDZ",
             {"BASIS__SPHERICAL": True, "QC_MODULE": "TCE", "SCF__ROHF": True},
-            marks=testing.using("nwchem"),
+            marks=using("nwchem"),
         ),
-        pytest.param("psi4", "AUG-CC-PVDZ", {"REFERENCE": "ROHF"}, marks=testing.using("psi4")),
-        # pytest.param("qchem", "AUG-CC-PVDZ", {"UNRESTRICTED": False}, marks=testing.using("qchem")),
+        pytest.param("psi4", "AUG-CC-PVDZ", {"REFERENCE": "ROHF"}, marks=using("psi4")),
+        # pytest.param("qchem", "AUG-CC-PVDZ", {"UNRESTRICTED": False}, marks=using("qchem")),
         # TODO Molpro has frozen-core on by default. For this to pass need new keyword frozen_core = False
-        # pytest.param('molpro', 'aug-cc-pvdz', {}, marks=testing.using("molpro")),
+        # pytest.param('molpro', 'aug-cc-pvdz', {}, marks=using("molpro")),
     ],
 )
 def test_sp_ccsd_rohf_full(program, basis, keywords, nh2):

--- a/qcengine/programs/tests/test_standard_suite_hf.py
+++ b/qcengine/programs/tests/test_standard_suite_hf.py
@@ -3,7 +3,7 @@ import qcelemental as qcel
 from qcelemental.testing import compare_values
 
 import qcengine as qcng
-from qcengine import testing
+from qcengine.testing import using
 
 
 @pytest.fixture
@@ -35,23 +35,21 @@ def nh2():
 @pytest.mark.parametrize(
     "program,basis,keywords",
     [
-        pytest.param("cfour", "aug-pvdz", {"scf_conv": 12}, marks=testing.using("cfour")),
-        pytest.param("cfour", "aug-pvdz", {}, marks=testing.using("cfour")),
+        pytest.param("cfour", "aug-pvdz", {"scf_conv": 12}, marks=using("cfour")),
+        pytest.param("cfour", "aug-pvdz", {}, marks=using("cfour")),
         pytest.param(
             "entos",
             "aug-cc-pVDZ",
             {"coulomb_method": "direct_4idx", "exchange_method": "direct_4idx"},
-            marks=testing.using("entos"),
+            marks=using("entos"),
         ),
-        pytest.param("gamess", "accd", {"contrl__ispher": 1}, marks=testing.using("gamess")),
-        pytest.param("molpro", "aug-cc-pvdz", {}, marks=testing.using("molpro")),
-        pytest.param("nwchem", "aug-cc-pvdz", {"basis__spherical": True}, marks=testing.using("nwchem")),
-        pytest.param(
-            "nwchem", "aug-cc-pvdz", {"basis__spherical": True, "qc_module": "tce"}, marks=testing.using("nwchem")
-        ),
-        pytest.param("psi4", "aug-cc-pvdz", {"scf_type": "direct"}, marks=testing.using("psi4")),
-        pytest.param("qchem", "aug-cc-pvdz", {}, marks=testing.using("qchem")),
-        pytest.param("turbomole", "aug-cc-pVDZ", {}, marks=testing.using("turbomole")),
+        pytest.param("gamess", "accd", {"contrl__ispher": 1}, marks=using("gamess")),
+        pytest.param("molpro", "aug-cc-pvdz", {}, marks=using("molpro")),
+        pytest.param("nwchem", "aug-cc-pvdz", {"basis__spherical": True}, marks=using("nwchem")),
+        pytest.param("nwchem", "aug-cc-pvdz", {"basis__spherical": True, "qc_module": "tce"}, marks=using("nwchem")),
+        pytest.param("psi4", "aug-cc-pvdz", {"scf_type": "direct"}, marks=using("psi4")),
+        pytest.param("qchem", "aug-cc-pvdz", {}, marks=using("qchem")),
+        pytest.param("turbomole", "aug-cc-pVDZ", {}, marks=using("turbomole")),
     ],
 )
 def test_sp_hf_rhf(program, basis, keywords, h2o):
@@ -81,29 +79,27 @@ def test_sp_hf_rhf(program, basis, keywords, h2o):
             "cfour",
             "aug-pvdz",
             {"reference": "uhf", "occupation": [[3, 1, 1, 0], [3, 0, 1, 0]], "scf_conv": 12},
-            marks=testing.using("cfour"),
+            marks=using("cfour"),
         ),
-        pytest.param("cfour", "aug-pvdz", {"reference": "uhf"}, marks=testing.using("cfour")),
+        pytest.param("cfour", "aug-pvdz", {"reference": "uhf"}, marks=using("cfour")),
         pytest.param(
             "entos",
             "aug-cc-pVDZ",
             {"ansatz": "u", "coulomb_method": "direct_4idx", "exchange_method": "direct_4idx"},
-            marks=testing.using("entos"),
+            marks=using("entos"),
         ),
-        pytest.param("gamess", "accd", {"contrl__ispher": 1, "contrl__scftyp": "uhf"}, marks=testing.using("gamess")),
-        pytest.param("molpro", "aug-cc-pvdz", {"reference": "unrestricted"}, marks=testing.using("molpro")),
-        pytest.param(
-            "nwchem", "aug-cc-pvdz", {"basis__spherical": True, "scf__uhf": True}, marks=testing.using("nwchem")
-        ),
+        pytest.param("gamess", "accd", {"contrl__ispher": 1, "contrl__scftyp": "uhf"}, marks=using("gamess")),
+        pytest.param("molpro", "aug-cc-pvdz", {"reference": "unrestricted"}, marks=using("molpro")),
+        pytest.param("nwchem", "aug-cc-pvdz", {"basis__spherical": True, "scf__uhf": True}, marks=using("nwchem")),
         pytest.param(
             "nwchem",
             "aug-cc-pvdz",
             {"basis__spherical": True, "qc_module": "tce", "scf__uhf": True},
-            marks=testing.using("nwchem"),
+            marks=using("nwchem"),
         ),
-        pytest.param("psi4", "aug-cc-pvdz", {"reference": "uhf", "scf_type": "direct"}, marks=testing.using("psi4")),
-        pytest.param("qchem", "aug-cc-pvdz", {}, marks=testing.using("qchem")),
-        pytest.param("turbomole", "aug-cc-pVDZ", {}, marks=testing.using("turbomole")),
+        pytest.param("psi4", "aug-cc-pvdz", {"reference": "uhf", "scf_type": "direct"}, marks=using("psi4")),
+        pytest.param("qchem", "aug-cc-pvdz", {}, marks=using("qchem")),
+        pytest.param("turbomole", "aug-cc-pVDZ", {}, marks=using("turbomole")),
     ],
 )
 def test_sp_hf_uhf(program, basis, keywords, nh2):
@@ -129,22 +125,20 @@ def test_sp_hf_uhf(program, basis, keywords, nh2):
             "cfour",
             "aug-pvdz",
             {"reference": "rohf", "occupation": [[3, 1, 1, 0], [3, 0, 1, 0]], "scf_conv": 12},
-            marks=testing.using("cfour"),
+            marks=using("cfour"),
         ),
-        pytest.param("cfour", "aug-pvdz", {"reference": "rohf"}, marks=testing.using("cfour")),
-        pytest.param("gamess", "accd", {"contrl__ispher": 1, "contrl__scftyp": "rohf"}, marks=testing.using("gamess")),
-        pytest.param("molpro", "aug-cc-pvdz", {}, marks=testing.using("molpro")),
-        pytest.param(
-            "nwchem", "aug-cc-pvdz", {"basis__spherical": True, "scf__rohf": True}, marks=testing.using("nwchem")
-        ),
+        pytest.param("cfour", "aug-pvdz", {"reference": "rohf"}, marks=using("cfour")),
+        pytest.param("gamess", "accd", {"contrl__ispher": 1, "contrl__scftyp": "rohf"}, marks=using("gamess")),
+        pytest.param("molpro", "aug-cc-pvdz", {}, marks=using("molpro")),
+        pytest.param("nwchem", "aug-cc-pvdz", {"basis__spherical": True, "scf__rohf": True}, marks=using("nwchem")),
         pytest.param(
             "nwchem",
             "aug-cc-pvdz",
             {"basis__spherical": True, "qc_module": "tce", "scf__rohf": True},
-            marks=testing.using("nwchem"),
+            marks=using("nwchem"),
         ),
-        pytest.param("psi4", "aug-cc-pvdz", {"reference": "rohf", "scf_type": "direct"}, marks=testing.using("psi4")),
-        pytest.param("qchem", "aug-cc-pvdz", {"UNRESTRICTED": False}, marks=testing.using("qchem")),
+        pytest.param("psi4", "aug-cc-pvdz", {"reference": "rohf", "scf_type": "direct"}, marks=using("psi4")),
+        pytest.param("qchem", "aug-cc-pvdz", {"UNRESTRICTED": False}, marks=using("qchem")),
     ],
 )
 def test_sp_hf_rohf(program, basis, keywords, nh2):

--- a/qcengine/programs/tests/test_standard_suite_mp2.py
+++ b/qcengine/programs/tests/test_standard_suite_mp2.py
@@ -3,7 +3,7 @@ import qcelemental as qcel
 from qcelemental.testing import compare_values
 
 import qcengine as qcng
-from qcengine import testing
+from qcengine.testing import using
 
 
 @pytest.fixture
@@ -34,17 +34,15 @@ def nh2():
 @pytest.mark.parametrize(
     "program,basis,keywords",
     [
-        pytest.param("cfour", "aug-pvdz", {"scf_conv": 12}, marks=testing.using("cfour")),
-        pytest.param("cfour", "aug-pvdz", {}, marks=testing.using("cfour")),
-        pytest.param("gamess", "accd", {"mp2__nacore": 0, "contrl__ispher": 1}, marks=testing.using("gamess")),
-        pytest.param("nwchem", "aug-cc-pvdz", {"basis__spherical": True}, marks=testing.using("nwchem")),
-        pytest.param(
-            "nwchem", "aug-cc-pvdz", {"basis__spherical": True, "qc_module": "tce"}, marks=testing.using("nwchem")
-        ),
-        pytest.param("psi4", "aug-cc-pvdz", {"mp2_type": "conv"}, marks=testing.using("psi4")),
-        pytest.param("qchem", "aug-cc-pvdz", {"N_FROZEN_CORE": 0}, marks=testing.using("qchem")),
+        pytest.param("cfour", "aug-pvdz", {"scf_conv": 12}, marks=using("cfour")),
+        pytest.param("cfour", "aug-pvdz", {}, marks=using("cfour")),
+        pytest.param("gamess", "accd", {"mp2__nacore": 0, "contrl__ispher": 1}, marks=using("gamess")),
+        pytest.param("nwchem", "aug-cc-pvdz", {"basis__spherical": True}, marks=using("nwchem")),
+        pytest.param("nwchem", "aug-cc-pvdz", {"basis__spherical": True, "qc_module": "tce"}, marks=using("nwchem")),
+        pytest.param("psi4", "aug-cc-pvdz", {"mp2_type": "conv"}, marks=using("psi4")),
+        pytest.param("qchem", "aug-cc-pvdz", {"N_FROZEN_CORE": 0}, marks=using("qchem")),
         # TODO Molpro has frozen-core on by default. For this to pass need keyword frozen_core = False
-        # pytest.param('molpro', 'aug-cc-pvdz', {}, marks=testing.using("molpro")),
+        # pytest.param('molpro', 'aug-cc-pvdz', {}, marks=using("molpro")),
     ],
 )
 def test_sp_mp2_rhf_full(program, basis, keywords, h2o):
@@ -80,31 +78,28 @@ def test_sp_mp2_rhf_full(program, basis, keywords, h2o):
                 "scf_conv": 12,
                 "cc_conv": 12,
             },
-            marks=testing.using("cfour"),
+            marks=using("cfour"),
         ),
-        pytest.param("cfour", "aug-pvdz", {"reference": "uhf", "dropmo": 1}, marks=testing.using("cfour")),
-        pytest.param("gamess", "accd", {"contrl__ispher": 1, "contrl__scftyp": "uhf"}, marks=testing.using("gamess")),
+        pytest.param("cfour", "aug-pvdz", {"reference": "uhf", "dropmo": 1}, marks=using("cfour")),
+        pytest.param("gamess", "accd", {"contrl__ispher": 1, "contrl__scftyp": "uhf"}, marks=using("gamess")),
         pytest.param(
             "nwchem",
             "aug-cc-pvdz",
             {"basis__spherical": True, "qc_module": "tce", "scf__uhf": True, "tce__freeze": 1},
-            marks=testing.using("nwchem"),
+            marks=using("nwchem"),
         ),
         pytest.param(
             "nwchem",
             "aug-cc-pvdz",
             {"basis__spherical": True, "scf__uhf": True, "mp2__freeze": 1},
-            marks=testing.using("nwchem"),
+            marks=using("nwchem"),
         ),
         pytest.param(
-            "psi4",
-            "aug-cc-pvdz",
-            {"reference": "uhf", "freeze_core": True, "mp2_type": "conv"},
-            marks=testing.using("psi4"),
+            "psi4", "aug-cc-pvdz", {"reference": "uhf", "freeze_core": True, "mp2_type": "conv"}, marks=using("psi4")
         ),
-        pytest.param("qchem", "aug-cc-pvdz", {"N_frozen_CORE": "fC"}, marks=testing.using("qchem")),
+        pytest.param("qchem", "aug-cc-pvdz", {"N_frozen_CORE": "fC"}, marks=using("qchem")),
         # TODO Molpro needs a new keyword for unrestricted MP2 (otherwise RMP2 by default) and needs symmetry c1
-        # pytest.param('molpro', 'aug-cc-pvdz', {"reference": "unrestricted"}, marks=testing.using("molpro")),
+        # pytest.param('molpro', 'aug-cc-pvdz', {"reference": "unrestricted"}, marks=using("molpro")),
     ],
 )
 def test_sp_mp2_uhf_fc(program, basis, keywords, nh2):
@@ -125,7 +120,7 @@ def test_sp_mp2_uhf_fc(program, basis, keywords, nh2):
 
 @pytest.mark.parametrize(
     "program,basis,keywords,errmsg",
-    [pytest.param("nwchem", "aug-cc-pvdz", {"scf__rohf": True}, "unknown SCFTYPE", marks=testing.using("nwchem"))],
+    [pytest.param("nwchem", "aug-cc-pvdz", {"scf__rohf": True}, "unknown SCFTYPE", marks=using("nwchem"))],
 )
 def test_sp_mp2_rohf_full_error(program, basis, keywords, nh2, errmsg):
     resi = {"molecule": nh2, "driver": "energy", "model": {"method": "mp2", "basis": basis}, "keywords": keywords}

--- a/qcengine/programs/tests/test_turbomole.py
+++ b/qcengine/programs/tests/test_turbomole.py
@@ -3,8 +3,8 @@ import pytest
 import qcelemental
 from qcelemental.testing import compare_values
 
-import qcengine
-from qcengine import testing
+import qcengine as qcng
+from qcengine.testing import using
 
 
 @pytest.fixture
@@ -22,16 +22,16 @@ def h2o():
 @pytest.mark.parametrize(
     "method, keywords, ref_energy",
     [
-        pytest.param("hf", {}, -75.95536954370, marks=testing.using("turbomole")),
-        pytest.param("pbe0", {"grid": "m5"}, -76.27371135900, marks=testing.using("turbomole")),
-        pytest.param("ricc2", {}, -76.1603807755, marks=testing.using("turbomole")),
-        pytest.param("rimp2", {}, -76.1593614075, marks=testing.using("turbomole")),
+        pytest.param("hf", {}, -75.95536954370, marks=using("turbomole")),
+        pytest.param("pbe0", {"grid": "m5"}, -76.27371135900, marks=using("turbomole")),
+        pytest.param("ricc2", {}, -76.1603807755, marks=using("turbomole")),
+        pytest.param("rimp2", {}, -76.1593614075, marks=using("turbomole")),
     ],
 )
 def test_turbomole_energy(method, keywords, ref_energy, h2o):
     resi = {"molecule": h2o, "driver": "energy", "model": {"method": method, "basis": "def2-SVP"}, "keywords": keywords}
 
-    res = qcengine.compute(resi, "turbomole", raise_error=True, return_dict=True)
+    res = qcng.compute(resi, "turbomole", raise_error=True, return_dict=True)
 
     assert res["driver"] == "energy"
     assert res["success"] is True
@@ -42,10 +42,10 @@ def test_turbomole_energy(method, keywords, ref_energy, h2o):
 @pytest.mark.parametrize(
     "method, keywords, ref_norm",
     [
-        pytest.param("hf", {}, 0.099340, marks=testing.using("turbomole")),
-        pytest.param("pbe0", {"grid": "m5"}, 0.060631, marks=testing.using("turbomole")),
-        pytest.param("ricc2", {}, 0.059378, marks=testing.using("turbomole")),
-        pytest.param("rimp2", {}, 0.061576, marks=testing.using("turbomole")),
+        pytest.param("hf", {}, 0.099340, marks=using("turbomole")),
+        pytest.param("pbe0", {"grid": "m5"}, 0.060631, marks=using("turbomole")),
+        pytest.param("ricc2", {}, 0.059378, marks=using("turbomole")),
+        pytest.param("rimp2", {}, 0.061576, marks=using("turbomole")),
     ],
 )
 def test_turbomole_gradient(method, keywords, ref_norm, h2o):
@@ -56,7 +56,7 @@ def test_turbomole_gradient(method, keywords, ref_norm, h2o):
         "keywords": keywords,
     }
 
-    res = qcengine.compute(resi, "turbomole", raise_error=True)
+    res = qcng.compute(resi, "turbomole", raise_error=True)
 
     assert res.driver == "gradient"
     assert res.success is True
@@ -66,7 +66,7 @@ def test_turbomole_gradient(method, keywords, ref_norm, h2o):
     assert compare_values(ref_norm, grad_norm)
 
 
-@testing.using("turbomole")
+@using("turbomole")
 def test_turbomole_ri_dsp(h2o):
     resi = {
         "molecule": h2o,
@@ -75,7 +75,7 @@ def test_turbomole_ri_dsp(h2o):
         "keywords": {"ri": True, "d3bj": True},
     }
 
-    res = qcengine.compute(resi, "turbomole", raise_error=True)
+    res = qcng.compute(resi, "turbomole", raise_error=True)
 
     assert res.driver == "energy"
     assert res.success is True

--- a/qcengine/tests/test_cli.py
+++ b/qcengine/tests/test_cli.py
@@ -6,7 +6,8 @@ from typing import List
 
 from qcelemental.models import AtomicInput, OptimizationInput
 
-from qcengine import cli, get_molecule, testing, util
+from qcengine import cli, get_molecule, util
+from qcengine.testing import using
 
 
 def run_qcengine_cli(args: List[str], stdin: str = None) -> str:
@@ -55,7 +56,7 @@ def test_info():
         assert output in default_output
 
 
-@testing.using("psi4")
+@using("psi4")
 def test_run_psi4(tmp_path):
     """Tests qcengine run with psi4 and JSON input"""
 
@@ -77,8 +78,8 @@ def test_run_psi4(tmp_path):
     check_result(run_qcengine_cli(args, stdin=inp.json()))
 
 
-@testing.using("geometric")
-@testing.using("psi4")
+@using("geometric")
+@using("psi4")
 def test_run_procedure(tmp_path):
     """Tests qcengine run-procedure with geometric, psi4, and JSON input"""
 

--- a/qcengine/tests/test_config.py
+++ b/qcengine/tests/test_config.py
@@ -85,7 +85,7 @@ def opt_state_basic():
                 "jobs_per_node": 1,
                 "mpiexec_command": "mpirun -n {total_ranks} -N {ranks_per_node}",
                 "ncores": 24,
-                "memory": 240
+                "memory": 240,
             },
             {
                 "name": "default",
@@ -168,24 +168,42 @@ def test_config_local_nnodes(opt_state_basic):
     # Give a warning that mentions that mpirun is needed if you define a multi-node task
     with pytest.raises(ValueError) as exc:
         qcng.config.get_config(hostname="something", local_options={"nnodes": 10})
-    assert 'https://qcengine.readthedocs.io/en/stable/environment.html' in str(exc.value)
+    assert "https://qcengine.readthedocs.io/en/stable/environment.html" in str(exc.value)
 
     # Test with an MPI run command
-    local_options = {"nnodes": 4,
-                     "mpiexec_command": "mpirun -n {total_ranks} -N {ranks_per_node} --cpus-per-slot {cores_per_rank}"}
+    local_options = {
+        "nnodes": 4,
+        "mpiexec_command": "mpirun -n {total_ranks} -N {ranks_per_node} --cpus-per-slot {cores_per_rank}",
+    }
     config = qcng.config.get_config(hostname="something", local_options=local_options)
     assert config.use_mpiexec
-    assert config.mpiexec_command.startswith('mpirun')
-    assert create_mpi_invocation('hello_world', config) == ['mpirun', '-n', '20', '-N', '5', '--cpus-per-slot', '1',
-                                                            'hello_world']
+    assert config.mpiexec_command.startswith("mpirun")
+    assert create_mpi_invocation("hello_world", config) == [
+        "mpirun",
+        "-n",
+        "20",
+        "-N",
+        "5",
+        "--cpus-per-slot",
+        "1",
+        "hello_world",
+    ]
 
     # Change the number of cores per rank
     local_options["cores_per_rank"] = 2
-    config = qcng.config.get_config(hostname='something', local_options=local_options)
+    config = qcng.config.get_config(hostname="something", local_options=local_options)
     assert config.use_mpiexec
-    assert config.mpiexec_command.startswith('mpirun')
-    assert create_mpi_invocation('hello_world', config) == ['mpirun', '-n', '20', '-N', '2', '--cpus-per-slot', '2',
-                                                            'hello_world']
+    assert config.mpiexec_command.startswith("mpirun")
+    assert create_mpi_invocation("hello_world", config) == [
+        "mpirun",
+        "-n",
+        "20",
+        "-N",
+        "2",
+        "--cpus-per-slot",
+        "2",
+        "hello_world",
+    ]
 
 
 def test_config_validation(opt_state_basic):
@@ -204,7 +222,7 @@ def test_batch_node(opt_state_basic):
     assert config.ncores == 24
     assert config.nnodes == 1
 
-    config = qcng.config.get_config(hostname="bn1", local_options={'nnodes': 2})
+    config = qcng.config.get_config(hostname="bn1", local_options={"nnodes": 2})
     assert config.use_mpiexec
     assert config.ncores == 24
     assert config.nnodes == 2
@@ -214,9 +232,8 @@ def test_mpirun_command_errors():
     # Checks for ranks_per_node
     with pytest.raises(ValueError) as exc:
         NodeDescriptor(name="something", hostname_pattern="*", mpiexec_command="mpirun -n {total_ranks}")
-    assert 'must explicitly state' in str(exc.value)
+    assert "must explicitly state" in str(exc.value)
 
     with pytest.raises(ValueError) as exc:
         NodeDescriptor(name="something", hostname_pattern="*", mpiexec_command="mpirun -N {ranks_per_node}")
-    assert 'must contain either' in str(exc.value)
-
+    assert "must contain either" in str(exc.value)

--- a/qcengine/tests/test_harness_canonical.py
+++ b/qcengine/tests/test_harness_canonical.py
@@ -8,7 +8,7 @@ import pytest
 from qcelemental.models import AtomicInput
 
 import qcengine as qcng
-from qcengine import testing
+from qcengine.testing import has_program
 
 _canonical_methods = [
     ("dftd3", {"method": "b3lyp-d3"}),
@@ -26,7 +26,7 @@ _canonical_methods = [
 
 @pytest.mark.parametrize("program, model", _canonical_methods)
 def test_compute_energy(program, model):
-    if not testing.has_program(program):
+    if not has_program(program):
         pytest.skip("Program '{}' not found.".format(program))
 
     inp = AtomicInput(molecule=qcng.get_molecule("hydrogen"), driver="energy", model=model)
@@ -38,7 +38,7 @@ def test_compute_energy(program, model):
 
 @pytest.mark.parametrize("program, model", _canonical_methods)
 def test_compute_gradient(program, model):
-    if not testing.has_program(program):
+    if not has_program(program):
         pytest.skip("Program '{}' not found.".format(program))
 
     inp = AtomicInput(
@@ -69,7 +69,7 @@ def test_compute_gradient(program, model):
     ],
 )
 def test_compute_bad_models(program, model):
-    if not testing.has_program(program):
+    if not has_program(program):
         pytest.skip("Program '{}' not found.".format(program))
 
     adriver = model.pop("driver", "energy")

--- a/qcengine/tests/test_mdi.py
+++ b/qcengine/tests/test_mdi.py
@@ -6,11 +6,11 @@ Tests the MDI interface
 from qcelemental.testing import compare_values
 
 import qcengine as qcng
-from qcengine import testing
+from qcengine.testing import using
 
 
-@testing.using("psi4")
-@testing.using("mdi")
+@using("psi4")
+@using("mdi")
 def test_mdi_water():
     json_data = {
         "molecule": qcng.get_molecule("water"),

--- a/qcengine/tests/test_procedures.py
+++ b/qcengine/tests/test_procedures.py
@@ -6,8 +6,7 @@ import pytest
 from qcelemental.models import OptimizationInput
 
 import qcengine as qcng
-from qcengine import testing
-from qcengine.testing import failure_engine
+from qcengine.testing import failure_engine, using
 
 
 @pytest.fixture(scope="function")
@@ -19,8 +18,8 @@ def input_data():
     }
 
 
-@testing.using("psi4")
-@testing.using("geometric")
+@using("psi4")
+@using("geometric")
 def test_geometric_psi4(input_data):
 
     input_data["initial_molecule"] = qcng.get_molecule("hydrogen")
@@ -43,8 +42,8 @@ def test_geometric_psi4(input_data):
         assert "WIBERG_LOWDIN_INDICES" in single.extras["qcvars"]
 
 
-@testing.using("psi4")
-@testing.using("geometric")
+@using("psi4")
+@using("geometric")
 def test_geometric_local_options(input_data):
 
     input_data["initial_molecule"] = qcng.get_molecule("hydrogen")
@@ -62,8 +61,8 @@ def test_geometric_local_options(input_data):
     assert "_qcengine_local_config" not in ret.trajectory[0].extras
 
 
-@testing.using("rdkit")
-@testing.using("geometric")
+@using("rdkit")
+@using("geometric")
 def test_geometric_stdout(input_data):
 
     input_data["initial_molecule"] = qcng.get_molecule("water")
@@ -77,8 +76,8 @@ def test_geometric_stdout(input_data):
     assert "Converged!" in ret.stdout
 
 
-@testing.using("geometric")
-@testing.using("rdkit")
+@using("geometric")
+@using("rdkit")
 def test_geometric_rdkit_error(input_data):
 
     input_data["initial_molecule"] = qcng.get_molecule("water").copy(exclude={"connectivity"})
@@ -92,8 +91,8 @@ def test_geometric_rdkit_error(input_data):
     assert isinstance(ret.error.error_message, str)
 
 
-@testing.using("rdkit")
-@testing.using("geometric")
+@using("rdkit")
+@using("geometric")
 def test_optimization_protocols(input_data):
 
     input_data["initial_molecule"] = qcng.get_molecule("water")
@@ -111,8 +110,8 @@ def test_optimization_protocols(input_data):
     assert ret.final_molecule.get_hash() == ret.trajectory[1].molecule.get_hash()
 
 
-@testing.using("geometric")
-@testing.using("rdkit")
+@using("geometric")
+@using("rdkit")
 def test_geometric_retries(failure_engine, input_data):
 
     failure_engine.iter_modes = ["random_error", "pass", "random_error", "random_error", "pass"]  # Iter 1  # Iter 2
@@ -143,27 +142,24 @@ def test_geometric_retries(failure_engine, input_data):
     assert len(ret.input_data["trajectory"]) == 2
 
 
-@testing.using("geometric")
+@using("geometric")
 @pytest.mark.parametrize(
     "program, model, bench",
     [
         pytest.param(
-            "rdkit",
-            {"method": "UFF"},
-            [1.87130923886072, 2.959448636243545, 104.5099642579023],
-            marks=testing.using("rdkit"),
+            "rdkit", {"method": "UFF"}, [1.87130923886072, 2.959448636243545, 104.5099642579023], marks=using("rdkit")
         ),
         pytest.param(
             "torchani",
             {"method": "ANI1x"},
             [1.82581873750194, 2.866376526793269, 103.4332610730292],
-            marks=testing.using("torchani"),
+            marks=using("torchani"),
         ),
         pytest.param(
             "mopac",
             {"method": "PM6"},
             [1.7927843431811934, 2.893333237502448, 107.60441967992045],
-            marks=testing.using("mopac"),
+            marks=using("mopac"),
         ),
     ],
 )

--- a/qcengine/tests/test_program_utils.py
+++ b/qcengine/tests/test_program_utils.py
@@ -5,7 +5,7 @@ Tests the DQM compute dispatch module
 import pytest
 
 import qcengine as qcng
-from qcengine import testing
+from qcengine.testing import using
 
 
 def test_list_programs():
@@ -17,9 +17,9 @@ def test_list_programs():
 @pytest.mark.parametrize(
     "program",
     [
-        pytest.param("psi4", marks=testing.using("psi4")),
-        pytest.param("torchani", marks=testing.using("torchani")),
-        pytest.param("rdkit", marks=testing.using("rdkit")),
+        pytest.param("psi4", marks=using("psi4")),
+        pytest.param("torchani", marks=using("torchani")),
+        pytest.param("rdkit", marks=using("rdkit")),
     ],
 )
 def test_check_program_avail(program):
@@ -41,7 +41,7 @@ def test_list_procedures():
     assert r >= {"geometric"}
 
 
-@pytest.mark.parametrize("procedure", [pytest.param("geometric", marks=testing.using("geometric"))])
+@pytest.mark.parametrize("procedure", [pytest.param("geometric", marks=using("geometric"))])
 def test_check_procedure_avail(procedure):
 
     assert procedure in qcng.list_available_procedures()

--- a/qcengine/tests/test_utils.py
+++ b/qcengine/tests/test_utils.py
@@ -79,13 +79,13 @@ def test_disk_files():
 
 def test_popen_tee_output(capsys):
     # Test without passing
-    with util.popen(['echo', 'hello']) as proc:
-        proc['proc'].wait()
-    assert proc['stdout'].strip() == 'hello'
+    with util.popen(["echo", "hello"]) as proc:
+        proc["proc"].wait()
+    assert proc["stdout"].strip() == "hello"
 
     # Test with passing
-    with util.popen(['echo', 'hello'], pass_output_forward=True) as proc:
-        proc['proc'].wait()
-    assert proc['stdout'] == 'hello\n'
+    with util.popen(["echo", "hello"], pass_output_forward=True) as proc:
+        proc["proc"].wait()
+    assert proc["stdout"] == "hello\n"
     captured = capsys.readouterr()
-    assert captured.out == 'hello\n'
+    assert captured.out == "hello\n"

--- a/qcengine/util.py
+++ b/qcengine/util.py
@@ -44,7 +44,7 @@ def create_mpi_invocation(executable: str, task_config: TaskConfig) -> List[str]
         nnodes=task_config.nnodes,
         ranks_per_node=task_config.ncores // task_config.cores_per_rank,
         total_ranks=task_config.nnodes * task_config.ncores,
-        cores_per_rank=task_config.cores_per_rank
+        cores_per_rank=task_config.cores_per_rank,
     )
     command = mpirun_str.split()
 
@@ -218,8 +218,12 @@ def terminate_process(proc: Any, timeout: int = 15) -> None:
 
 
 @contextmanager
-def popen(args: List[str], append_prefix: bool = False, popen_kwargs: Optional[Dict[str, Any]] = None,
-          pass_output_forward: bool = False) -> Dict[str, Any]:
+def popen(
+    args: List[str],
+    append_prefix: bool = False,
+    popen_kwargs: Optional[Dict[str, Any]] = None,
+    pass_output_forward: bool = False,
+) -> Dict[str, Any]:
     """
     Opens a background task
 
@@ -287,10 +291,11 @@ def popen(args: List[str], append_prefix: bool = False, popen_kwargs: Optional[D
     #  from the buffers to ensure that they do not fill.
     #
     def read_from_buffer(buffer: BinaryIO, storage: io.BytesIO, sysio: TextIO):
-        for r in iter(partial(buffer.read, 1024), b''):
+        for r in iter(partial(buffer.read, 1024), b""):
             storage.write(r)
             if pass_output_forward:
                 sysio.write(r.decode())
+
     stdout_reader = Thread(target=read_from_buffer, args=(ret["proc"].stdout, stdout, sys.stdout))
     stdout_reader.start()
     stderr_reader = Thread(target=read_from_buffer, args=(ret["proc"].stderr, stderr, sys.stderr))

--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,13 @@ import sys
 import setuptools
 import versioneer
 
-short_description = "QCEngine provides a wrapper to ingest and produce QCSchema for a variety of quantum chemistry programs."
+short_description = (
+    "QCEngine provides a wrapper to ingest and produce QCSchema for a variety of quantum chemistry programs."
+)
 
 # from https://github.com/pytest-dev/pytest-runner#conditional-requirement
-needs_pytest = {'pytest', 'test', 'ptr'}.intersection(sys.argv)
-pytest_runner = ['pytest-runner'] if needs_pytest else []
+needs_pytest = {"pytest", "test", "ptr"}.intersection(sys.argv)
+pytest_runner = ["pytest-runner"] if needs_pytest else []
 
 try:
     with open("README.md", "r") as handle:
@@ -16,51 +18,38 @@ except FileNotFoundError:
 
 if __name__ == "__main__":
     setuptools.setup(
-        name='qcengine',
-        description='A compute wrapper for Quantum Chemistry.',
-        author='The QCArchive Development Team',
-        author_email='qcarchive@molssi.org',
+        name="qcengine",
+        description="A compute wrapper for Quantum Chemistry.",
+        author="The QCArchive Development Team",
+        author_email="qcarchive@molssi.org",
         url="https://github.com/MolSSI/QCEngine",
-        license='BSD-3C',
+        license="BSD-3C",
         version=versioneer.get_version(),
         cmdclass=versioneer.get_cmdclass(),
         packages=setuptools.find_packages(),
         setup_requires=[] + pytest_runner,
-        install_requires=[
-            'pyyaml',
-            'py-cpuinfo',
-            'psutil',
-            'qcelemental>=0.12.0',
-            'pydantic>=1.0.0'
-        ],
-        entry_points={"console_scripts": [
-            "qcengine=qcengine.cli:main",
-        ]},
+        install_requires=["pyyaml", "py-cpuinfo", "psutil", "qcelemental>=0.12.0", "pydantic>=1.0.0"],
+        entry_points={"console_scripts": ["qcengine=qcengine.cli:main"]},
         extras_require={
-            'docs': [
-                'sphinx==1.2.3',  # autodoc was broken in 1.3.1
-                'sphinxcontrib-napoleon',
-                'sphinx_rtd_theme',
-                'numpydoc',
+            "docs": [
+                "sphinx==1.2.3",  # autodoc was broken in 1.3.1
+                "sphinxcontrib-napoleon",
+                "sphinx_rtd_theme",
+                "numpydoc",
             ],
-            'tests': [
-                'pytest',
-                'pytest-cov',
-            ],
+            "tests": ["pytest", "pytest-cov"],
+            "lint": ["black"],
         },
-        tests_require=[
-            'pytest',
-            'pytest-cov',
-        ],
+        tests_require=["pytest", "pytest-cov"],
         classifiers=[
-            'Development Status :: 4 - Beta',
-            'Intended Audience :: Science/Research',
-            'Programming Language :: Python :: 3 :: Only',
-            'Programming Language :: Python :: 3',
-            'Programming Language :: Python :: 3.6',
-            'Programming Language :: Python :: 3.7',
+            "Development Status :: 4 - Beta",
+            "Intended Audience :: Science/Research",
+            "Programming Language :: Python :: 3 :: Only",
+            "Programming Language :: Python :: 3",
+            "Programming Language :: Python :: 3.6",
+            "Programming Language :: Python :: 3.7",
         ],
         zip_safe=False,
         long_description=long_description,
-        long_description_content_type="text/markdown"
+        long_description_content_type="text/markdown",
     )


### PR DESCRIPTION
## Description
Updates several GitHub templates to QCArchive standard. Reblackens the code base and fixes the error with black on nwchem files (fmt on/off not paired), this also adds a GHA check for black as well.

## Status
- [ ] Changelog updated
- [x] Ready to go