### PR TITLE
psi4 windows version and outfile psiapi mode

### DIFF
--- a/qcengine/programs/psi4.py
+++ b/qcengine/programs/psi4.py
@@ -41,8 +41,6 @@ class Psi4Harness(ProgramHarness):
         self.found(raise_error=True)
 
         which_prog = which("psi4")
-        with popen([which_prog, "--version"]) as exc:
-            exc["proc"].wait(timeout=30)
         if which_prog not in self.version_cache:
             with popen([which_prog, "--version"]) as exc:
                 exc["proc"].wait(timeout=30)
@@ -154,6 +152,7 @@ class Psi4Harness(ProgramHarness):
                     psi4.set_memory(f"{config.memory}GB", quiet=True)
                     psi4.core.IOManager.shared_object().set_default_path(str(tmpdir))
                     output_data = psi4.schema_wrapper.run_qcschema(input_model).dict()
+                    print(output_data)
                     output_data["extras"]["psiapi_evaluated"] = True
                     success = True
                     psi4.core.IOManager.shared_object().set_default_path(orig_scr)

--- a/qcengine/programs/psi4.py
+++ b/qcengine/programs/psi4.py
@@ -64,7 +64,6 @@ class Psi4Harness(ProgramHarness):
 
         if pversion < parse_version("1.2"):
             raise ResourceError("Psi4 version '{}' not understood.".format(self.get_version()))
-        print("VERSION", self.get_version(), pversion, parse_version("1.4a2.dev160"), pversion < parse_version("1.4a2.dev160"))
 
         # Location resolution order config.scratch_dir, $PSI_SCRATCH, /tmp
         parent = config.scratch_directory
@@ -87,7 +86,6 @@ class Psi4Harness(ProgramHarness):
 
             # Old-style JSON-based command line
             if pversion < parse_version("1.4a2.dev160"):
-                print("hit old")
 
                 # Setup the job
                 input_data = input_model.dict(encoding="json")
@@ -146,7 +144,6 @@ class Psi4Harness(ProgramHarness):
             else:
 
                 if input_model.extras.get("psiapi", False):
-                    print("hit new psiapi")
                     import psi4
 
                     orig_scr = psi4.core.IOManager.shared_object().get_default_path()
@@ -154,12 +151,10 @@ class Psi4Harness(ProgramHarness):
                     psi4.set_memory(f"{config.memory}GB", quiet=True)
                     psi4.core.IOManager.shared_object().set_default_path(str(tmpdir))
                     output_data = psi4.schema_wrapper.run_qcschema(input_model, postclean=False).dict()
-                    print(output_data["extras"])
                     output_data["extras"]["psiapi_evaluated"] = True
                     success = True
                     psi4.core.IOManager.shared_object().set_default_path(orig_scr)
                 else:
