### PR TITLE
NWCHEM:  added keyword dft to xc_functionals list.  If method == "dft"

### DIFF
--- a/qcengine/programs/nwchem/germinate.py
+++ b/qcengine/programs/nwchem/germinate.py
@@ -175,12 +175,14 @@ def muster_modelchem(method: str, derint: int, use_tce: bool) -> Tuple[str, Dict
         )
 
     elif method in _xc_functionals:
-        if method != "dft":
-            opts["dft__xc"] = method
+        opts["dft__xc"] = method
         if use_tce:
             mdccmd = f"task tce {runtyp}\n\n"
             opts["tce__"] = "dft"
         else:
+            mdccmd = f"task dft {runtyp}\n\n"
+
+    elif method != "dft":
             mdccmd = f"task dft {runtyp}\n\n"
 
     else:

--- a/qcengine/programs/nwchem/germinate.py
+++ b/qcengine/programs/nwchem/germinate.py
@@ -182,7 +182,11 @@ def muster_modelchem(method: str, derint: int, use_tce: bool) -> Tuple[str, Dict
             mdccmd = f"task dft {runtyp}\n\n"
 
     elif method == "dft":
-        mdccmd = f"task dft {runtyp}\n\n"
+        if use_tce:
+            mdccmd = f"task tce {runtyp}\n\n"
+            opts["tce__"] = "dft"
+        else:
+            mdccmd = f"task dft {runtyp}\n\n"
 
     else:
         raise InputError(f"Method not recognized: {method}")

--- a/qcengine/programs/nwchem/germinate.py
+++ b/qcengine/programs/nwchem/germinate.py
@@ -182,7 +182,7 @@ def muster_modelchem(method: str, derint: int, use_tce: bool) -> Tuple[str, Dict
             mdccmd = f"task dft {runtyp}\n\n"
 
     elif method != "dft":
-            mdccmd = f"task dft {runtyp}\n\n"
+        mdccmd = f"task dft {runtyp}\n\n"
 
     else:
         raise InputError(f"Method not recognized: {method}")

--- a/qcengine/programs/nwchem/germinate.py
+++ b/qcengine/programs/nwchem/germinate.py
@@ -109,7 +109,7 @@ def muster_modelchem(method: str, derint: int, use_tce: bool) -> Tuple[str, Dict
         0: "energy",
         1: "gradient",
         2: "hessian",
-        #'properties': 'prop',
+        # 'properties': 'prop',
     }[derint]
 
     # Write out the theory directive
@@ -181,7 +181,7 @@ def muster_modelchem(method: str, derint: int, use_tce: bool) -> Tuple[str, Dict
         else:
             mdccmd = f"task dft {runtyp}\n\n"
 
-    elif method != "dft":
+    elif method == "dft":
         mdccmd = f"task dft {runtyp}\n\n"
 
     else:

--- a/qcengine/programs/nwchem/germinate.py
+++ b/qcengine/programs/nwchem/germinate.py
@@ -4,6 +4,7 @@ from qcengine.exceptions import InputError
 
 # List of XC functionals known to NWChem
 _xc_functionals = [
+    "dft",
     "acm",
     "b3lyp",
     "beckehandh",
@@ -174,7 +175,8 @@ def muster_modelchem(method: str, derint: int, use_tce: bool) -> Tuple[str, Dict
         )
 
     elif method in _xc_functionals:
-        opts["dft__xc"] = method
+        if method != "dft":
+            opts["dft__xc"] = method
         if use_tce:
             mdccmd = f"task tce {runtyp}\n\n"
             opts["tce__"] = "dft"

--- a/qcengine/programs/nwchem/germinate.py
+++ b/qcengine/programs/nwchem/germinate.py
@@ -4,7 +4,6 @@ from qcengine.exceptions import InputError
 
 # List of XC functionals known to NWChem
 _xc_functionals = [
-    "dft",
     "acm",
     "b3lyp",
     "beckehandh",

--- a/qcengine/programs/nwchem/germinate.py
+++ b/qcengine/programs/nwchem/germinate.py
@@ -178,64 +178,11 @@ def muster_modelchem(method: str, derint: int, use_tce: bool) -> Tuple[str, Dict
         if use_tce:
             mdccmd = f"task tce {runtyp}\n\n"
             opts["tce__"] = "dft"
-        elseimport qcelemental as qcel
-import qcengine as qcng
-sdimerF='/home/adrian/projects/qca/benzeneDimer/Sdimer-004.xyz'
-pddimerF='/home/adrian/projects/qca/benzeneDimer/PDdimer-051.xyz'
-SDIMER_MOL = qcel.models.Molecule.from_file(filename=sdimerF)
-PDDIMER_MOL = qcel.models.Molecule.from_file(filename=pddimerF)
-
-KW = {'dft__xc': 'xc vwn_1_rpa 0.19 lyp 0.81 HFexch 0.20  slater 0.80 becke88 nonlocal 0.72',
-      'dft__direct': True,
-      # 'dft__disp__vdw': 3,
-      'dft__grid': 'fine',
-      'dft__tolerances__tight': True,
-      'dft__tolerances__acccoul': 10,
-      'dft__tolerances__radius': 30,
-      'dft__convergence__density': 1e-6}
-
-blyp = {'dft__xc': 'becke88 lyp',  # blyp
-        'dft__direct': True,
-        'dft__grid': 'fine',
-        'dft__tolerances__tight': True,
-        'dft__tolerances__radius': 30,
-        'dft__tolerances__acccoul': 10,
-        'dft__convergence__density': 1e-6}
-
-b3lyp = {'dft__xc': 'b3lyp',
-         'dft__direct': True,
-         # 'dft__disp__vdw': 3,
-         'dft__grid': 'fine',
-         'dft__tolerances__tight': True,
-         'dft__tolerances__acccoul': 10,
-         'dft__tolerances__radius': 30,
-         'dft__convergence__density': 1e-6}
-
-
-inp2 = qcel.models.AtomicInput(
-    molecule=PDDIMER_MOL,
-    driver="energy",
-    model={"method": "dft", "basis": 'sto-3g'},
-    keywords=blyp
-)
-inp3 = qcel.models.AtomicInput(
-    molecule=PDDIMER_MOL,
-    driver="energy",
-    model={"method": "dft", "basis": 'sto-3g'},
-    keywords=b3lyp
-)
-
-# r1 = qcng.compute(inp1, 'nwchem')
-r2 = qcng.compute(inp2, 'nwchem')
-r3 = qcng.compute(inp3, 'nwchem')
+        else:
             mdccmd = f"task dft {runtyp}\n\n"
 
     elif method == "dft":
-        if use_tce:
-            mdccmd = f"task tce {runtyp}\n\n"
-            opts["tce__"] = "dft"
-        else:
-            mdccmd = f"task dft {runtyp}\n\n"
+        mdccmd = f"task dft {runtyp}\n\n"
 
     else:
         raise InputError(f"Method not recognized: {method}")

--- a/qcengine/programs/nwchem/germinate.py
+++ b/qcengine/programs/nwchem/germinate.py
@@ -178,11 +178,64 @@ def muster_modelchem(method: str, derint: int, use_tce: bool) -> Tuple[str, Dict
         if use_tce:
             mdccmd = f"task tce {runtyp}\n\n"
             opts["tce__"] = "dft"
-        else:
+        elseimport qcelemental as qcel
+import qcengine as qcng
+sdimerF='/home/adrian/projects/qca/benzeneDimer/Sdimer-004.xyz'
+pddimerF='/home/adrian/projects/qca/benzeneDimer/PDdimer-051.xyz'
+SDIMER_MOL = qcel.models.Molecule.from_file(filename=sdimerF)
+PDDIMER_MOL = qcel.models.Molecule.from_file(filename=pddimerF)
+
+KW = {'dft__xc': 'xc vwn_1_rpa 0.19 lyp 0.81 HFexch 0.20  slater 0.80 becke88 nonlocal 0.72',
+      'dft__direct': True,
+      # 'dft__disp__vdw': 3,
+      'dft__grid': 'fine',
+      'dft__tolerances__tight': True,
+      'dft__tolerances__acccoul': 10,
+      'dft__tolerances__radius': 30,
+      'dft__convergence__density': 1e-6}
+
+blyp = {'dft__xc': 'becke88 lyp',  # blyp
+        'dft__direct': True,
+        'dft__grid': 'fine',
+        'dft__tolerances__tight': True,
+        'dft__tolerances__radius': 30,
+        'dft__tolerances__acccoul': 10,
+        'dft__convergence__density': 1e-6}
+
+b3lyp = {'dft__xc': 'b3lyp',
+         'dft__direct': True,
+         # 'dft__disp__vdw': 3,
+         'dft__grid': 'fine',
+         'dft__tolerances__tight': True,
+         'dft__tolerances__acccoul': 10,
+         'dft__tolerances__radius': 30,
+         'dft__convergence__density': 1e-6}
+
+
+inp2 = qcel.models.AtomicInput(
+    molecule=PDDIMER_MOL,
+    driver="energy",
+    model={"method": "dft", "basis": 'sto-3g'},
+    keywords=blyp
+)
+inp3 = qcel.models.AtomicInput(
+    molecule=PDDIMER_MOL,
+    driver="energy",
+    model={"method": "dft", "basis": 'sto-3g'},
+    keywords=b3lyp
+)
+
+# r1 = qcng.compute(inp1, 'nwchem')
+r2 = qcng.compute(inp2, 'nwchem')
+r3 = qcng.compute(inp3, 'nwchem')
             mdccmd = f"task dft {runtyp}\n\n"
 
     elif method == "dft":
-        mdccmd = f"task dft {runtyp}\n\n"
+        if use_tce:
+            mdccmd = f"task tce {runtyp}\n\n"
+            opts["tce__"] = "dft"
+        else:
+            mdccmd = f"task dft {runtyp}\n\n"
 
     else:
         raise InputError(f"Method not recognized: {method}")


### PR DESCRIPTION

<!-- Thank you for your contribution! -->

## Description
NWChem: added "dft" to list of exchange functionals.  If method == "dft" let exchange functional be handled by keywords.  Works with mixed functionals like "xc becke88 lyp".  This doesn't deal with cases like 'dft__xc': 'xc vwn_1_rpa 0.19 lyp 0.81 HFexch 0.20  slater 0.80 becke88 nonlocal 0.72'.

## Changelog description
NWChem: added "dft" to list of exchange functionals and let xc option be handled by keywords
## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [X] Code base linted
- [X] Ready to go
