### PR TITLE
psithon and psiapi

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 QCEngine
 ========
 [![Travis Build Status](https://travis-ci.org/MolSSI/QCEngine.png)](https://travis-ci.org/MolSSI/QCEngine)
-[![codecov](https://codecov.io/gh/MolSSI/QCEngine/branch/master/graph/badge.svg)](https://codecov.io/gh/MolSSI/QCEngine/branch/master)
+[![codecov](https://img.shields.io/codecov/c/github/MolSSI/QCEngine.svg?logo=Codecov&logoColor=white)](https://codecov.io/gh/MolSSI/QCEngine)
 [![Azure Build Status](https://dev.azure.com/MolSSI/QCArchive/_apis/build/status/MolSSI.QCEngine?branchName=master)](https://dev.azure.com/MolSSI/QCArchive/_build/latest?definitionId=5&branchName=master)
 [![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/MolSSI/QCEngine.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/MolSSI/QCEngine/context:python)
 [![Documentation Status](https://readthedocs.org/projects/qcengine/badge/?version=latest)](https://qcengine.readthedocs.io/en/latest/?badge=latest)

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,8 +1,8 @@
 Changelog
 =========
 
-.. vX.Y.0 / 2019-MM-DD
-.. -------------------
+.. vX.Y.0 / 2020-MM-DD
+.. --------------------
 ..
 .. New Features
 .. ++++++++++++
@@ -12,6 +12,23 @@ Changelog
 ..
 .. Bug Fixes
 .. +++++++++
+
+
+v0.14.0 / 2020-MM-DD
+--------------------
+
+New Features
+++++++++++++
+
+Enhancements
+++++++++++++
+-(:pr:`215`) Psi4 - indicating location by either PATH or PYTHONPATH sets up both subprocess and API execution.
+-(:pr:`215`) ``get_program`` shows the helpful "install this" messages from ``found()`` rather than just saying "cannot be found".
+
+Bug Fixes
++++++++++
+-(:pr:`215`) NWChem complains *before* a calculation if the necessary ``networkx`` package not available.
+
 
 v0.13.0 / 2019-12-10
 --------------------

--- a/qcengine/cli.py
+++ b/qcengine/cli.py
@@ -75,8 +75,8 @@ def info_cli(args):
         import qcelemental
 
         print(">>> Version information")
-        print(f"QCEngine version:    {__version__}")
-        print(f"QCElemental version: {qcelemental.__version__}")
+        print(f"QCEngine:    {__version__}")
+        print(f"QCElemental: {qcelemental.__version__}")
         print()
 
     def info_programs():  # lgtm: [py/similar-function]
@@ -88,11 +88,15 @@ def info_cli(args):
             version = get_program(prog_name).get_version()
             if version is None:
                 version = "???"
-            print(f"{prog_name} v{version}")
+            print(f"{prog_name + ':':12} v{version}")
 
         print()
         print("Other supported programs:")
         print(" ".join(sorted(all_progs - avail_progs)))
+        print()
+        print(
+            """If you think available programs are missing, query for details: `python -c "import qcengine as qcng; qcng.get_program('<program>')"`"""
+        )
         print()
 
     def info_procedures():  # lgtm: [py/similar-function]

--- a/qcengine/programs/base.py
+++ b/qcengine/programs/base.py
@@ -103,7 +103,7 @@ register_program(QChemHarness())
 register_program(TeraChemHarness())
 register_program(TurbomoleHarness())
 
-# Semi-emperical
+# Semi-empirical
 register_program(MopacHarness())
 
 # AI

--- a/qcengine/programs/base.py
+++ b/qcengine/programs/base.py
@@ -66,8 +66,11 @@ def get_program(name: str, check: bool = True) -> "ProgramHarness":
         raise InputError(f"Program {name} is not registered to QCEngine.")
 
     ret = programs[name]
-    if check and not ret.found():
-        raise ResourceError(f"Program {name} is registered with QCEngine, but cannot be found.")
+    if check:
+        try:
+            found = ret.found(raise_error=True)
+        except ModuleNotFoundError as err:
+            raise ResourceError(f"Program {name} is registered with QCEngine, but cannot be found.") from err
 
     return ret
 

--- a/qcengine/programs/base.py
+++ b/qcengine/programs/base.py
@@ -68,7 +68,7 @@ def get_program(name: str, check: bool = True) -> "ProgramHarness":
     ret = programs[name]
     if check:
         try:
-            found = ret.found(raise_error=True)
+            ret.found(raise_error=True)
         except ModuleNotFoundError as err:
             raise ResourceError(f"Program {name} is registered with QCEngine, but cannot be found.") from err
 

--- a/qcengine/programs/nwchem/runner.py
+++ b/qcengine/programs/nwchem/runner.py
@@ -52,25 +52,21 @@ class NWChemHarness(ProgramHarness):
 
     @staticmethod
     def found(raise_error: bool = False) -> bool:
-        qc = which("nwchem", return_bool=True)
-        dep = which_import("networkx", return_bool=True)
-
-        if (qc and dep) or not raise_error:
-            return qc and dep
-
-        which(
+        qc = which(
             "nwchem",
             return_bool=True,
             raise_error=raise_error,
             raise_msg="Please install via http://www.nwchem-sw.org/index.php/Download",
         )
 
-        which_import(
+        dep = which_import(
             "networkx",
             return_bool=True,
             raise_error=raise_error,
             raise_msg="For NWChem harness, please install via `conda install networkx -c conda-forge`.",
         )
+
+        return qc and dep
 
     def get_version(self) -> str:
         self.found(raise_error=True)

--- a/qcengine/programs/nwchem/runner.py
+++ b/qcengine/programs/nwchem/runner.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, Optional, Tuple
 import numpy as np
 import qcelemental as qcel
 from qcelemental.models import AtomicResult, Provenance, AtomicInput
-from qcelemental.util import safe_version, which
+from qcelemental.util import safe_version, which, which_import
 
 from qcengine.config import TaskConfig, get_config
 from qcengine.exceptions import UnknownError
@@ -52,11 +52,24 @@ class NWChemHarness(ProgramHarness):
 
     @staticmethod
     def found(raise_error: bool = False) -> bool:
-        return which(
+        qc = which("nwchem", return_bool=True)
+        dep = which_import("networkx", return_bool=True)
+
+        if (qc and dep) or not raise_error:
+            return qc and dep
+
+        which(
             "nwchem",
             return_bool=True,
             raise_error=raise_error,
             raise_msg="Please install via http://www.nwchem-sw.org/index.php/Download",
+        )
+
+        which_import(
+            "networkx",
+            return_bool=True,
+            raise_error=raise_error,
+            raise_msg="For NWChem harness, please install via `conda install networkx -c conda-forge`.",
         )
 
     def get_version(self) -> str:

--- a/qcengine/programs/psi4.py
+++ b/qcengine/programs/psi4.py
@@ -3,6 +3,7 @@ Calls the Psi4 executable.
 """
 import json
 import os
+import sys
 from pathlib import Path
 from typing import Dict, TYPE_CHECKING
 
@@ -41,7 +42,10 @@ class Psi4Harness(ProgramHarness):
         if psithon and not psiapi:
             with popen([which("psi4"), "--pythonpath"]) as exc:
                 exc["proc"].wait(timeout=30)
-            sys.path.append(exc["stdout"].split()[-1])
+            if "pythonpath does not exist" in exc["stderr"]:
+                pass
+            else:
+                sys.path.append(exc["stdout"].split()[-1])
 
         if psiapi and not psithon:
             psiimport = str(Path(which_import("psi4")).parent.parent)
@@ -54,13 +58,12 @@ class Psi4Harness(ProgramHarness):
         if psithon or psiapi:
             return True
 
-        else:
-            return which(
-                "psi4",
-                return_bool=True,
-                raise_error=raise_error,
-                raise_msg="Please install via `conda install psi4 -c psi4`.",
-            )
+        return which(
+            "psi4",
+            return_bool=True,
+            raise_error=raise_error,
+            raise_msg="Please install via `conda install psi4 -c psi4`.",
+        )
 
     def get_version(self) -> str:
         self.found(raise_error=True)
@@ -84,7 +87,6 @@ class Psi4Harness(ProgramHarness):
         """
         Runs Psi4 in API mode
         """
-
         self.found(raise_error=True)
         pversion = parse_version(self.get_version())
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
~Adapt psi harness to choose psithon or psiapi for `found` and `version` fns. What I'm aiming for is to not require PATH _and_ PYTHONPATH environment edits to run psi4 (which calls qcng which calls psi4) when providing full path to exe.~

If psi4 is found through PATH _or_ PYTHONPATH, this sets the env in qcng to make both psithon and psiapi available.
- does not check if you had PATH pointing to one psi4 installation and PYTHONPATH to another. just don't do that.
- running in psiapi when psi4 in PATH only works for latest ddd branch b/c I had to add `psi --module` to access that importdir.
- result of this is that running tests in ddd no longer requires typing path to `bin/psi4` _and_ having PATH set _and_ having PYTHONPATH set. hoping this will avert lots of questions down the road.

wrt #213, the `found()` fn universally means fully operational, so let's keep that meaning and add extra checks for harness-dep programs into the found. For the setup guidance, let's just stop the generic "cannot be found" and instead propagate `found`'s nice messages and also link how to run `found` in the `qcengine info` page.

## Questions
- [ ] ~This PR works for my purposes except I have to hack around "psi4 is registered with QCEngine, but cannot be found." b/c psiapi vs psithon as a mode of operation (usually supplied in `AtomicInput`) isn't know at that stage. Any strong opinions on whether psithon and psiapi should be set up as separate harnesses based on whether PATH or PYTHONPATH had been provided by the user. An alternative is that both psithon and psiapi modes can be made available from one of PATH/PYTHONPATH so that `found` could look for both and figure out the mods to `env` that need to be passed to `popen`.~

## Changelog description
included

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
