### PR TITLE
RDKit MMFF94 and CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,6 @@ matrix:
     - os: linux
       env:
         - PYTHON_VER=3.6
-        - PROG=RDKIT
-    - os: linux
-      env:
-        - PYTHON_VER=3.6
         - PROG=PSI4
     - os: linux
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,9 +50,7 @@ install:
 
     # Create test environment for package
   - |
-    if [ $PROG == "RDKIT" ]; then
-      python devtools/scripts/conda_env.py -n=test -p=$PYTHON_VER devtools/conda-envs/rdkit.yaml
-    elif [ $PROG == "PSI4" ]; then
+    if [ $PROG == "PSI4" ]; then
       python devtools/scripts/conda_env.py -n=test -p=$PYTHON_VER devtools/conda-envs/psi.yaml
     elif [ $PROG == "PSI4DEV" ]; then
       python devtools/scripts/conda_env.py -n=test -p=$PYTHON_VER devtools/conda-envs/psi-nightly.yaml

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,10 @@ matrix:
       env:
         - PYTHON_VER=3.7
         - PROG=PSI4DEV  # py37 not avail for latest release
-#    - os: linux
-#      env:
-#        - PYTHON_VER=3.6
-#        - PROG=ANI
+    - os: linux
+      env:
+        - PYTHON_VER=3.6
+        - PROG=ANI
     - os: linux
       env:
         - PYTHON_VER=3.6
@@ -70,9 +70,6 @@ install:
   - |
     if [ $PROG == "PSI4DEV" ]; then
       conda remove qcengine --force
-    elif [ $PROG == "ANI" ]; then
-      pip install torch_nightly -q -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
-      pip install torchani -q
     fi
   - export QCER_VER=`python -c "import qcengine.testing; print(qcengine.testing.QCENGINE_RECORDS_COMMIT)"`
   - pip install git+https://github.com/MolSSI/QCEngineRecords.git@${QCER_VER}#egg=qcenginerecords

--- a/devtools/conda-envs/torchani.yaml
+++ b/devtools/conda-envs/torchani.yaml
@@ -12,7 +12,11 @@ dependencies:
   - qcelemental >=0.12.0
   - pydantic>=1.0.0
 
+  - pytorch-cpu::pytorch
+
     # Testing
   - pytest
   - pytest-cov
   - codecov
+  - pip:
+    - torchani

--- a/devtools/conda-envs/torchani.yaml
+++ b/devtools/conda-envs/torchani.yaml
@@ -12,7 +12,7 @@ dependencies:
   - qcelemental >=0.12.0
   - pydantic>=1.0.0
 
-  - pytorch-cpu::pytorch
+  - pytorch::pytorch-nightly-cpu
 
     # Testing
   - pytest

--- a/qcengine/programs/openmm.py
+++ b/qcengine/programs/openmm.py
@@ -91,6 +91,13 @@ class OpenMMHarness(ProgramHarness):
         # this harness requires RDKit as well, so this needs checking too
         rdkit_found = RDKitHarness.found(raise_error=raise_error)
 
+        openff_found = which_import(
+            "openforcefield",
+            return_bool=True,
+            raise_error=raise_error,
+            raise_msg="Please install via `conda install openforcefield -c omnia`.",
+        )
+
         openmm_found = which_import(
             ".openmm",
             return_bool=True,
@@ -99,7 +106,7 @@ class OpenMMHarness(ProgramHarness):
             raise_msg="Please install via `conda install openmm -c omnia`.",
         )
 
