### PR TITLE
Minor issues involving >1 core per MPI rank

### DIFF
--- a/qcengine/programs/nwchem/runner.py
+++ b/qcengine/programs/nwchem/runner.py
@@ -123,7 +123,7 @@ class NWChemHarness(ProgramHarness):
         # someday, replace with this: opts['memory'] = str(int(config.memory * (1024**3) / 1e6)) + ' mb'
         memory_size = int(config.memory * (1024 ** 3))
         if config.use_mpiexec:  # It is the memory per MPI rank
-            memory_size //= config.nnodes * config.ncores
+            memory_size //= config.nnodes * config.ncores // config.cores_per_rank
         opts["memory"] = memory_size
 
         # Handle molecule
@@ -175,8 +175,9 @@ task python
             nwchemrec["infiles"]["nwchem.nw"] += pycmd
 
         # Determine the command
-        if config.nnodes > 1:
+        if config.use_mpiexec:
             nwchemrec["command"] = create_mpi_invocation(which("nwchem"), config)
+            logger.info(f"Launching with mpiexec: {' '.join(nwchemrec['command'])}")
         else:
             nwchemrec["command"] = [which("nwchem")]
 

--- a/qcengine/tests/test_config.py
+++ b/qcengine/tests/test_config.py
@@ -197,7 +197,7 @@ def test_config_local_nnodes(opt_state_basic):
     assert create_mpi_invocation("hello_world", config) == [
         "mpirun",
         "-n",
-        "20",
+        "10",
         "-N",
         "2",
         "--cpus-per-slot",

--- a/qcengine/util.py
+++ b/qcengine/util.py
@@ -43,7 +43,7 @@ def create_mpi_invocation(executable: str, task_config: TaskConfig) -> List[str]
     mpirun_str = task_config.mpiexec_command.format(
         nnodes=task_config.nnodes,
         ranks_per_node=task_config.ncores // task_config.cores_per_rank,
-        total_ranks=task_config.nnodes * task_config.ncores,
+        total_ranks=task_config.nnodes * task_config.ncores // task_config.cores_per_rank,
         cores_per_rank=task_config.cores_per_rank,
     )
     command = mpirun_str.split()


### PR DESCRIPTION
## Description
Fixes bugs with how the total number of ranks and memory size for NWChem are determined when there is more than one core per MPI rank

## Changelog description
Minor bug fixes for NWChem when more than core per MPI rank is used

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [ ] Ready to go
