### PR TITLE
Added NWChem to the canonical harness tests, fixed issues

### DIFF
--- a/qcengine/programs/nwchem/runner.py
+++ b/qcengine/programs/nwchem/runner.py
@@ -226,7 +226,7 @@ task python
         output_data = {
             "schema_name": "qcschema_output",
             "schema_version": 1,
-            "extras": {"outfiles": outfiles},
+            "extras": {"outfiles": outfiles, **input_model.extras},
             "properties": qcprops,
             "provenance": Provenance(creator="NWChem", version=self.get_version(), routine="nwchem"),
             "return_result": retres,

--- a/qcengine/tests/test_harness_canonical.py
+++ b/qcengine/tests/test_harness_canonical.py
@@ -15,6 +15,7 @@ _canonical_methods = [
     ("molpro", {"method": "hf", "basis": "6-31G"}),
     ("mopac", {"method": "PM6"}),
     ("mp2d", {"method": "MP2-DMP2"}),
+    ("nwchem", {"method": "hf", "basis": "6-31G"}),
     ("psi4", {"method": "hf", "basis": "6-31G"}),
     ("qchem", {"method": "hf", "basis": "6-31G"}),
     ("rdkit", {"method": "UFF"}),


### PR DESCRIPTION
## Description
NWChem does not pass the standard harness tests. This PR adds it to the suite of harnesses being tested to show it fails, and then fixes an issue around "extra" tags being eaten.

## Changelog description
Fixed missing extras tags in NWChem harness

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [ ] Ready to go