-        return rdkit_found and openmm_found
+        return rdkit_found and openff_found and openmm_found
 
     def compute(self, input_data: "AtomicInput", config: "TaskConfig") -> "AtomicResult":
         """

--- a/qcengine/programs/openmm.py
+++ b/qcengine/programs/openmm.py
@@ -128,9 +128,9 @@ class OpenMMHarness(ProgramHarness):
             raise InputError("Method must contain a basis set.")
 
         # Build a system based off input
-        if input_data.model.method.lower() == "smirnoff":
+        if input_data.model.basis.lower() == "smirnoff":
 
-            ff_file = input_data.model.basis + ".offxml"
+            ff_file = input_data.model.method + ".offxml"
             off_forcefield = self._get_off_forcefield(ff_file, ff_file)
 
             # Process molecule with RDKit
@@ -144,7 +144,7 @@ class OpenMMHarness(ProgramHarness):
                 off_top = off_mol.to_topology()
                 openmm_system = self._get_openmm_system(off_forcefield, off_top)
         else:
-            raise InputError("Accepted methods are: {'smirnoff', }")
+            raise InputError("Accepted bases are: {'smirnoff', }")
 
         # Need an integrator for simulation even if we don't end up using it really
         integrator = openmm.VerletIntegrator(1.0 * unit.femtoseconds)

--- a/qcengine/programs/rdkit.py
+++ b/qcengine/programs/rdkit.py
@@ -101,8 +101,12 @@ class RDKitHarness(ProgramHarness):
         if input_data.model.method.lower() == "uff":
             ff = AllChem.UFFGetMoleculeForceField(mol)
             all_params = AllChem.UFFHasAllMoleculeParams(mol)
+        elif input_data.model.method.lower() in ["mmff94", "mmff94s"]:
+            props = AllChem.MMFFGetMoleculeProperties(mol, mmffVariant=input_data.model.method)
+            ff = AllChem.MMFFGetMoleculeForceField(mol, props)
+            all_params = AllChem.MMFFHasAllMoleculeParams(mol)
         else:
-            raise InputError("RDKit only supports the UFF method currently.")
+            raise InputError("RDKit only supports the UFF, MMFF94, and MMFF94s methods currently.")
 
         if all_params is False:
             raise InputError("RDKit parameters not found for all atom types in molecule.")

--- a/qcengine/programs/tests/test_programs.py
+++ b/qcengine/programs/tests/test_programs.py
@@ -131,11 +131,12 @@ def test_psi4_ref_switch():
 
 
 @using("rdkit")
-def test_rdkit_task():
+@pytest.mark.parametrize("method", ["UFF", "MM94", "MM94s"])
+def test_rdkit_task(method):
     input_data = {
         "molecule": qcng.get_molecule("water"),
         "driver": "gradient",
-        "model": {"method": "UFF"},
+        "model": {"method": method},
         "keywords": {},
     }
 
@@ -148,7 +149,7 @@ def test_rdkit_task():
 def test_rdkit_connectivity_error():
     input_data = {
         "molecule": qcng.get_molecule("water").dict(),
-        "driver": "gradient",
+        "driver": "energy",
         "model": {"method": "UFF", "basis": ""},
         "keywords": {},
     }

--- a/qcengine/programs/tests/test_programs.py
+++ b/qcengine/programs/tests/test_programs.py
@@ -131,7 +131,7 @@ def test_psi4_ref_switch():
 
 
 @using("rdkit")
-@pytest.mark.parametrize("method", ["UFF", "MM94", "MM94s"])
+@pytest.mark.parametrize("method", ["UFF", "MMFF94", "MMFF94s"])
 def test_rdkit_task(method):
     input_data = {
         "molecule": qcng.get_molecule("water"),

--- a/qcengine/programs/tests/test_programs.py
+++ b/qcengine/programs/tests/test_programs.py
@@ -248,7 +248,7 @@ def test_openmm_task_smirnoff():
     input_data = {
         "molecule": qcng.get_molecule("water"),
         "driver": "energy",
-        "model": {"method": "smirnoff", "basis": "openff-1.0.0"},
+        "model": {"method": "openff-1.0.0", "basis": "smirnoff"},
         "keywords": {},
     }
 

--- a/qcengine/tests/test_harness_canonical.py
+++ b/qcengine/tests/test_harness_canonical.py
@@ -17,7 +17,7 @@ _canonical_methods = [
     ("mopac", {"method": "PM6"}),
     ("mp2d", {"method": "MP2-DMP2"}),
     ("nwchem", {"method": "hf", "basis": "6-31G"}),
-    ("openmm", {"method": "smirnoff", "basis": "openff-1.0.0"}),
+    ("openmm", {"method": "openff-1.0.0", "basis": "smirnoff"}),
     ("psi4", {"method": "hf", "basis": "6-31G"}),
     ("qchem", {"method": "hf", "basis": "6-31G"}),
     ("rdkit", {"method": "UFF"}),

--- a/qcengine/tests/test_procedures.py
+++ b/qcengine/tests/test_procedures.py
@@ -150,6 +150,12 @@ def test_geometric_retries(failure_engine, input_data):
             "rdkit", {"method": "UFF"}, [1.87130923886072, 2.959448636243545, 104.5099642579023], marks=using("rdkit")
         ),
         pytest.param(
+            "rdkit", {"method": "mmff94"}, [1.8310842343589573, 2.884612338953529, 103.93822919865106], marks=using("rdkit")
+        ),
+        pytest.param(
+            "rdkit", {"method": "MMFF94s"}, [1.8310842343589573, 2.884612338953529, 103.93822919865106], marks=using("rdkit")
+        ),
+        pytest.param(
             "torchani",
             {"method": "ANI1x"},
             [1.82581873750194, 2.866376526793269, 103.4332610730292],
@@ -165,6 +171,18 @@ def test_geometric_retries(failure_engine, input_data):
             "openmm",
             {"method": "smirnoff", "basis": "openff-1.0.0"},
             [1.889726881670907, 3.10070288709234, 110.25177977849998],
+            marks=using("openmm"),
+        ),
+        pytest.param(
+            "openmm",
+            {"method": "smirnoff", "basis": "openff_unconstrained-1.0.0"},
+            [1.8344994291195869, 3.0100994772976124, 110.25259556886984],
+            marks=using("openmm"),
+        ),
+        pytest.param(
+            "openmm",
+            {"method": "smirnoff", "basis": "smirnoff99Frosst-1.1.0"},
+            [1.8897269787924604, 3.1516330703676063, 112.9999999990053],
             marks=using("openmm"),
         ),
     ],

--- a/qcengine/tests/test_procedures.py
+++ b/qcengine/tests/test_procedures.py
@@ -175,19 +175,19 @@ def test_geometric_retries(failure_engine, input_data):
         ),
         pytest.param(
             "openmm",
-            {"method": "smirnoff", "basis": "openff-1.0.0"},
+            {"method": "openff-1.0.0", "basis": "smirnoff"},
             [1.889726881670907, 3.10070288709234, 110.25177977849998],
             marks=using("openmm"),
         ),
         pytest.param(
             "openmm",
-            {"method": "smirnoff", "basis": "openff_unconstrained-1.0.0"},
+            {"method": "openff_unconstrained-1.0.0", "basis": "smirnoff"},
             [1.8344994291195869, 3.0100994772976124, 110.25259556886984],
             marks=using("openmm"),
         ),
         pytest.param(
             "openmm",
-            {"method": "smirnoff", "basis": "smirnoff99Frosst-1.1.0"},
+            {"method": "smirnoff99Frosst-1.1.0", "basis": "smirnoff"},
             [1.8897269787924604, 3.1516330703676063, 112.9999999990053],
             marks=using("openmm"),
         ),

--- a/qcengine/tests/test_procedures.py
+++ b/qcengine/tests/test_procedures.py
@@ -150,10 +150,16 @@ def test_geometric_retries(failure_engine, input_data):
             "rdkit", {"method": "UFF"}, [1.87130923886072, 2.959448636243545, 104.5099642579023], marks=using("rdkit")
         ),
         pytest.param(
-            "rdkit", {"method": "mmff94"}, [1.8310842343589573, 2.884612338953529, 103.93822919865106], marks=using("rdkit")
+            "rdkit",
+            {"method": "mmff94"},
+            [1.8310842343589573, 2.884612338953529, 103.93822919865106],
+            marks=using("rdkit"),
         ),
         pytest.param(
-            "rdkit", {"method": "MMFF94s"}, [1.8310842343589573, 2.884612338953529, 103.93822919865106], marks=using("rdkit")
+            "rdkit",
+            {"method": "MMFF94s"},
+            [1.8310842343589573, 2.884612338953529, 103.93822919865106],
+            marks=using("rdkit"),
         ),
         pytest.param(
             "torchani",


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
Adds MMFF94 to RDKit, adds tests for other OpenMM FF's, and re-enables TorchANI CI testing.

WARNING! I had implemented #192 backwards in the method/basis combination, this is also fixed here.

## Changelog description
Adds MMFF94 to RDKit computational abilities.

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
