### PR TITLE
Fix for NWChem Gradients with >1 MPI Rank

### DIFF
--- a/qcengine/programs/nwchem/harvester.py
+++ b/qcengine/programs/nwchem/harvester.py
@@ -778,7 +778,7 @@ def harvest(in_mol: Molecule, nwout: str, **outfiles) -> Tuple[PreservingDict, N
     # If present, align the gradients and hessian with the original molecular coordinates
     #  NWChem rotates the coordinates of the input molecule. `out_mol` contains the coordinates for the
     #  rotated molecule, which we can use to determine how to rotate the gradients/hessian
-    amol, data = out_mol.align(in_mol, atoms_map=True, mols_align=True, verbose=0)
+    amol, data = out_mol.align(in_mol, atoms_map=False, mols_align=True, verbose=0)
 
     mill = data["mill"]  # Retrieve tool with alignment routines
 

--- a/qcengine/programs/nwchem/runner.py
+++ b/qcengine/programs/nwchem/runner.py
@@ -163,9 +163,9 @@ class NWChemHarness(ProgramHarness):
             #  (not 6 significant figures)
             pycmd = f"""
 python
+  grad = rtdb_get('{theory}:gradient')
   if ga_nodeid() == 0:
       import json
-      grad = rtdb_get('{theory}:gradient')
       with open('nwchem.grad', 'w') as fp:
           json.dump(grad, fp)
 end


### PR DESCRIPTION
## Description
Bug fix: I did not test with >1 MPI rank for NWChem gradients, and found I needed to have all threads read from the database.

Also changed atom_map to False, as suggested in #205 

## Changelog description
[I would call this under the same description as the previous NWC gradients PR]

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [ ] Ready to go