-                    print("hit new psithon")
                     run_cmd = [
                         which("psi4"),
                         "--scratch",

--- a/qcengine/programs/psi4.py
+++ b/qcengine/programs/psi4.py
@@ -152,7 +152,7 @@ class Psi4Harness(ProgramHarness):
                     psi4.set_memory(f"{config.memory}GB", quiet=True)
                     psi4.core.IOManager.shared_object().set_default_path(str(tmpdir))
                     output_data = psi4.schema_wrapper.run_qcschema(input_model).dict()
-                    print(output_data)
+                    print(output_data["extras"])
                     output_data["extras"]["psiapi_evaluated"] = True
                     success = True
                     psi4.core.IOManager.shared_object().set_default_path(orig_scr)

--- a/qcengine/programs/psi4.py
+++ b/qcengine/programs/psi4.py
@@ -158,7 +158,7 @@ class Psi4Harness(ProgramHarness):
                     run_cmd = [
                         which("psi4"),
                         "--scratch",
-                        tmpdir,
+                        str(tmpdir),
                         "--nthread",
                         str(config.ncores),
                         "--memory",

--- a/qcengine/programs/psi4.py
+++ b/qcengine/programs/psi4.py
@@ -151,7 +151,7 @@ class Psi4Harness(ProgramHarness):
                     psi4.core.set_num_threads(config.ncores, quiet=True)
                     psi4.set_memory(f"{config.memory}GB", quiet=True)
                     psi4.core.IOManager.shared_object().set_default_path(str(tmpdir))
-                    output_data = psi4.schema_wrapper.run_qcschema(input_model).dict()
+                    output_data = psi4.schema_wrapper.run_qcschema(input_model, postclean=False).dict()
                     print(output_data["extras"])
                     output_data["extras"]["psiapi_evaluated"] = True
                     success = True

--- a/qcengine/programs/psi4.py
+++ b/qcengine/programs/psi4.py
@@ -151,7 +151,6 @@ class Psi4Harness(ProgramHarness):
                     psi4.set_memory(f"{config.memory}GB", quiet=True)
                     # psi4.core.IOManager.shared_object().set_default_path(str(tmpdir))
                     output_data = psi4.schema_wrapper.run_qcschema(input_model, postclean=False).dict()
-                    # output_data = psi4.schema_wrapper.run_qcschema(input_model).dict()
                     output_data["extras"]["psiapi_evaluated"] = True
                     success = True
                     psi4.core.IOManager.shared_object().set_default_path(orig_scr)

--- a/qcengine/programs/psi4.py
+++ b/qcengine/programs/psi4.py
@@ -153,7 +153,7 @@ class Psi4Harness(ProgramHarness):
                     psi4.core.IOManager.shared_object().set_default_path(str(tmpdir))
                     output_data = psi4.schema_wrapper.run_qcschema(input_model, postclean=False).dict()
                     print(output_data["extras"])
-                    output_data["extras"]["psiapi_evaluated"] = True
+                    #output_data["extras"]["psiapi_evaluated"] = True
                     success = True
                     psi4.core.IOManager.shared_object().set_default_path(orig_scr)
                 else:

--- a/qcengine/programs/psi4.py
+++ b/qcengine/programs/psi4.py
@@ -149,9 +149,9 @@ class Psi4Harness(ProgramHarness):
                     orig_scr = psi4.core.IOManager.shared_object().get_default_path()
                     psi4.core.set_num_threads(config.ncores, quiet=True)
                     psi4.set_memory(f"{config.memory}GB", quiet=True)
-                    #psi4.core.IOManager.shared_object().set_default_path(str(tmpdir))
-                    #output_data = psi4.schema_wrapper.run_qcschema(input_model, postclean=False).dict()
-                    output_data = psi4.schema_wrapper.run_qcschema(input_model).dict()
+                    # psi4.core.IOManager.shared_object().set_default_path(str(tmpdir))
+                    output_data = psi4.schema_wrapper.run_qcschema(input_model, postclean=False).dict()
+                    # output_data = psi4.schema_wrapper.run_qcschema(input_model).dict()
                     output_data["extras"]["psiapi_evaluated"] = True
                     success = True
                     psi4.core.IOManager.shared_object().set_default_path(orig_scr)

--- a/qcengine/programs/psi4.py
+++ b/qcengine/programs/psi4.py
@@ -47,12 +47,12 @@ class Psi4Harness(ProgramHarness):
         with popen([which_prog, "--version"]) as exc:
             exc["proc"].wait(timeout=30)
         print("v2:", exc["stdout"])
-        print("v3:", exc["stdout"].strip())
         print("v4:", safe_version(exc["stdout"]))
+        print("v5:", safe_version(exc["stdout"].split()[-1]))
         if which_prog not in self.version_cache:
             with popen([which_prog, "--version"]) as exc:
                 exc["proc"].wait(timeout=30)
-            self.version_cache[which_prog] = safe_version(exc["stdout"])
+            self.version_cache[which_prog] = safe_version(exc["stdout"].split()[-1])
 
         candidate_version = self.version_cache[which_prog]
 

--- a/qcengine/programs/psi4.py
+++ b/qcengine/programs/psi4.py
@@ -64,6 +64,7 @@ class Psi4Harness(ProgramHarness):
 
         if pversion < parse_version("1.2"):
             raise ResourceError("Psi4 version '{}' not understood.".format(self.get_version()))
+        print("VERSION", self.get_version(), pversion, parse_version("1.4a2.dev160"), pversion < parse_version("1.4a2.dev160"))
 
         # Location resolution order config.scratch_dir, $PSI_SCRATCH, /tmp
         parent = config.scratch_directory
@@ -86,6 +87,7 @@ class Psi4Harness(ProgramHarness):
 
             # Old-style JSON-based command line
             if pversion < parse_version("1.4a2.dev160"):
+                print("hit old")
 
                 # Setup the job
                 input_data = input_model.dict(encoding="json")
@@ -144,19 +146,20 @@ class Psi4Harness(ProgramHarness):
             else:
 
                 if input_model.extras.get("psiapi", False):
+                    print("hit new psiapi")
                     import psi4
 
                     orig_scr = psi4.core.IOManager.shared_object().get_default_path()
-
                     psi4.core.set_num_threads(config.ncores, quiet=True)
                     psi4.set_memory(f"{config.memory}GB", quiet=True)
                     psi4.core.IOManager.shared_object().set_default_path(str(tmpdir))
                     output_data = psi4.schema_wrapper.run_qcschema(input_model, postclean=False).dict()
                     print(output_data["extras"])
-                    #output_data["extras"]["psiapi_evaluated"] = True
+                    output_data["extras"]["psiapi_evaluated"] = True
                     success = True
                     psi4.core.IOManager.shared_object().set_default_path(orig_scr)
                 else:
+                    print("hit new psithon")
                     run_cmd = [
                         which("psi4"),
                         "--scratch",

--- a/qcengine/programs/psi4.py
+++ b/qcengine/programs/psi4.py
@@ -30,7 +30,6 @@ class Psi4Harness(ProgramHarness):
 
     @staticmethod
     def found(raise_error: bool = False) -> bool:
-        print("qcng:  ", which("psi4"))
         return which(
             "psi4",
             return_bool=True,
@@ -42,13 +41,8 @@ class Psi4Harness(ProgramHarness):
         self.found(raise_error=True)
 
         which_prog = which("psi4")
-        print("v0:", which_prog)
-        print("v1:", self.version_cache)
         with popen([which_prog, "--version"]) as exc:
             exc["proc"].wait(timeout=30)
-        print("v2:", exc["stdout"])
-        print("v4:", safe_version(exc["stdout"]))
-        print("v5:", safe_version(exc["stdout"].split()[-1]))
         if which_prog not in self.version_cache:
             with popen([which_prog, "--version"]) as exc:
                 exc["proc"].wait(timeout=30)
@@ -159,7 +153,6 @@ class Psi4Harness(ProgramHarness):
                     psi4.core.set_num_threads(config.ncores, quiet=True)
                     psi4.set_memory(f"{config.memory}GB", quiet=True)
                     psi4.core.IOManager.shared_object().set_default_path(str(tmpdir))
-                    print("scratchE", psi4.core.IOManager.shared_object().get_default_path())
                     output_data = psi4.schema_wrapper.run_qcschema(input_model).dict()
                     output_data["extras"]["psiapi_evaluated"] = True
                     success = True

--- a/qcengine/programs/psi4.py
+++ b/qcengine/programs/psi4.py
@@ -146,14 +146,14 @@ class Psi4Harness(ProgramHarness):
                 if input_model.extras.get("psiapi", False):
                     import psi4
 
-                    orig_scr = psi4.core.IOManager.shared_object().get_default_path()
-                    psi4.core.set_num_threads(config.ncores, quiet=True)
-                    psi4.set_memory(f"{config.memory}GB", quiet=True)
+                    #orig_scr = psi4.core.IOManager.shared_object().get_default_path()
+                    #psi4.core.set_num_threads(config.ncores, quiet=True)
+                    #psi4.set_memory(f"{config.memory}GB", quiet=True)
                     psi4.core.IOManager.shared_object().set_default_path(str(tmpdir))
                     output_data = psi4.schema_wrapper.run_qcschema(input_model, postclean=False).dict()
-                    output_data["extras"]["psiapi_evaluated"] = True
+                    #output_data["extras"]["psiapi_evaluated"] = True
                     success = True
-                    psi4.core.IOManager.shared_object().set_default_path(orig_scr)
+                    #psi4.core.IOManager.shared_object().set_default_path(orig_scr)
                 else:
                     run_cmd = [
                         which("psi4"),

--- a/qcengine/programs/psi4.py
+++ b/qcengine/programs/psi4.py
@@ -149,8 +149,9 @@ class Psi4Harness(ProgramHarness):
                     #orig_scr = psi4.core.IOManager.shared_object().get_default_path()
                     #psi4.core.set_num_threads(config.ncores, quiet=True)
                     #psi4.set_memory(f"{config.memory}GB", quiet=True)
-                    psi4.core.IOManager.shared_object().set_default_path(str(tmpdir))
-                    output_data = psi4.schema_wrapper.run_qcschema(input_model, postclean=False).dict()
+                    #psi4.core.IOManager.shared_object().set_default_path(str(tmpdir))
+                    #output_data = psi4.schema_wrapper.run_qcschema(input_model, postclean=False).dict()
+                    output_data = psi4.schema_wrapper.run_qcschema(input_model).dict()
                     #output_data["extras"]["psiapi_evaluated"] = True
                     success = True
                     #psi4.core.IOManager.shared_object().set_default_path(orig_scr)

--- a/qcengine/programs/psi4.py
+++ b/qcengine/programs/psi4.py
@@ -146,15 +146,15 @@ class Psi4Harness(ProgramHarness):
                 if input_model.extras.get("psiapi", False):
                     import psi4
 
-                    #orig_scr = psi4.core.IOManager.shared_object().get_default_path()
-                    #psi4.core.set_num_threads(config.ncores, quiet=True)
-                    #psi4.set_memory(f"{config.memory}GB", quiet=True)
+                    orig_scr = psi4.core.IOManager.shared_object().get_default_path()
+                    psi4.core.set_num_threads(config.ncores, quiet=True)
+                    psi4.set_memory(f"{config.memory}GB", quiet=True)
                     #psi4.core.IOManager.shared_object().set_default_path(str(tmpdir))
                     #output_data = psi4.schema_wrapper.run_qcschema(input_model, postclean=False).dict()
                     output_data = psi4.schema_wrapper.run_qcschema(input_model).dict()
-                    #output_data["extras"]["psiapi_evaluated"] = True
+                    output_data["extras"]["psiapi_evaluated"] = True
                     success = True
-                    #psi4.core.IOManager.shared_object().set_default_path(orig_scr)
+                    psi4.core.IOManager.shared_object().set_default_path(orig_scr)
                 else:
                     run_cmd = [
                         which("psi4"),

--- a/qcengine/programs/psi4.py
+++ b/qcengine/programs/psi4.py
@@ -30,6 +30,9 @@ class Psi4Harness(ProgramHarness):
 
     @staticmethod
     def found(raise_error: bool = False) -> bool:
+        import shutil
+        print("shutil:", shutil.which("psi4"))
+        print("qcng:  ", which("psi4"))
         return which(
             "psi4",
             return_bool=True,
@@ -41,9 +44,13 @@ class Psi4Harness(ProgramHarness):
         self.found(raise_error=True)
 
         which_prog = which("psi4")
+        print("v0:", which_prog)
+        print("v1:", self.version_cache)
         if which_prog not in self.version_cache:
             with popen([which_prog, "--version"]) as exc:
                 exc["proc"].wait(timeout=30)
+            print("v2:", exc["stdout"])
+            print("v3:", safe_version(exc["stdout"]))
             self.version_cache[which_prog] = safe_version(exc["stdout"])
 
         candidate_version = self.version_cache[which_prog]
@@ -143,14 +150,19 @@ class Psi4Harness(ProgramHarness):
 
             else:
 
-                if ("psiapi" in input_model.extras) and input_model.extras["psiapi"]:
+                if input_model.extras.get("psiapi", False):
+                #if ("psiapi" in input_model.extras) and input_model.extras["psiapi"]:
                     import psi4
+                    orig_scr = psi4.core.IOManager.shared_object().get_default_path()
 
                     psi4.core.set_num_threads(config.ncores, quiet=True)
                     psi4.set_memory(f"{config.memory}GB", quiet=True)
+                    psi4.core.IOManager.shared_object().set_default_path(str(tmpdir)) #os.path.abspath(os.path.expanduser(args["scratch"])))
+                    print('scratchE', psi4.core.IOManager.shared_object().get_default_path())
                     output_data = psi4.schema_wrapper.run_qcschema(input_model).dict()
                     output_data["extras"]["psiapi_evaluated"] = True
                     success = True
+                    psi4.core.IOManager.shared_object().set_default_path(orig_scr)
                 else:
                     run_cmd = [
                         which("psi4"),

--- a/qcengine/util.py
+++ b/qcengine/util.py
@@ -444,6 +444,8 @@ def execute(
     popen_kwargs = {}
     if environment is not None:
         popen_kwargs["env"] = {k: v for k, v in environment.items() if v is not None}
+    if scratch_directory is not None:
+        scratch_directory = str(scratch_directory)  # Windows unhappy with Path
 
     # Execute
     with temporary_directory(

--- a/qcengine/util.py
+++ b/qcengine/util.py
@@ -533,7 +533,7 @@ def temporary_directory(
             else:
                 raise
     try:
-        yield tmpdir
+        yield str(tmpdir)
 
     finally:
         if not messy:

--- a/qcengine/util.py
+++ b/qcengine/util.py
@@ -444,8 +444,6 @@ def execute(
     popen_kwargs = {}
     if environment is not None:
         popen_kwargs["env"] = {k: v for k, v in environment.items() if v is not None}
-    if scratch_directory is not None:
-        scratch_directory = str(scratch_directory)  # Windows unhappy with Path
 
     # Execute
     with temporary_directory(
@@ -533,7 +531,7 @@ def temporary_directory(
             else:
                 raise
     try:
-        yield str(tmpdir)
+        yield tmpdir
 
     finally:
         if not messy:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
Fixes in conjunction with psi4 ddd. Still needs printing cleared out, after I confirm working.

## Changelog description
- [x] Switch `psi4 --version` collection to only grab the last line. This should fix #200, but I can't say for sure because chocolatey is down _again_.
- [x] Use an independent tmpdir for each psi4 run in psiapi mode, not just exe.
- [x] Reset the scratch dir for psi4 in psiapi mode, so `set guess read` in distributed driver has a chance.
- [x] Add a connection to a `postclean` kwarg to cleanup the qcschema_tmpfile at end of routine (suitable for psiapi) rather than at atexit

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [ ] Ready to go SQUASH!
