### PR TITLE
CI for NWChem

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,7 +4,6 @@ coverage:
     - qcengine/programs/util/.*
     - qcengine/programs/cfour/.*
     - qcengine/programs/gamess/.*
-    - qcengine/programs/nwchem/.*
     - setup.py
   status:
     patch: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ install:
     elif [ $PROG == "OPENMM" ]; then
       python devtools/scripts/conda_env.py -n=test -p=$PYTHON_VER devtools/conda-envs/openmm.yaml
     elif [ $PROG == "NWCHEM" ]; then
-      python devtools/scripts/conda_env.py -n=test -p=$PYTHON_VER devtools/conda-envs/base.yaml
+      python devtools/scripts/conda_env.py -n=test -p=$PYTHON_VER devtools/conda-envs/nwchem.yaml
     else
       echo "ERROR: No match for PROG ($PROG)."
       exit 1
@@ -78,7 +78,6 @@ install:
     fi
   - export QCER_VER=`python -c "import qcengine.testing; print(qcengine.testing.QCENGINE_RECORDS_COMMIT)"`
   - pip install git+https://github.com/MolSSI/QCEngineRecords.git@${QCER_VER}#egg=qcenginerecords
-  - which conda python nwchem
   - conda list
 
     # Build and install package

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,15 @@ matrix:
         - PYTHON_VER=3.6
         - PROG=OPENMM
 
+    - os: linux
+      addons: &1
+        apt:
+          packages:
+          - nwchem
+      env:
+        - PYTHON_VER=3.6
+        - PROG=NWCHEM
+
 before_install:
     # Additional info about the build
   - uname -a
@@ -51,6 +60,8 @@ install:
       python devtools/scripts/conda_env.py -n=test -p=$PYTHON_VER devtools/conda-envs/torchani.yaml
     elif [ $PROG == "OPENMM" ]; then
       python devtools/scripts/conda_env.py -n=test -p=$PYTHON_VER devtools/conda-envs/openmm.yaml
+    elif [ $PROG == "NWCHEM" ]; then
+      python devtools/scripts/conda_env.py -n=test -p=$PYTHON_VER devtools/conda-envs/base.yaml
     else
       echo "ERROR: No match for PROG ($PROG)."
       exit 1
@@ -67,6 +78,7 @@ install:
     fi
   - export QCER_VER=`python -c "import qcengine.testing; print(qcengine.testing.QCENGINE_RECORDS_COMMIT)"`
   - pip install git+https://github.com/MolSSI/QCEngineRecords.git@${QCER_VER}#egg=qcenginerecords
+  - which conda python nwchem
   - conda list
 
     # Build and install package

--- a/devtools/conda-envs/nwchem.yaml
+++ b/devtools/conda-envs/nwchem.yaml
@@ -1,0 +1,17 @@
+name: test
+channels:
+  - conda-forge
+dependencies:
+    # Core
+  - python
+  - pyyaml
+  - py-cpuinfo
+  - psutil
+  - qcelemental >=0.12.0
+  - pydantic>=1.0.0
+  - networkx>=2.4.0
+
+    # Testing
+  - pytest
+  - pytest-cov
+  - codecov


### PR DESCRIPTION
closes #211 

## Description
try ubuntu's nwchem package, as recc by #211 

## Changelog description
- [x] Adds CI testing of NWChem 6.6 through Ubuntu xenial pkg

## Questions
- [ ] networkx is req'd for the NWChem interface for all but energies to align arrays, but at present it's only an optional requirement for qcel. There's a nice "install me" message, but in production users would probably like to know to install the pkg _before_ the QC job, not after. But I'm hesitant to put the check in `def found` because if ppl are only looking at the boolean, it'd be unintuitive for `which nwchem` to be present but nwchem harness not be available. Where to address this? require networkx? or have a distinction btwn nwchem-found and nwchem-ready?
- [ ] combine this CI lane with another?

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
