### PR TITLE
add procedure for pyberny geometry optimizer

### DIFF
--- a/devtools/conda-envs/psi.yaml
+++ b/devtools/conda-envs/psi.yaml
@@ -21,3 +21,7 @@ dependencies:
   - pytest
   - pytest-cov
   - codecov
+
+  - pip
+  - pip:
+    - pyberny

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -84,6 +84,7 @@ In addition, several procedures are available:
 - Geometry Optimization:
 
   - `geomeTRIC <https://github.com/leeping/geomeTRIC>`_
+  - `Pyberny <https://github.com/jhrmnn/pyberny>`_
 
 Configuration Determination
 ---------------------------

--- a/qcengine/compute.py
+++ b/qcengine/compute.py
@@ -115,7 +115,7 @@ def compute_procedure(
     ----------
     input_data : dict or qcelemental.models.OptimizationInput
         A JSON input specific to the procedure executed in dictionary or model from QCElemental.models
-    procedure : {"geometric"}
+    procedure : {"geometric", "berny"}
         The name of the procedure to run
     raise_error : bool, option
         Determines if compute should raise an error or not.

--- a/qcengine/procedures/base.py
+++ b/qcengine/procedures/base.py
@@ -6,6 +6,7 @@ from typing import Set
 
 from ..exceptions import InputError, ResourceError
 from .geometric import GeometricProcedure
+from .berny import BernyProcedure
 
 __all__ = ["register_procedure", "get_procedure", "list_all_procedures", "list_available_procedures"]
 
@@ -62,3 +63,4 @@ def list_available_procedures() -> Set[str]:
 
 
 register_procedure(GeometricProcedure())
+register_procedure(BernyProcedure())

--- a/qcengine/procedures/berny.py
+++ b/qcengine/procedures/berny.py
@@ -1,0 +1,84 @@
+import sys
+import logging
+import traceback
+from io import StringIO
+from typing import Any, Dict, Union
+
+import numpy as np
+from qcelemental.models import OptimizationInput, OptimizationResult
+from qcelemental.util import which_import
+
+import qcengine
+
+from ..config import TaskConfig
+from .model import ProcedureHarness
+
+
+class BernyProcedure(ProcedureHarness):
+    _defaults = {"name": "Berny", "procedure": "optimization"}
+
+    def found(self, raise_error: bool = False) -> bool:
+        return which_import(
+            "berny", return_bool=True, raise_error=raise_error, raise_msg="Please install via `pip install pyberny`.",
+        )
+
+    def build_input_model(self, data: Union[Dict[str, Any], "OptimizationInput"]) -> "OptimizationInput":
+        return self._build_model(data, OptimizationInput)
+
+    def compute(self, input_data: "OptimizationInput", config: "TaskConfig") -> "OptimizationResult":
+        try:
+            import berny
+        except ModuleNotFoundError:
+            raise ModuleNotFoundError("Could not find Berny in the Python path.")
+
+        # Get berny version from the installed package, use setuptools'
+        # pkg_resources for python < 3.8
+        if sys.version_info >= (3, 8):
+            from importlib.metadata import distribution
+        else:
+            from pkg_resources import get_distribution as distribution
+        berny_version = distribution("pyberny").version
+
+        # Berny uses the stdlib logging module and by default uses per-module
+        # loggers. For QCEngine, we create one logger per BernyProcedure
+        # instance, by using the instance's id(), and send all logging messages
+        # to a string stream
+        log_stream = StringIO()
+        log = logging.getLogger(f"{__name__}.{id(self)}")
+        log.addHandler(logging.StreamHandler(log_stream))
+        log.setLevel("INFO")
+
+        input_data = input_data.dict()
+        geom_qcng = input_data["initial_molecule"]
+        comput = {**input_data["input_specification"], "molecule": geom_qcng}
+        program = input_data["keywords"].pop("program")
+        trajectory = []
+        output_data = input_data.copy()
+        try:
+            # Pyberny uses angstroms for the Cartesian geometry, but atomic
+            # units for everything else, including the gradients (hartree/bohr).
+            geom_berny = berny.Geometry(geom_qcng["symbols"], geom_qcng["geometry"] / berny.angstrom)
+            opt = berny.Berny(geom_berny, logger=log, **input_data["keywords"])
+            for geom_berny in opt:
+                geom_qcng["geometry"] = np.stack(geom_berny.coords * berny.angstrom)
+                ret = qcengine.compute(comput, program)
+                trajectory.append(ret.dict())
+                opt.send((ret.properties.return_energy, ret.return_result))
+        except Exception:
+            output_data["success"] = False
+            output_data["error"] = {"error_type": "unknown", "error_message": f"Berny error:\n{traceback.format_exc()}"}
+        else:
+            output_data["success"] = True
+        output_data.update(
+            {
+                "schema_name": "qcschema_optimization_output",
+                "final_molecule": trajectory[-1]["molecule"],
+                "energies": [r["properties"]["return_energy"] for r in trajectory],
+                "trajectory": trajectory,
+                "provenance": {"creator": "Berny", "routine": "berny.Berny", "version": berny_version},
+                "stdout": log_stream.getvalue(),  # collect logged messages
+            }
+        )
+        if output_data["success"]:
+            output_data = OptimizationResult(**output_data)
+        return output_data

--- a/qcengine/testing.py
+++ b/qcengine/testing.py
@@ -147,6 +147,7 @@ _programs = {
     "gamess": which("rungms", return_bool=True),
     "gcp": which("gcp", return_bool=True),
     "geometric": which_import("geometric", return_bool=True),
+    "berny": which_import("berny", return_bool=True),
     "mdi": which_import("mdi", return_bool=True),
     "molpro": is_program_new_enough("molpro", "2018.1"),
     "mopac": is_program_new_enough("mopac", "2016"),

--- a/qcengine/tests/test_procedures.py
+++ b/qcengine/tests/test_procedures.py
@@ -76,6 +76,21 @@ def test_geometric_stdout(input_data):
     assert "Converged!" in ret.stdout
 
 
+@using("psi4")
+@using("berny")
+def test_berny_stdout(input_data):
+
+    input_data["initial_molecule"] = qcng.get_molecule("water")
+    input_data["input_specification"]["model"] = {"method": "HF", "basis": "sto-3g"}
+    input_data["keywords"]["program"] = "psi4"
+
+    input_data = OptimizationInput(**input_data)
+
+    ret = qcng.compute_procedure(input_data, "berny", raise_error=True)
+    assert ret.success is True
+    assert "All criteria matched" in ret.stdout
+
+
 @using("geometric")
 @using("rdkit")
 def test_geometric_rdkit_error(input_data):

--- a/qcengine/tests/test_program_utils.py
+++ b/qcengine/tests/test_program_utils.py
@@ -38,10 +38,12 @@ def test_program_avail_bounce():
 def test_list_procedures():
 
     r = qcng.list_all_procedures()
-    assert r >= {"geometric"}
+    assert r >= {"geometric", "berny"}
 
 
-@pytest.mark.parametrize("procedure", [pytest.param("geometric", marks=using("geometric"))])
+@pytest.mark.parametrize(
+    "procedure", [pytest.param("geometric", marks=using("geometric")), pytest.param("berny", marks=using("berny"))]
+)
 def test_check_procedure_avail(procedure):
 
     assert procedure in qcng.list_available_procedures()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->
Following a discussion with @dgasmith, this PR adds a procedure for the [pyberny](https://github.com/jhrmnn/pyberny) geometry optimizer.

The PR is functional, the following test case runs sucessfully:

```python
import qcelemental as qcel
import qcengine as qcng

mol = qcel.models.Molecule(
    geometry=[[0, 0, 0], [0, 1.5, 0], [0, 0, 1.5]], symbols=["O", "H", "H"], connectivity=[[0, 1, 1], [0, 2, 1]]
)
opt_input = {
    "keywords": {"program": "mopac"},
    "input_specification": {"driver": "gradient", "model": {"method": "PM7"}},
    "initial_molecule": mol,
}
opt = qcng.compute_procedure(opt_input, "berny")
print(opt)
```

However, the PR is still a work in progress. The following needs to be resolved before merging, and I would welcome input from the QCEngine maintainers:

- [x] there is a lot of boilerplate shared with `GeometricProcedure`. `found()`, `build_input_model()`, `Config`, also it seems that if we have `found`, there should be no need to check for the presence of the package in `compute()` again. Is this necessary?
- [x] how to handle logging? Currently Berny logs verbosly, and this is adjustable by passing appropriate argumetns. How is this handled in QCEngine in general? (Pyberny doesn't use the `logging` module, but I can change that if QCEngine would prefer that.)
- [x] where to store paramters for Berny?


## Changelog description
<!-- Provide a brief single sentence for the changelog. -->
Added a new geometry optimizer: [pyberny](https://github.com/jhrmnn/pyberny)

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
