### PR TITLE
Return stdout rather than stderr

### DIFF
--- a/qcengine/programs/nwchem/runner.py
+++ b/qcengine/programs/nwchem/runner.py
@@ -132,7 +132,7 @@ class NWChemHarness(ProgramHarness):
             dexe["outfiles"]["stderr"] = dexe["stderr"]
             return self.parse_output(dexe["outfiles"], input_model)
         else:
-            raise UnknownError(dexe["stderr"])
+            raise UnknownError(dexe["stdout"])
 
     def build_input(
         self, input_model: AtomicInput, config: TaskConfig, template: Optional[str] = None


### PR DESCRIPTION


<!-- Thank you for your contribution! -->

## Description
The stdout from NWChem contains better debugging information than the stderr.

## Changelog description
Improved debugging output from NWChem runner

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [ ] Ready to go
