### PR TITLE
standard suite expansions

### DIFF
--- a/qcengine/programs/cfour/runner.py
+++ b/qcengine/programs/cfour/runner.py
@@ -136,8 +136,10 @@ class CFOURHarness(ProgramHarness):
 
         if c4grad is not None:
             qcvars["CURRENT GRADIENT"] = c4grad
+            qcvars[f"{input_model.model.method.upper()[3:]} TOTAL GRADIENT"] = c4grad
 
         if c4hess is not None:
+            qcvars[f"{input_model.model.method.upper()[3:]} TOTAL HESSIAN"] = c4hess
             qcvars["CURRENT HESSIAN"] = c4hess
 
         if input_model.driver.upper() == "PROPERTIES":

--- a/qcengine/programs/nwchem/runner.py
+++ b/qcengine/programs/nwchem/runner.py
@@ -231,6 +231,7 @@ task python
         qcvars, nwhess, nwgrad, nwmol, version, errorTMP = harvest(input_model.molecule, stdout, **outfiles)
 
         if nwgrad is not None:
+            qcvars[f"{input_model.model.method.upper()[4:]} TOTAL GRADIENT"] = nwgrad
             qcvars["CURRENT GRADIENT"] = nwgrad
         if nwhess is not None:
             qcvars["CURRENT HESSIAN"] = nwhess

--- a/qcengine/programs/psi4.py
+++ b/qcengine/programs/psi4.py
@@ -199,8 +199,10 @@ class Psi4Harness(ProgramHarness):
                         output_data = psi4.schema_wrapper.run_qcschema(input_model).dict()
                     else:
                         output_data = psi4.schema_wrapper.run_qcschema(input_model, postclean=False).dict()
-                    output_data["extras"]["psiapi_evaluated"] = True
+                    # success here means execution returned. output_data may yet be qcel.models.AtomicResult or qcel.models.FailedOperation
                     success = True
+                    if output_data["success"]:
+                        output_data["extras"]["psiapi_evaluated"] = True
                     psi4.core.IOManager.shared_object().set_default_path(orig_scr)
                 else:
                     run_cmd = [

--- a/qcengine/programs/tests/standard_suite_contracts.py
+++ b/qcengine/programs/tests/standard_suite_contracts.py
@@ -235,6 +235,56 @@ def contractual_lccd(
         yield (pv, pv, expected)
 
 
+def contractual_lccsd(
+    qc_module: str, driver: str, reference: str, method: str, corl_type: str, fcae: str
+) -> Tuple[str, str, bool]:
+    """Of the list of QCVariables an ideal LCCSD should produce, returns whether or
+    not each is expected, given the calculation circumstances (like QC program).
+
+    Parameters
+    ----------
+    qc_module : str
+        The program or subprogram running the job (e.g., "cfour" or "cfour-ecc").
+    driver : {"energy", "gradient", "hessian"}
+        The derivative level that should be expected.
+    reference: {"rhf", "uhf", "rohf"}
+        The SCF reference since programs often output differently based on it.
+    method: str
+        The target AtomicInput.model.method since "free" methods may not always be
+        output (e.g., MP2 available when target is MP2 but not when target is CCSD).
+    corl_type: {"conv", "df", "cd"}
+        The algorithm for the target method since programs often output differently
+        based on it.
+    fcae: {"ae", "fc"}
+        The all-electron vs. frozen-orbital aspect.
+
+    Returns
+    -------
+    (rpv, pv, expected)
+        Of all the QCVariables `pv` that should be available, returns tuple of
+        whether `expected` and what key `rpv` in the reference `pv` should match.
+
+    """
+    contractual_qcvars = [
+        "HF TOTAL ENERGY",
+        "LCCSD CORRELATION ENERGY",
+        "LCCSD TOTAL ENERGY",
+        "LCCSD SAME-SPIN CORRELATION ENERGY",
+        "LCCSD SINGLES ENERGY",
+        "LCCSD DOUBLES ENERGY",
+        "LCCSD OPPOSITE-SPIN CORRELATION ENERGY",
+    ]
+    if driver == "gradient" and method == "lccd":
+        contractual_qcvars.append("LCCSD TOTAL GRADIENT")
+
+    for pv in contractual_qcvars:
+        expected = True
+        if False:
+            expected = False
+
+        yield (pv, pv, expected)
+
+
 def contractual_ccsd(
     qc_module: str, driver: str, reference: str, method: str, corl_type: str, fcae: str
 ) -> Tuple[str, str, bool]:

--- a/qcengine/programs/tests/standard_suite_contracts.py
+++ b/qcengine/programs/tests/standard_suite_contracts.py
@@ -155,6 +155,10 @@ def contractual_mp2(
                 ]
             )
             or (
+                ((qc_module == "psi4-occ" and reference == "rohf" and method in ["olccd"]))
+                and pv in ["MP2 CORRELATION ENERGY", "MP2 TOTAL ENERGY", "MP2 SINGLES ENERGY",]
+            )
+            or (
                 (
                     (qc_module == "psi4-ccenergy" and reference == "rohf" and method == "ccsd")
                     or (qc_module == "nwchem-tce" and method in ["ccsd", "ccsd(t)"])
@@ -429,9 +433,33 @@ def contractual_ccsd_prt_pr(
         contractual_qcvars.append("CCSD(T) TOTAL GRADIENT")
 
     for pv in contractual_qcvars:
-        print("WW", qc_module, driver, reference, method, corl_type, fcae, pv)
+        # print("WW", qc_module, driver, reference, method, corl_type, fcae, pv)
         expected = True
         if False:
             expected = False
+
+        yield (pv, pv, expected)
+
+
+def contractual_olccd(
+    qc_module: str, driver: str, reference: str, method: str, corl_type: str, fcae: str
+) -> Tuple[str, str, bool]:
+    """Of the list of QCVariables an ideal OLCCD should produce, returns whether or
+    not each is expected, given the calculation circumstances (like QC program).
+
+    """
+    contractual_qcvars = [
+        "HF TOTAL ENERGY",
+        "OLCCD CORRELATION ENERGY",
+        "OLCCD TOTAL ENERGY",
+        "OLCCD REFERENCE CORRECTION ENERGY",
+        "OLCCD SAME-SPIN CORRELATION ENERGY",
+        "OLCCD OPPOSITE-SPIN CORRELATION ENERGY",
+    ]
+    if driver == "gradient" and method == "olccd":
+        contractual_qcvars.append("OLCCD TOTAL GRADIENT")
+
+    for pv in contractual_qcvars:
+        expected = True
 
         yield (pv, pv, expected)

--- a/qcengine/programs/tests/standard_suite_contracts.py
+++ b/qcengine/programs/tests/standard_suite_contracts.py
@@ -185,6 +185,56 @@ def contractual_mp2(
 #        # TODO check CUSTOM SCS-MP2 _absent_
 
 
+def contractual_lccd(
+    qc_module: str, driver: str, reference: str, method: str, corl_type: str, fcae: str
+) -> Tuple[str, str, bool]:
+    """Of the list of QCVariables an ideal LCCD should produce, returns whether or
+    not each is expected, given the calculation circumstances (like QC program).
+
+    Parameters
+    ----------
+    qc_module : str
+        The program or subprogram running the job (e.g., "cfour" or "cfour-ecc").
+    driver : {"energy", "gradient", "hessian"}
+        The derivative level that should be expected.
+    reference: {"rhf", "uhf", "rohf"}
+        The SCF reference since programs often output differently based on it.
+    method: str
+        The target AtomicInput.model.method since "free" methods may not always be
+        output (e.g., MP2 available when target is MP2 but not when target is CCSD).
+    corl_type: {"conv", "df", "cd"}
+        The algorithm for the target method since programs often output differently
+        based on it.
+    fcae: {"ae", "fc"}
+        The all-electron vs. frozen-orbital aspect.
+
+    Returns
+    -------
+    (rpv, pv, expected)
+        Of all the QCVariables `pv` that should be available, returns tuple of
+        whether `expected` and what key `rpv` in the reference `pv` should match.
+
+    """
+    contractual_qcvars = [
+        "HF TOTAL ENERGY",
+        "LCCD CORRELATION ENERGY",
+        "LCCD TOTAL ENERGY",
+        "LCCD SAME-SPIN CORRELATION ENERGY",
+        "LCCD SINGLES ENERGY",
+        "LCCD DOUBLES ENERGY",
+        "LCCD OPPOSITE-SPIN CORRELATION ENERGY",
+    ]
+    if driver == "gradient" and method == "lccd":
+        contractual_qcvars.append("LCCD TOTAL GRADIENT")
+
+    for pv in contractual_qcvars:
+        expected = True
+        if False:
+            expected = False
+
+        yield (pv, pv, expected)
+
+
 def contractual_ccsd(
     qc_module: str, driver: str, reference: str, method: str, corl_type: str, fcae: str
 ) -> Tuple[str, str, bool]:

--- a/qcengine/programs/tests/standard_suite_contracts.py
+++ b/qcengine/programs/tests/standard_suite_contracts.py
@@ -71,7 +71,6 @@ def contractual_current(
         whether `expected` and what key `rpv` in the reference `pv` should match.
 
     """
-
     contractual_qcvars = [
         ("HF TOTAL ENERGY", "SCF TOTAL ENERGY"),
         ("HF TOTAL ENERGY", "CURRENT REFERENCE ENERGY"),
@@ -132,16 +131,21 @@ def contractual_mp2(
         if (
             (
                 (
-                    (qc_module == "psi4-occ" and reference == "rhf" and corl_type in ["df", "cd"])
-                    or (qc_module == "gamess" and reference in ["uhf", "rohf"])
-                    or (qc_module == "nwchem-tce")
+                    (qc_module == "gamess" and reference in ["uhf", "rohf"] and method == "mp2")
+                    or (qc_module == "gamess" and reference in ["rhf"] and method in ["ccsd", "ccsd(t)"])
+                    or (qc_module == "nwchem-tce" and method == "mp2")
+                    or (qc_module == "nwchem" and reference in ["rhf"] and method in ["ccsd", "ccsd(t)"])
+                    or (
+                        qc_module == "psi4-occ"
+                        and reference == "rhf"
+                        and corl_type in ["df", "cd"]
+                        and method in ["mp2", "ccsd", "ccsd(t)"]
+                    )
                 )
-                and method == "mp2"
                 and pv in ["MP2 SAME-SPIN CORRELATION ENERGY", "MP2 OPPOSITE-SPIN CORRELATION ENERGY"]
             )
             or (
-                ((qc_module == "psi4-detci"))
-                and method == "mp2"
+                ((qc_module == "psi4-detci" and method == "mp2"))
                 and pv
                 in [
                     "MP2 SAME-SPIN CORRELATION ENERGY",
@@ -151,25 +155,17 @@ def contractual_mp2(
                 ]
             )
             or (
-                ((qc_module == "gamess" and reference in ["rhf"]) or (qc_module == "nwchem" and reference in ["rhf"]))
-                and method == "ccsd"
-                and pv in ["MP2 SAME-SPIN CORRELATION ENERGY", "MP2 OPPOSITE-SPIN CORRELATION ENERGY",]
-            )
-            or (
-                ((qc_module == "psi4-occ" and reference == "rhf" and corl_type in ["df", "cd"]))
-                and method == "ccsd"
-                and pv in ["MP2 SAME-SPIN CORRELATION ENERGY", "MP2 OPPOSITE-SPIN CORRELATION ENERGY"]
-            )
-            or (
                 (
-                    (qc_module == "psi4-ccenergy" and reference == "rohf")
-                    or (qc_module == "nwchem-tce")
-                    or (qc_module == "gamess" and reference == "rohf")
+                    (qc_module == "psi4-ccenergy" and reference == "rohf" and method == "ccsd")
+                    or (qc_module == "nwchem-tce" and method in ["ccsd", "ccsd(t)"])
+                    or (qc_module == "gamess" and reference == "rohf" and method == "ccsd")
                     or (
-                        qc_module.startswith("cfour") and reference == "rohf" and fcae == "fc"
+                        qc_module.startswith("cfour")
+                        and reference == "rohf"
+                        and fcae == "fc"
+                        and method in ["ccsd", "ccsd(t)"]
                     )  # this is a cop out as c4 perfectly able to produce good rohf mp2 but not with same orbitals as ref definition on ccsd
                 )
-                and method == "ccsd"
                 and pv
                 in [
                     "MP2 CORRELATION ENERGY",
@@ -219,8 +215,6 @@ def contractual_ccsd(
         whether `expected` and what key `rpv` in the reference `pv` should match.
 
     """
-    """For CCSD, check that the expected QCVars are present in P::e.globals and wfn and match expected ref_block."""
-
     contractual_qcvars = [
         "HF TOTAL ENERGY",
         "CCSD CORRELATION ENERGY",
@@ -230,7 +224,7 @@ def contractual_ccsd(
         "CCSD DOUBLES ENERGY",
         "CCSD OPPOSITE-SPIN CORRELATION ENERGY",
     ]
-    if driver == "gradient":
+    if driver == "gradient" and method == "ccsd":
         contractual_qcvars.append("CCSD TOTAL GRADIENT")
 
     for pv in contractual_qcvars:
@@ -238,30 +232,35 @@ def contractual_ccsd(
         if (
             (
                 (
-                    (qc_module == "gamess" and reference == "rhf")
-                    or (qc_module == "nwchem-tce" and reference in ["rhf", "uhf"])
-                    or (qc_module in ["cfour-ncc", "cfour-ecc"] and reference in ["rhf"])
-                    or (qc_module == "psi4-occ" and reference == "rhf" and corl_type in ["df", "cd"])
+                    (qc_module == "gamess" and reference == "rhf" and method in ["ccsd", "ccsd(t)"])
+                    or (qc_module == "nwchem-tce" and reference in ["rhf", "uhf"] and method in ["ccsd", "ccsd(t)"])
+                    or (
+                        qc_module in ["cfour-ncc", "cfour-ecc"]
+                        and reference in ["rhf"]
+                        and method in ["ccsd", "ccsd(t)"]
+                    )
+                    or (
+                        qc_module == "psi4-occ"
+                        and reference == "rhf"
+                        and corl_type in ["df", "cd"]
+                        and method in ["ccsd", "ccsd(t)"]
+                    )
                 )
-                and method == "ccsd"
                 and pv in ["CCSD SAME-SPIN CORRELATION ENERGY", "CCSD OPPOSITE-SPIN CORRELATION ENERGY"]
             )
             or (
-                (qc_module == "cfour-vcc" and reference in ["rohf"])
-                and method == "ccsd"
+                (qc_module == "cfour-vcc" and reference in ["rohf"] and method in ["ccsd", "ccsd(t)"])
                 and pv in ["CCSD SAME-SPIN CORRELATION ENERGY", "CCSD SINGLES ENERGY", "CCSD DOUBLES ENERGY",]
             )
             or (
-                (qc_module == "cfour-ecc" and reference in ["rohf"])
-                and method == "ccsd"
+                (qc_module == "cfour-ecc" and reference in ["rohf"] and method in ["ccsd", "ccsd(t)"])
                 and pv in ["CCSD OPPOSITE-SPIN CORRELATION ENERGY", "CCSD SINGLES ENERGY", "CCSD DOUBLES ENERGY",]
             )
             or (
                 (
-                    (qc_module == "gamess" and reference in ["rohf"])
-                    or (qc_module == "nwchem-tce" and reference in ["rohf"])
+                    (qc_module == "gamess" and reference in ["rohf"] and method == "ccsd")
+                    or (qc_module == "nwchem-tce" and reference in ["rohf"] and method in ["ccsd", "ccsd(t)"])
                 )
-                and method == "ccsd"
                 and pv
                 in [
                     "CCSD SAME-SPIN CORRELATION ENERGY",
@@ -271,8 +270,7 @@ def contractual_ccsd(
                 ]
             )
             or (
-                ()
-                and method == "ccsd(t)"
+                (False)
                 and pv
                 in [
                     "CCSD CORRELATION ENERGY",
@@ -289,3 +287,51 @@ def contractual_ccsd(
         yield (pv, pv, expected)
 
     # TODO check CUSTOM SCS-CCSD _absent_
+
+
+def contractual_ccsd_prt_pr(
+    qc_module: str, driver: str, reference: str, method: str, corl_type: str, fcae: str
+) -> Tuple[str, str, bool]:
+    """Of the list of QCVariables an ideal CCSD(T) should produce, returns whether or
+    not each is expected, given the calculation circumstances (like QC program).
+
+    Parameters
+    ----------
+    qc_module : str
+        The program or subprogram running the job (e.g., "cfour" or "cfour-ecc").
+    driver : {"energy", "gradient", "hessian"}
+        The derivative level that should be expected.
+    reference: {"rhf", "uhf", "rohf"}
+        The SCF reference since programs often output differently based on it.
+    method: str
+        The target AtomicInput.model.method since "free" methods may not always be
+        output (e.g., MP2 available when target is MP2 but not when target is CCSD).
+    corl_type: {"conv", "df", "cd"}
+        The algorithm for the target method since programs often output differently
+        based on it.
+    fcae: {"ae", "fc"}
+        The all-electron vs. frozen-orbital aspect.
+
+    Returns
+    -------
+    (rpv, pv, expected)
+        Of all the QCVariables `pv` that should be available, returns tuple of
+        whether `expected` and what key `rpv` in the reference `pv` should match.
+
+    """
+    contractual_qcvars = [
+        "HF TOTAL ENERGY",
+        "(T) CORRECTION ENERGY",
+        "CCSD(T) CORRELATION ENERGY",
+        "CCSD(T) TOTAL ENERGY",
+    ]
+    if driver == "gradient":
+        contractual_qcvars.append("CCSD(T) TOTAL GRADIENT")
+
+    for pv in contractual_qcvars:
+        print("WW", qc_module, driver, reference, method, corl_type, fcae, pv)
+        expected = True
+        if False:
+            expected = False
+
+        yield (pv, pv, expected)

--- a/qcengine/programs/tests/standard_suite_contracts.py
+++ b/qcengine/programs/tests/standard_suite_contracts.py
@@ -139,7 +139,7 @@ def contractual_mp2(
                         qc_module == "psi4-occ"
                         and reference == "rhf"
                         and corl_type in ["df", "cd"]
-                        and method in ["mp2", "ccsd", "ccsd(t)"]
+                        and method in ["mp2", "lccd", "ccsd", "ccsd(t)"]
                     )
                 )
                 and pv in ["MP2 SAME-SPIN CORRELATION ENERGY", "MP2 OPPOSITE-SPIN CORRELATION ENERGY"]
@@ -233,7 +233,9 @@ def contractual_lccd(
 
     for pv in contractual_qcvars:
         expected = True
-        if False:
+        if (
+            (qc_module == "psi4-occ" and reference == "rhf" and corl_type in ["df", "cd"] and method == "lccd")
+        ) and pv in ["LCCD SAME-SPIN CORRELATION ENERGY", "LCCD OPPOSITE-SPIN CORRELATION ENERGY"]:
             expected = False
 
         yield (pv, pv, expected)

--- a/qcengine/programs/tests/standard_suite_ref.py
+++ b/qcengine/programs/tests/standard_suite_ref.py
@@ -244,6 +244,9 @@ _std_suite = [
                     -0.00022012333306,
                 ]
             ).reshape((-1, 3)),
+            "LCCD CORRELATION ENERGY": -0.0834347185,  # p4n
+            "LCCD SINGLES ENERGY": 0.0,
+            "LCCD SAME-SPIN CORRELATION ENERGY": -0.0024003297,  # occ
             "CCSD CORRELATION ENERGY": -0.08217287869,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.002377557359,
@@ -283,6 +286,9 @@ _std_suite = [
             "MP2 TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.025490652204, 0.0, 0.013491755791, -0.012745326102, 0.0, -0.013491755791, -0.012745326102,]
             ).reshape((-1, 3)),
+            "LCCD CORRELATION ENERGY": -0.1770086091,  # p4n
+            "LCCD SINGLES ENERGY": 0.0,
+            "LCCD SAME-SPIN CORRELATION ENERGY": -0.0341268118,  # occ
             "CCSD CORRELATION ENERGY": -0.17387203707017695,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.033935818857082,
@@ -309,6 +315,9 @@ _std_suite = [
             "MP2 TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.013731673196, 0.0, 0.005352105826, -0.006865836598, 0.0, -0.005352105826, -0.006865836598,]
             ).reshape((-1, 3)),
+            "LCCD CORRELATION ENERGY": -0.2167878305,  # p4n
+            "LCCD SINGLES ENERGY": 0.0,
+            "LCCD SAME-SPIN CORRELATION ENERGY": -0.0401306050,  # occ
             "CCSD CORRELATION ENERGY": -0.213298055172,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.039907245914335,
@@ -547,6 +556,9 @@ _std_suite = [
                     -0.000226972977580,
                 ]
             ).reshape((-1, 3)),
+            "LCCD CORRELATION ENERGY": -0.0824313452,  # p4n
+            "LCCD SINGLES ENERGY": 0.0,
+            "LCCD SAME-SPIN CORRELATION ENERGY": -0.0022532590,  # occ
             "CCSD CORRELATION ENERGY": -0.08117105566,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.002231965267,
@@ -586,6 +598,9 @@ _std_suite = [
             "MP2 TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.026279427993, 0.0, 0.013998590506, -0.013139713997, 0.0, -0.013998590506, -0.013139713997,]
             ).reshape((-1, 3)),
+            "LCCD CORRELATION ENERGY": -0.1747537294,  # p4n
+            "LCCD SINGLES ENERGY": 0.0,
+            "LCCD SAME-SPIN CORRELATION ENERGY": -0.0334378864,  # occ
             "CCSD CORRELATION ENERGY": -0.1716495276680232,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.033248190929062,
@@ -612,6 +627,9 @@ _std_suite = [
             "MP2 TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.014740098324, 0.0, 0.005852228009, -0.007370049162, 0.0, -0.005852228009, -0.007370049162,]
             ).reshape((-1, 3)),
+            "LCCD CORRELATION ENERGY": -0.1917024115,  # p4n
+            "LCCD SINGLES ENERGY": 0.0,
+            "LCCD SAME-SPIN CORRELATION ENERGY": -0.0367596656,  # occ
             "CCSD CORRELATION ENERGY": -0.188317222733,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.036526852874970,
@@ -2885,6 +2903,9 @@ _std_suite = [
             "MP2 TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.00281165, 0.0, 0.0, -0.00281165]  # occ findif-5 ae df+conv
             ).reshape((-1, 3)),
+            "LCCD CORRELATION ENERGY": -0.2098900858,  # p4n
+            "LCCD SINGLES ENERGY": 0.0,
+            "LCCD SAME-SPIN CORRELATION ENERGY": -0.048336089041,  # fnocc
             "CCSD CORRELATION ENERGY": -0.20872812,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.04857038,
@@ -2907,6 +2928,9 @@ _std_suite = [
             "MP2 TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.00281136, 0.0, 0.0, -0.00281136]  # occ findif-5 ae cd+conv
             ).reshape((-1, 3)),
+            "LCCD CORRELATION ENERGY": -0.2099004485,  # p4n
+            "LCCD SINGLES ENERGY": 0.0,
+            "LCCD SAME-SPIN CORRELATION ENERGY": -0.048339111990,  # fnocc
             "CCSD CORRELATION ENERGY": -0.20873814,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.04857333,

--- a/qcengine/programs/tests/standard_suite_ref.py
+++ b/qcengine/programs/tests/standard_suite_ref.py
@@ -119,7 +119,6 @@ _scf_h2o_adz_cd_rhf = -76.04132169763341
 _scf_nh2_adz_cd_uhf = -55.57506886675886
 _scf_nh2_adz_cd_rohf = -55.57065536578708
 
-
 _std_suite = [
     # <<<  CONV-AE-CONV  >>>
     {
@@ -149,6 +148,9 @@ _std_suite = [
             "LCCD CORRELATION ENERGY": -0.2099060277,  # p4n
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.048339903547,  # fnocc
+            "LCCSD CORRELATION ENERGY": -0.2107436391,  # p4n
+            "LCCSD SINGLES ENERGY": 0.0,
+            "LCCSD SAME-SPIN CORRELATION ENERGY": -0.048460183760,  # fnocc
             "CCSD CORRELATION ENERGY": -0.208743643,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.04857419039,
@@ -176,6 +178,9 @@ _std_suite = [
             "LCCD CORRELATION ENERGY": -0.2318870702,  # p4n
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.049937236558,  # fnocc
+            "LCCSD CORRELATION ENERGY": -0.2341051403,  # p4n
+            "LCCSD SINGLES ENERGY": 0.0,
+            "LCCSD SAME-SPIN CORRELATION ENERGY": -0.050442387759,  # fnocc
             "CCSD CORRELATION ENERGY": -0.2294105794,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.050177977945205,
@@ -205,6 +210,9 @@ _std_suite = [
             "LCCD CORRELATION ENERGY": -0.2786913134,  # p4n
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.057792990490,  # fnocc
+            "LCCSD CORRELATION ENERGY": -0.2808517417,  # p4n
+            "LCCSD SINGLES ENERGY": 0.0,
+            "LCCSD SAME-SPIN CORRELATION ENERGY": -0.058297242512,  # fnocc
             "CCSD CORRELATION ENERGY": -0.275705491773,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.058006927914493,
@@ -247,6 +255,8 @@ _std_suite = [
             "LCCD CORRELATION ENERGY": -0.0834347185,  # p4n
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0024003297,  # occ
+            "LCCSD CORRELATION ENERGY": -0.0848110820,  # p4n
+            "LCCSD SINGLES ENERGY": 0.0,
             "CCSD CORRELATION ENERGY": -0.08217287869,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.002377557359,
@@ -289,6 +299,8 @@ _std_suite = [
             "LCCD CORRELATION ENERGY": -0.1770086091,  # p4n
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0341268118,  # occ
+            "LCCSD CORRELATION ENERGY": -0.1786081472,  # p4n
+            "LCCSD SINGLES ENERGY": 0.0,
             "CCSD CORRELATION ENERGY": -0.17387203707017695,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.033935818857082,
@@ -318,6 +330,8 @@ _std_suite = [
             "LCCD CORRELATION ENERGY": -0.2167878305,  # p4n
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0401306050,  # occ
+            "LCCSD CORRELATION ENERGY": -0.2185061347,  # p4n
+            "LCCSD SINGLES ENERGY": 0.0,
             "CCSD CORRELATION ENERGY": -0.213298055172,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.039907245914335,
@@ -358,6 +372,8 @@ _std_suite = [
                     -0.000233556107879,
                 ]
             ).reshape((-1, 3)),
+            "LCCD CORRELATION ENERGY": -0.0834094914,  # p4n
+            "LCCSD CORRELATION ENERGY": -0.0861427228,  # p4n
             "CCSD CORRELATION ENERGY": -0.08357160616,
             "CCSD SINGLES ENERGY": -0.0011743271,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.00244892164,
@@ -397,6 +413,8 @@ _std_suite = [
             "MP2 TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.025609525826, 0.0, 0.013506941035, -0.012804762913, 0.0, -0.013506941035, -0.012804762913,]
             ).reshape((-1, 3)),
+            "LCCD CORRELATION ENERGY": -0.1791714105,  # p4n
+            "LCCSD CORRELATION ENERGY": -0.1830545845,  # p4n
             "CCSD CORRELATION ENERGY": -0.178236032911,
             "CCSD SINGLES ENERGY": -0.00327524740575,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.033982707798170,
@@ -423,6 +441,8 @@ _std_suite = [
             "MP2 TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.0138883429, 0.0, 0.005389090661, -0.00694417145, 0.0, -0.005389090661, -0.00694417145,]
             ).reshape((-1, 3)),
+            "LCCD CORRELATION ENERGY": -0.2191039411,  # p4n
+            "LCCSD CORRELATION ENERGY": -0.2231241199,  # p4n
             "CCSD CORRELATION ENERGY": -0.217849506326,
             "CCSD SINGLES ENERGY": -0.00338286103325,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.039891470497466,
@@ -460,6 +480,9 @@ _std_suite = [
             "LCCD CORRELATION ENERGY": -0.2079585027,  # p4n
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.047635656759,  # fnocc
+            "LCCSD CORRELATION ENERGY": -0.2087915976,  # p4n
+            "LCCSD SINGLES ENERGY": 0.0,
+            "LCCSD SAME-SPIN CORRELATION ENERGY": -0.047754723454,  # fnocc
             "CCSD CORRELATION ENERGY": -0.2068152041,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.0478712079,
@@ -487,6 +510,9 @@ _std_suite = [
             "LCCD CORRELATION ENERGY": -0.2296135965,  # p4n
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.049154543318,  # fnocc
+            "LCCSD CORRELATION ENERGY": -0.2318316308,  # p4n
+            "LCCSD SINGLES ENERGY": 0.0,
+            "LCCSD SAME-SPIN CORRELATION ENERGY": -0.049659952324,  # fnocc
             "CCSD CORRELATION ENERGY": -0.2271733460,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.049398348010672,
@@ -516,6 +542,9 @@ _std_suite = [
             "LCCD CORRELATION ENERGY": -0.2531942099,  # p4n
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.053842594884,  # fnocc
+            "LCCSD CORRELATION ENERGY": -0.2553008820,  # p4n
+            "LCCSD SINGLES ENERGY": 0.0,
+            "LCCSD SAME-SPIN CORRELATION ENERGY": -0.054321637599,  # fnocc
             "CCSD CORRELATION ENERGY": -0.250330548844,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.054051928864870,
@@ -559,6 +588,8 @@ _std_suite = [
             "LCCD CORRELATION ENERGY": -0.0824313452,  # p4n
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0022532590,  # occ
+            "LCCSD CORRELATION ENERGY": -0.0837903430,  # p4n
+            "LCCSD SINGLES ENERGY": 0.0,
             "CCSD CORRELATION ENERGY": -0.08117105566,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.002231965267,
@@ -601,6 +632,8 @@ _std_suite = [
             "LCCD CORRELATION ENERGY": -0.1747537294,  # p4n
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0334378864,  # occ
+            "LCCSD CORRELATION ENERGY": -0.1763496376,  # p4n
+            "LCCSD SINGLES ENERGY": 0.0,
             "CCSD CORRELATION ENERGY": -0.1716495276680232,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.033248190929062,
@@ -630,6 +663,8 @@ _std_suite = [
             "LCCD CORRELATION ENERGY": -0.1917024115,  # p4n
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0367596656,  # occ
+            "LCCSD CORRELATION ENERGY": -0.1933416962,  # p4n
+            "LCCSD SINGLES ENERGY": 0.0,
             "CCSD CORRELATION ENERGY": -0.188317222733,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.036526852874970,
@@ -670,6 +705,8 @@ _std_suite = [
                     -0.000240521034770,
                 ]
             ).reshape((-1, 3)),
+            "LCCD CORRELATION ENERGY": -0.0824056198,  # p4n
+            "LCCSD CORRELATION ENERGY": -0.0851177481,  # p4n
             "CCSD CORRELATION ENERGY": -0.08256719,
             "CCSD SINGLES ENERGY": -0.00117001688,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.00230304,
@@ -708,6 +745,8 @@ _std_suite = [
             "MP2 TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.026398091851, 0.0, 0.014012163884, -0.013199045925, 0.0, -0.014012163884, -0.013199045925,]
             ).reshape((-1, 3)),
+            "LCCD CORRELATION ENERGY": -0.1769020687,  # p4n
+            "LCCSD CORRELATION ENERGY": -0.1807707740,  # p4n
             "CCSD CORRELATION ENERGY": -0.175988485854028,
             "CCSD SINGLES ENERGY": -0.003256808469230,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.033291143258924,
@@ -733,6 +772,8 @@ _std_suite = [
             "MP2 TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.014894057335, 0.0, 0.005886660707, -0.007447028667, 0.0, -0.005886660707, -0.007447028667,]
             ).reshape((-1, 3)),
+            "LCCD CORRELATION ENERGY": -0.1939920915,  # p4n
+            "LCCSD CORRELATION ENERGY": -0.1979175937,  # p4n
             "CCSD CORRELATION ENERGY": -0.19282621471297376,
             "CCSD SINGLES ENERGY": -0.003354603508621,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.036502859698546,
@@ -2906,6 +2947,9 @@ _std_suite = [
             "LCCD CORRELATION ENERGY": -0.2098900858,  # p4n
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.048336089041,  # fnocc
+            "LCCSD CORRELATION ENERGY": -0.2107275173,  # p4n
+            "LCCSD SINGLES ENERGY": 0.0,
+            "LCCSD SAME-SPIN CORRELATION ENERGY": -0.048456320034,  # fnocc
             "CCSD CORRELATION ENERGY": -0.20872812,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.04857038,
@@ -2931,6 +2975,9 @@ _std_suite = [
             "LCCD CORRELATION ENERGY": -0.2099004485,  # p4n
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.048339111990,  # fnocc
+            "LCCSD CORRELATION ENERGY": -0.2107380019,  # p4n
+            "LCCSD SINGLES ENERGY": 0.0,
+            "LCCSD SAME-SPIN CORRELATION ENERGY": -0.048459381537,  # fnocc
             "CCSD CORRELATION ENERGY": -0.20873814,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.04857333,
@@ -3044,14 +3091,29 @@ for calc in _std_suite:
             calc["data"]["LCCD TOTAL ENERGY"] = (
                 calc["data"]["LCCD CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
             )
-            calc["data"]["LCCD DOUBLES ENERGY"] = (
-                calc["data"]["LCCD CORRELATION ENERGY"] - calc["data"]["LCCD SINGLES ENERGY"]
+            if "LCCD SAME-SPIN CORRELATION ENERGY" in calc["data"]:
+                calc["data"]["LCCD DOUBLES ENERGY"] = (
+                    calc["data"]["LCCD CORRELATION ENERGY"] - calc["data"]["LCCD SINGLES ENERGY"]
+                )
+                calc["data"]["LCCD OPPOSITE-SPIN CORRELATION ENERGY"] = (
+                    calc["data"]["LCCD CORRELATION ENERGY"]
+                    - calc["data"]["LCCD SAME-SPIN CORRELATION ENERGY"]
+                    - calc["data"]["LCCD SINGLES ENERGY"]
+                )
+
+        if "LCCSD CORRELATION ENERGY" in calc["data"]:
+            calc["data"]["LCCSD TOTAL ENERGY"] = (
+                calc["data"]["LCCSD CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
             )
-            calc["data"]["LCCD OPPOSITE-SPIN CORRELATION ENERGY"] = (
-                calc["data"]["LCCD CORRELATION ENERGY"]
-                - calc["data"]["LCCD SAME-SPIN CORRELATION ENERGY"]
-                - calc["data"]["LCCD SINGLES ENERGY"]
-            )
+            if "LCCSD SAME-SPIN CORRELATION ENERGY" in calc["data"]:
+                calc["data"]["LCCSD DOUBLES ENERGY"] = (
+                    calc["data"]["LCCSD CORRELATION ENERGY"] - calc["data"]["LCCSD SINGLES ENERGY"]
+                )
+                calc["data"]["LCCSD OPPOSITE-SPIN CORRELATION ENERGY"] = (
+                    calc["data"]["LCCSD CORRELATION ENERGY"]
+                    - calc["data"]["LCCSD SAME-SPIN CORRELATION ENERGY"]
+                    - calc["data"]["LCCSD SINGLES ENERGY"]
+                )
 
         if "CCSD CORRELATION ENERGY" in calc["data"]:
             calc["data"]["CCSD TOTAL ENERGY"] = (

--- a/qcengine/programs/tests/standard_suite_ref.py
+++ b/qcengine/programs/tests/standard_suite_ref.py
@@ -119,6 +119,7 @@ _scf_h2o_adz_cd_rhf = -76.04132169763341
 _scf_nh2_adz_cd_uhf = -55.57506886675886
 _scf_nh2_adz_cd_rohf = -55.57065536578708
 
+
 _std_suite = [
     # <<<  CONV-AE-CONV  >>>
     {
@@ -156,6 +157,9 @@ _std_suite = [
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.04857419039,
             "CCSD TOTAL GRADIENT": np.array([0.0, 0.0, 0.001989217717, 0.0, 0.0, -0.001989217717,]).reshape((-1, 3)),
             "(T) CORRECTION ENERGY": -0.0019363896542312043,
+            "OLCCD REFERENCE CORRECTION ENERGY": 0.0005522939,  # p4n
+            "OLCCD CORRELATION ENERGY": -0.2104417743,  # p4n
+            "OLCCD SAME-SPIN CORRELATION ENERGY": -0.0484443079,  # occ
         },
     },
     {
@@ -188,6 +192,9 @@ _std_suite = [
                 [0.0, 0.0, 0.007512595487, 0.0, 0.004613769715, -0.003756297743, 0.0, -0.004613769715, -0.003756297743,]
             ).reshape((-1, 3)),
             "(T) CORRECTION ENERGY": -0.00523856,
+            "OLCCD REFERENCE CORRECTION ENERGY": 0.0011895155,  # p4n
+            "OLCCD CORRELATION ENERGY": -0.2330452995,  # p4n
+            "OLCCD SAME-SPIN CORRELATION ENERGY": -0.0503175223,  # occ
         },
     },
     {
@@ -220,6 +227,9 @@ _std_suite = [
                 [0.0, 0.0, -0.003374258422, 0.0, -0.002334452569, 0.001687129211, 0.0, 0.002334452569, 0.001687129211,]
             ).reshape((-1, 3)),
             "(T) CORRECTION ENERGY": -0.007263596331,
+            "OLCCD REFERENCE CORRECTION ENERGY": 0.0013521561,  # p4n
+            "OLCCD CORRELATION ENERGY": -0.2800053174,  # p4n
+            "OLCCD SAME-SPIN CORRELATION ENERGY": -0.0582676514,  # occ
         },
     },
     {
@@ -277,6 +287,9 @@ _std_suite = [
                 ]
             ).reshape((-1, 3)),
             "(T) CORRECTION ENERGY": -0.00062614,
+            "OLCCD REFERENCE CORRECTION ENERGY": 0.0014842084,  # p4n
+            "OLCCD CORRELATION ENERGY": -0.0847413506,  # p4n
+            "OLCCD SAME-SPIN CORRELATION ENERGY": -0.0024486744,  # occ
         },
     },
     {
@@ -308,6 +321,9 @@ _std_suite = [
                 [0.0, 0.0, 0.029278727285, 0.0, 0.015813927533, -0.014639363642, 0.0, -0.015813927533, -0.014639363642,]
             ).reshape((-1, 3)),
             "(T) CORRECTION ENERGY": -0.00384378,
+            "OLCCD REFERENCE CORRECTION ENERGY": 0.0011118724,  # p4n
+            "OLCCD CORRELATION ENERGY": -0.1781057943,  # p4n
+            "OLCCD SAME-SPIN CORRELATION ENERGY": -0.0344689234,  # occ
         },
     },
     {
@@ -339,6 +355,9 @@ _std_suite = [
                 [0.0, 0.0, 0.016842165003, 0.0, 0.007150136873, -0.008421082502, 0.0, -0.007150136873, -0.008421082502,]
             ).reshape((-1, 3)),
             "(T) CORRECTION ENERGY": -0.00516659,
+            "OLCCD REFERENCE CORRECTION ENERGY": 0.0012856903,  # p4n
+            "OLCCD CORRELATION ENERGY": -0.2180560836,  # p4n
+            "OLCCD SAME-SPIN CORRELATION ENERGY": -0.0405122800,  # occ
         },
     },
     {
@@ -394,6 +413,9 @@ _std_suite = [
                 ]
             ).reshape((-1, 3)),
             "(T) CORRECTION ENERGY": -0.000713766189,
+            "OLCCD REFERENCE CORRECTION ENERGY": -0.0000399018,  # p4n
+            "OLCCD CORRELATION ENERGY": -0.0862654609,  # p4n
+            "OLCCD SAME-SPIN CORRELATION ENERGY": -0.0024486744,  # occ
         },
     },
     {
@@ -422,6 +444,9 @@ _std_suite = [
                 [0.0, 0.0, 0.029273628227, 0.0, 0.015808308241, -0.014636814114, 0.0, -0.015808308241, -0.014636814114,]
             ).reshape((-1, 3)),
             "(T) CORRECTION ENERGY": -0.003901085777,
+            "OLCCD REFERENCE CORRECTION ENERGY": -0.0033018315,  # p4n
+            "OLCCD CORRELATION ENERGY": -0.1825194982,  # p4n
+            "OLCCD SAME-SPIN CORRELATION ENERGY": -0.0344689234,  # occ
         },
     },
     {
@@ -450,6 +475,9 @@ _std_suite = [
                 [0.0, 0.0, 0.016833254665, 0.0, 0.007144029475, -0.008416627332, 0.0, -0.007144029475, -0.008416627332,]
             ).reshape((-1, 3)),
             "(T) CORRECTION ENERGY": -0.005233938447,
+            "OLCCD REFERENCE CORRECTION ENERGY": -0.0033240178,  # p4n
+            "OLCCD CORRELATION ENERGY": -0.2226657917,  # p4n
+            "OLCCD SAME-SPIN CORRELATION ENERGY": -0.0405122800,  # occ
         },
     },
     # <<<  CONV-FC-CONV  >>>
@@ -3134,6 +3162,16 @@ for calc in _std_suite:
             )
             calc["data"]["CCSD(T) TOTAL ENERGY"] = (
                 calc["data"]["CCSD(T) CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
+            )
+
+        if "OLCCD CORRELATION ENERGY" in calc["data"]:
+            calc["data"]["OLCCD TOTAL ENERGY"] = (
+                calc["data"]["OLCCD CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
+            )
+            calc["data"]["OLCCD OPPOSITE-SPIN CORRELATION ENERGY"] = (
+                calc["data"]["OLCCD CORRELATION ENERGY"]
+                - calc["data"]["OLCCD REFERENCE CORRECTION ENERGY"]
+                - calc["data"]["OLCCD SAME-SPIN CORRELATION ENERGY"]
             )
 
     calc["data"].update(_std_generics[f"{calc['meta']['system']}_{calc['meta']['basis']}_{calc['meta']['fcae']}"])

--- a/qcengine/programs/tests/standard_suite_ref.py
+++ b/qcengine/programs/tests/standard_suite_ref.py
@@ -827,10 +827,10 @@ _std_suite = [
             "HF TOTAL ENERGY": _scf_hf_dz_pk_rhf,
             "MP2 CORRELATION ENERGY": -0.203778449,
             "MP2 SINGLES ENERGY": 0.0,
-            "MP2 SAME-SPIN CORRELATION ENERGY": 86,  # can't calc
+            "LCCD CORRELATION ENERGY": -0.20990784,  # dfocc
+            "LCCD SINGLES ENERGY": 0.0,
             "CCSD CORRELATION ENERGY": -0.20874537,
             "CCSD SINGLES ENERGY": 0.0,
-            "CCSD SAME-SPIN CORRELATION ENERGY": 86,  # can't calc
             "(T) CORRECTION ENERGY": -0.00193646,
         },
     },
@@ -847,10 +847,10 @@ _std_suite = [
             "HF TOTAL ENERGY": _scf_h2o_adz_pk_rhf,
             "MP2 CORRELATION ENERGY": -0.22188844,
             "MP2 SINGLES ENERGY": 0.0,
-            "MP2 SAME-SPIN CORRELATION ENERGY": 20,  # can't calc
+            "LCCD CORRELATION ENERGY": -0.23188996,  # dfocc
+            "LCCD SINGLES ENERGY": 0.0,
             "CCSD CORRELATION ENERGY": -0.22941330,
             "CCSD SINGLES ENERGY": 0.0,
-            "CCSD SAME-SPIN CORRELATION ENERGY": 85,  # can't calc
             "(T) CORRECTION ENERGY": -0.00523874,
         },
     },
@@ -867,10 +867,10 @@ _std_suite = [
             "HF TOTAL ENERGY": _scf_h2o_qz2p_pk_rhf,
             "MP2 CORRELATION ENERGY": -0.27018509,
             "MP2 SINGLES ENERGY": 0.0,
-            "MP2 SAME-SPIN CORRELATION ENERGY": 21,  # can't calc
+            "LCCD CORRELATION ENERGY": -0.27869144,  # dfocc
+            "LCCD SINGLES ENERGY": 0.0,
             "CCSD CORRELATION ENERGY": -0.27570541,
             "CCSD SINGLES ENERGY": 0.0,
-            "CCSD SAME-SPIN CORRELATION ENERGY": 84,  # can't calc
             "(T) CORRECTION ENERGY": -0.00726403,
         },
     },
@@ -888,6 +888,9 @@ _std_suite = [
             "MP2 CORRELATION ENERGY": -0.059477703268,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.001918940186,
+            "LCCD CORRELATION ENERGY": -0.08343267,  # dfocc
+            "LCCD SINGLES ENERGY": 0.0,
+            "LCCD SAME-SPIN CORRELATION ENERGY": -0.00240067,  # dfocc
         },
     },
     {
@@ -904,6 +907,9 @@ _std_suite = [
             "MP2 CORRELATION ENERGY": -0.15485159,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.03520588,
+            "LCCD CORRELATION ENERGY": -0.17701281,  # dfocc
+            "LCCD SINGLES ENERGY": 0.0,
+            "LCCD SAME-SPIN CORRELATION ENERGY": -0.03413088,  # dfocc
         },
     },
     {
@@ -920,6 +926,9 @@ _std_suite = [
             "MP2 CORRELATION ENERGY": -0.19552518,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.04162160,
+            "LCCD CORRELATION ENERGY": -0.21678793,  # dfocc
+            "LCCD SINGLES ENERGY": 0.0,
+            "LCCD SAME-SPIN CORRELATION ENERGY": -0.04013550,  # dfocc
         },
     },
     {
@@ -984,10 +993,10 @@ _std_suite = [
             "HF TOTAL ENERGY": _scf_hf_dz_pk_rhf,
             "MP2 CORRELATION ENERGY": -0.20162439774,
             "MP2 SINGLES ENERGY": 0.0,
-            "MP2 SAME-SPIN CORRELATION ENERGY": 29,  # can't calc
+            "LCCD CORRELATION ENERGY": -0.20796060,  # dfocc
+            "LCCD SINGLES ENERGY": 0.0,
             "CCSD CORRELATION ENERGY": -0.20681721,
             "CCSD SINGLES ENERGY": 0.0,
-            "CCSD SAME-SPIN CORRELATION ENERGY": 83,  # can't calc
             "(T) CORRECTION ENERGY": -0.00192057,
         },
     },
@@ -1004,10 +1013,10 @@ _std_suite = [
             "HF TOTAL ENERGY": _scf_h2o_adz_pk_rhf,
             "MP2 CORRELATION ENERGY": -0.21939933,
             "MP2 SINGLES ENERGY": 0.0,
-            "MP2 SAME-SPIN CORRELATION ENERGY": 20,  # can't calc
+            "LCCD CORRELATION ENERGY": -0.22961687,  # dfocc
+            "LCCD SINGLES ENERGY": 0.0,
             "CCSD CORRELATION ENERGY": -0.22717646,
             "CCSD SINGLES ENERGY": 0.0,
-            "CCSD SAME-SPIN CORRELATION ENERGY": 82,  # can't calc
             "(T) CORRECTION ENERGY": -0.00521255,
         },
     },
@@ -1024,10 +1033,10 @@ _std_suite = [
             "HF TOTAL ENERGY": _scf_h2o_qz2p_pk_rhf,
             "MP2 CORRELATION ENERGY": -0.24514540,
             "MP2 SINGLES ENERGY": 0.0,
-            "MP2 SAME-SPIN CORRELATION ENERGY": 21,  # can't calc
+            "LCCD CORRELATION ENERGY": -0.25319438,  # dfocc
+            "LCCD SINGLES ENERGY": 0.0,
             "CCSD CORRELATION ENERGY": -0.25033052,
             "CCSD SINGLES ENERGY": 0.0,
-            "CCSD SAME-SPIN CORRELATION ENERGY": 81,  # can't calc
             "(T) CORRECTION ENERGY": -0.00709694,
         },
     },
@@ -1045,6 +1054,9 @@ _std_suite = [
             "MP2 CORRELATION ENERGY": -0.05841222894,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.0017676971,
+            "LCCD CORRELATION ENERGY": -0.08242955,  # dfocc
+            "LCCD SINGLES ENERGY": 0.0,
+            "LCCD SAME-SPIN CORRELATION ENERGY": -0.00225358,  # dfocc
         },
     },
     {
@@ -1061,6 +1073,9 @@ _std_suite = [
             "MP2 CORRELATION ENERGY": -0.15241971,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.03445776,
+            "LCCD CORRELATION ENERGY": -0.17475833,  # dfocc
+            "LCCD SINGLES ENERGY": 0.0,
+            "LCCD SAME-SPIN CORRELATION ENERGY": -0.03344184,  # dfocc
         },
     },
     {
@@ -1077,6 +1092,9 @@ _std_suite = [
             "MP2 CORRELATION ENERGY": -0.17117906,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.03822980,
+            "LCCD CORRELATION ENERGY": -0.19170259,  # dfocc
+            "LCCD SINGLES ENERGY": 0.0,
+            "LCCD SAME-SPIN CORRELATION ENERGY": -0.03676455,  # dfocc
         },
     },
     {
@@ -1145,9 +1163,10 @@ _std_suite = [
             "MP2 TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.0027998, 0.0, 0.0, -0.0027998]  # dfmp2 findif-5 ae pk+df
             ).reshape((-1, 3)),
+            "LCCD CORRELATION ENERGY": -0.2100497124,  # p4n
+            "LCCD SINGLES ENERGY": 0.0000000000,
             "CCSD CORRELATION ENERGY": -0.20888438,
             "CCSD SINGLES ENERGY": 0.0,
-            "CCSD SAME-SPIN CORRELATION ENERGY": 79,  # can't calc
             "(T) CORRECTION ENERGY": -0.00193859,
         },
     },
@@ -1157,18 +1176,19 @@ _std_suite = [
             "basis": "aug-cc-pvdz",
             "scf_type": "pk",
             "reference": "rhf",
-            "fcae": "fc",
+            "fcae": "ae",
             "corl_type": "df",
         },
         "data": {
             "HF TOTAL ENERGY": _scf_h2o_adz_pk_rhf,
-            "MP2 CORRELATION ENERGY": -0.21939942,
+            "MP2 CORRELATION ENERGY": -0.22188894,
             "MP2 SINGLES ENERGY": 0.0,
-            "MP2 SAME-SPIN CORRELATION ENERGY": -0.05588210,
-            "CCSD CORRELATION ENERGY": -0.22730597,
+            "MP2 SAME-SPIN CORRELATION ENERGY": -0.05674808,
+            "LCCD CORRELATION ENERGY": -0.2320261414,  # p4n
+            "LCCD SINGLES ENERGY": 0.0000000000,
+            "CCSD CORRELATION ENERGY": -0.22954333,
             "CCSD SINGLES ENERGY": 0.0,
-            "CCSD SAME-SPIN CORRELATION ENERGY": 79,  # can't calc
-            "(T) CORRECTION ENERGY": -0.00521769,
+            "(T) CORRECTION ENERGY": -0.00524393,
         },
     },
     {
@@ -1177,18 +1197,19 @@ _std_suite = [
             "basis": "cfour-qz2p",
             "scf_type": "pk",
             "reference": "rhf",
-            "fcae": "fc",
+            "fcae": "ae",
             "corl_type": "df",
         },
         "data": {
             "HF TOTAL ENERGY": _scf_h2o_qz2p_pk_rhf,
-            "MP2 CORRELATION ENERGY": -0.24514425,
+            "MP2 CORRELATION ENERGY": -0.27018057,
             "MP2 SINGLES ENERGY": 0.0,
-            "MP2 SAME-SPIN CORRELATION ENERGY": -0.06126481,
-            "CCSD CORRELATION ENERGY": -0.25033030,
+            "MP2 SAME-SPIN CORRELATION ENERGY": -0.06530212,
+            "LCCD CORRELATION ENERGY": -0.2786878429,  # p4n
+            "LCCD SINGLES ENERGY": 0.0000000000,
+            "CCSD CORRELATION ENERGY": -0.27570207,
             "CCSD SINGLES ENERGY": 0.0,
-            "CCSD SAME-SPIN CORRELATION ENERGY": 79,  # can't calc
-            "(T) CORRECTION ENERGY": -0.00709666,
+            "(T) CORRECTION ENERGY": -0.00726375,
         },
     },
     {
@@ -1205,6 +1226,9 @@ _std_suite = [
             "MP2 CORRELATION ENERGY": -0.05945820694747983,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.0019203155958724552,
+            "LCCD CORRELATION ENERGY": -0.0835080983,  # p4n
+            "LCCD SINGLES ENERGY": 0.0000000000,
+            "LCCD SAME-SPIN CORRELATION ENERGY": -0.0024018298,  # dfocc
         },
     },
     {
@@ -1213,14 +1237,17 @@ _std_suite = [
             "basis": "aug-cc-pvdz",
             "scf_type": "pk",
             "reference": "uhf",
-            "fcae": "fc",
+            "fcae": "ae",
             "corl_type": "df",
         },
         "data": {
             "HF TOTAL ENERGY": _scf_nh2_adz_pk_uhf,
-            "MP2 CORRELATION ENERGY": -0.15241501,
+            "MP2 CORRELATION ENERGY": -0.15484736,
             "MP2 SINGLES ENERGY": 0.0,
-            "MP2 SAME-SPIN CORRELATION ENERGY": -0.03448519,
+            "MP2 SAME-SPIN CORRELATION ENERGY": -0.03523329,
+            "LCCD CORRELATION ENERGY": -0.1771107929,  # p4n
+            "LCCD SINGLES ENERGY": 0.0000000000,
+            "LCCD SAME-SPIN CORRELATION ENERGY": -0.0340809591,  # dfocc
         },
     },
     {
@@ -1229,14 +1256,17 @@ _std_suite = [
             "basis": "cfour-qz2p",
             "scf_type": "pk",
             "reference": "uhf",
-            "fcae": "fc",
+            "fcae": "ae",
             "corl_type": "df",
         },
         "data": {
             "HF TOTAL ENERGY": _scf_nh2_qz2p_pk_uhf,
-            "MP2 CORRELATION ENERGY": -0.17117615,
+            "MP2 CORRELATION ENERGY": -0.19551918,
             "MP2 SINGLES ENERGY": 0.0,
-            "MP2 SAME-SPIN CORRELATION ENERGY": -0.03822512,
+            "MP2 SAME-SPIN CORRELATION ENERGY": -0.04161696,
+            "LCCD CORRELATION ENERGY": -0.2167841215,  # p4n
+            "LCCD SINGLES ENERGY": 0.0000000000,
+            "LCCD SAME-SPIN CORRELATION ENERGY": -0.0401306929,  # dfocc
         },
     },
     {
@@ -1253,6 +1283,7 @@ _std_suite = [
             "MP2 CORRELATION ENERGY": -0.0604460449537298,
             "MP2 SINGLES ENERGY": -0.0006940498589629459,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.0020066877639503184,
+            "LCCD CORRELATION ENERGY": -0.0834825821,  # p4n
         },
     },
     {
@@ -1261,14 +1292,15 @@ _std_suite = [
             "basis": "aug-cc-pvdz",
             "scf_type": "pk",
             "reference": "rohf",
-            "fcae": "fc",
+            "fcae": "ae",
             "corl_type": "df",
         },
         "data": {
             "HF TOTAL ENERGY": _scf_nh2_adz_pk_rohf,
-            "MP2 CORRELATION ENERGY": -0.15701209,
-            "MP2 SINGLES ENERGY": -0.00280600,
-            "MP2 SAME-SPIN CORRELATION ENERGY": -0.03469422,
+            "MP2 CORRELATION ENERGY": -0.15948289,
+            "MP2 SINGLES ENERGY": -0.00282963,
+            "MP2 SAME-SPIN CORRELATION ENERGY": -0.03544835,
+            "LCCD CORRELATION ENERGY": -0.1792713801,  # p4n
         },
     },
     {
@@ -1277,14 +1309,15 @@ _std_suite = [
             "basis": "cfour-qz2p",
             "scf_type": "pk",
             "reference": "rohf",
-            "fcae": "fc",
+            "fcae": "ae",
             "corl_type": "df",
         },
         "data": {
             "HF TOTAL ENERGY": _scf_nh2_qz2p_pk_rohf,
-            "MP2 CORRELATION ENERGY": -0.17610830,
-            "MP2 SINGLES ENERGY": -0.00294339,
-            "MP2 SAME-SPIN CORRELATION ENERGY": -0.03837541,
+            "MP2 CORRELATION ENERGY": -0.20052829,
+            "MP2 SINGLES ENERGY": -0.00298375,
+            "MP2 SAME-SPIN CORRELATION ENERGY": -0.04178599,
+            "LCCD CORRELATION ENERGY": -0.2191002183,  # p4n
         },
     },
     # <<<  CONV-FC-DF  >>>
@@ -1305,9 +1338,10 @@ _std_suite = [
             "MP2 TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.00315485, 0.0, 0.0, -0.00315485]  # dfmp2 findif-5 fc pk+df
             ).reshape((-1, 3)),
+            "LCCD CORRELATION ENERGY": -0.2081020566,  # p4n
+            "LCCD SINGLES ENERGY": 0.0000000000,
             "CCSD CORRELATION ENERGY": -0.20695586,
             "CCSD SINGLES ENERGY": 0.0,
-            "CCSD SAME-SPIN CORRELATION ENERGY": 78,  # can't calc
             "(T) CORRECTION ENERGY": -0.00192267,
         },
     },
@@ -1317,18 +1351,19 @@ _std_suite = [
             "basis": "aug-cc-pvdz",
             "scf_type": "pk",
             "reference": "rhf",
-            "fcae": "ae",
+            "fcae": "fc",
             "corl_type": "df",
         },
         "data": {
             "HF TOTAL ENERGY": _scf_h2o_adz_pk_rhf,
-            "MP2 CORRELATION ENERGY": -0.22188894,
+            "MP2 CORRELATION ENERGY": -0.21939942,
             "MP2 SINGLES ENERGY": 0.0,
-            "MP2 SAME-SPIN CORRELATION ENERGY": -0.05674808,
-            "CCSD CORRELATION ENERGY": -0.22954333,
+            "MP2 SAME-SPIN CORRELATION ENERGY": -0.05588210,
+            "LCCD CORRELATION ENERGY": -0.2297524911,  # p4n
+            "LCCD SINGLES ENERGY": 0.0000000000,
+            "CCSD CORRELATION ENERGY": -0.22730597,
             "CCSD SINGLES ENERGY": 0.0,
-            "CCSD SAME-SPIN CORRELATION ENERGY": 78,  # can't calc
-            "(T) CORRECTION ENERGY": -0.00524393,
+            "(T) CORRECTION ENERGY": -0.00521769,
         },
     },
     {
@@ -1337,18 +1372,19 @@ _std_suite = [
             "basis": "cfour-qz2p",
             "scf_type": "pk",
             "reference": "rhf",
-            "fcae": "ae",
+            "fcae": "fc",
             "corl_type": "df",
         },
         "data": {
             "HF TOTAL ENERGY": _scf_h2o_qz2p_pk_rhf,
-            "MP2 CORRELATION ENERGY": -0.27018057,
+            "MP2 CORRELATION ENERGY": -0.24514425,
             "MP2 SINGLES ENERGY": 0.0,
-            "MP2 SAME-SPIN CORRELATION ENERGY": -0.06530212,
-            "CCSD CORRELATION ENERGY": -0.27570207,
+            "MP2 SAME-SPIN CORRELATION ENERGY": -0.06126481,
+            "LCCD CORRELATION ENERGY": -0.2531939249,  # p4n
+            "LCCD SINGLES ENERGY": 0.0000000000,
+            "CCSD CORRELATION ENERGY": -0.25033030,
             "CCSD SINGLES ENERGY": 0.0,
-            "CCSD SAME-SPIN CORRELATION ENERGY": 78,  # can't calc
-            "(T) CORRECTION ENERGY": -0.00726375,
+            "(T) CORRECTION ENERGY": -0.00709666,
         },
     },
     {
@@ -1365,6 +1401,9 @@ _std_suite = [
             "MP2 CORRELATION ENERGY": -0.058392397606538686,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.0017690135626491292,
+            "LCCD CORRELATION ENERGY": -0.0825046579,  # p4n
+            "LCCD SINGLES ENERGY": 0.0000000000,
+            "LCCD SAME-SPIN CORRELATION ENERGY": -0.0022547041,  # dfocc
         },
     },
     {
@@ -1373,14 +1412,17 @@ _std_suite = [
             "basis": "aug-cc-pvdz",
             "scf_type": "pk",
             "reference": "uhf",
-            "fcae": "ae",
+            "fcae": "fc",
             "corl_type": "df",
         },
         "data": {
             "HF TOTAL ENERGY": _scf_nh2_adz_pk_uhf,
-            "MP2 CORRELATION ENERGY": -0.15484736,
+            "MP2 CORRELATION ENERGY": -0.15241501,
             "MP2 SINGLES ENERGY": 0.0,
-            "MP2 SAME-SPIN CORRELATION ENERGY": -0.03523329,
+            "MP2 SAME-SPIN CORRELATION ENERGY": -0.03448519,
+            "LCCD CORRELATION ENERGY": -0.1748557523,  # p4n
+            "LCCD SINGLES ENERGY": 0.0000000000,
+            "LCCD SAME-SPIN CORRELATION ENERGY": -0.0333918420,  # dfocc
         },
     },
     {
@@ -1389,14 +1431,17 @@ _std_suite = [
             "basis": "cfour-qz2p",
             "scf_type": "pk",
             "reference": "uhf",
-            "fcae": "ae",
+            "fcae": "fc",
             "corl_type": "df",
         },
         "data": {
             "HF TOTAL ENERGY": _scf_nh2_qz2p_pk_uhf,
-            "MP2 CORRELATION ENERGY": -0.19551918,
+            "MP2 CORRELATION ENERGY": -0.17117615,
             "MP2 SINGLES ENERGY": 0.0,
-            "MP2 SAME-SPIN CORRELATION ENERGY": -0.04161696,
+            "MP2 SAME-SPIN CORRELATION ENERGY": -0.03822512,
+            "LCCD CORRELATION ENERGY": -0.1917015960,  # p4n
+            "LCCD SINGLES ENERGY": 0.0000000000,
+            "LCCD SAME-SPIN CORRELATION ENERGY": -0.0367596684,  # dfocc
         },
     },
     {
@@ -1413,6 +1458,7 @@ _std_suite = [
             "MP2 CORRELATION ENERGY": -0.05937514348825628,
             "MP2 SINGLES ENERGY": -0.0006883686516107368,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.0018536363586657242,
+            "LCCD CORRELATION ENERGY": -0.0824786458,  # p4n
         },
     },
     {
@@ -1421,14 +1467,15 @@ _std_suite = [
             "basis": "aug-cc-pvdz",
             "scf_type": "pk",
             "reference": "rohf",
-            "fcae": "ae",
+            "fcae": "fc",
             "corl_type": "df",
         },
         "data": {
             "HF TOTAL ENERGY": _scf_nh2_adz_pk_rohf,
-            "MP2 CORRELATION ENERGY": -0.15948289,
-            "MP2 SINGLES ENERGY": -0.00282963,
-            "MP2 SAME-SPIN CORRELATION ENERGY": -0.03544835,
+            "MP2 CORRELATION ENERGY": -0.15701209,
+            "MP2 SINGLES ENERGY": -0.00280600,
+            "MP2 SAME-SPIN CORRELATION ENERGY": -0.03469422,
+            "LCCD CORRELATION ENERGY": -0.1770018748,  # p4n
         },
     },
     {
@@ -1437,14 +1484,15 @@ _std_suite = [
             "basis": "cfour-qz2p",
             "scf_type": "pk",
             "reference": "rohf",
-            "fcae": "ae",
+            "fcae": "fc",
             "corl_type": "df",
         },
         "data": {
             "HF TOTAL ENERGY": _scf_nh2_qz2p_pk_rohf,
-            "MP2 CORRELATION ENERGY": -0.20052829,
-            "MP2 SINGLES ENERGY": -0.00298375,
-            "MP2 SAME-SPIN CORRELATION ENERGY": -0.04178599,
+            "MP2 CORRELATION ENERGY": -0.17610830,
+            "MP2 SINGLES ENERGY": -0.00294339,
+            "MP2 SAME-SPIN CORRELATION ENERGY": -0.03837541,
+            "LCCD CORRELATION ENERGY": -0.1939912613,  # p4n
         },
     },
     # <<<  CD-AE-CD  >>>
@@ -1466,6 +1514,8 @@ _std_suite = [
                 # dfocc findif-5 ae cd+cd
                 [0.0, 0.0, 0.00281146, 0.0, 0.0, -0.00281146]
             ).reshape((-1, 3)),
+            "LCCD CORRELATION ENERGY": -0.20990226,  # dfocc
+            "LCCD SINGLES ENERGY": 0.0000000000,
             "CCSD CORRELATION ENERGY": -0.20873986012771106,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.04857381,
@@ -1490,6 +1540,8 @@ _std_suite = [
                 # dfocc findif-5 ae cd+cd
                 [0.0, 0.0, 0.009643414073, 0.0, 0.005501440694, -0.004821707036, 0.0, -0.005501440694, -0.004821707036,]
             ).reshape((-1, 3)),
+            "LCCD CORRELATION ENERGY": -0.23188949,  # dfocc
+            "LCCD SINGLES ENERGY": 0.0000000000,
             "CCSD CORRELATION ENERGY": -0.22941290,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.05017955,
@@ -1514,6 +1566,8 @@ _std_suite = [
                 # dfocc findif-5 ae cd+cd
                 [0.0, 0.0, -0.000546229785, 0.0, -0.000967320028, 0.000273114892, 0.0, 0.000967320028, 0.000273114892,]
             ).reshape((-1, 3)),
+            "LCCD CORRELATION ENERGY": -0.27869015,  # dfocc
+            "LCCD SINGLES ENERGY": 0.0000000000,
             "CCSD CORRELATION ENERGY": -0.27570421,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.05801141,
@@ -1551,6 +1605,9 @@ _std_suite = [
                     -0.00022204,
                 ]
             ).reshape((-1, 3)),
+            "LCCD CORRELATION ENERGY": -0.08343038,  # dfocc
+            "LCCD SINGLES ENERGY": 0.0000000000,
+            "LCCD SAME-SPIN CORRELATION ENERGY": -0.00240059,  # dfocc
         },
     },
     {
@@ -1580,6 +1637,9 @@ _std_suite = [
                     -0.012735031905,
                 ]
             ).reshape((-1, 3)),
+            "LCCD CORRELATION ENERGY": -0.17701192,  # dfocc
+            "LCCD SINGLES ENERGY": 0.0000000000,
+            "LCCD SAME-SPIN CORRELATION ENERGY": -0.03413070,  # dfocc
         },
     },
     {
@@ -1609,6 +1669,9 @@ _std_suite = [
                     -0.006863712188,
                 ]
             ).reshape((-1, 3)),
+            "LCCD CORRELATION ENERGY": -0.21678706,  # dfocc
+            "LCCD SINGLES ENERGY": 0.0000000000,
+            "LCCD SAME-SPIN CORRELATION ENERGY": -0.04013515,  # dfocc
         },
     },
     {
@@ -1708,6 +1771,8 @@ _std_suite = [
                 # dfocc findif-5 fc cd+cd
                 [0.0, 0.0, 0.00316665, 0.0, 0.0, -0.00316665]
             ).reshape((-1, 3)),
+            "LCCD CORRELATION ENERGY": -0.20795503,  # dfocc
+            "LCCD SINGLES ENERGY": 0.0000000000,
             "CCSD CORRELATION ENERGY": -0.2068117080298787,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.04787083,
@@ -1732,6 +1797,8 @@ _std_suite = [
                 # dfocc findif-5 fc cd+cd
                 [0.0, 0.0, 0.010264703011, 0.0, 0.00588885358, -0.005132351506, 0.0, -0.00588885358, -0.005132351506,]
             ).reshape((-1, 3)),
+            "LCCD CORRELATION ENERGY": -0.22961642,  # dfocc
+            "LCCD SINGLES ENERGY": 0.0000000000,
             "CCSD CORRELATION ENERGY": -0.22717607,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.04939986,
@@ -1756,6 +1823,8 @@ _std_suite = [
                 # dfocc findif-5 fc cd+cd
                 [0.0, 0.0, 0.000318778691, 0.0, -0.000569356625, -0.000159389346, 0.0, 0.000569356625, -0.000159389346,]
             ).reshape((-1, 3)),
+            "LCCD CORRELATION ENERGY": -0.25319315,  # dfocc
+            "LCCD SINGLES ENERGY": 0.0000000000,
             "CCSD CORRELATION ENERGY": -0.25032939,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.05405638,
@@ -1793,6 +1862,9 @@ _std_suite = [
                     -0.00022889,
                 ]
             ).reshape((-1, 3)),
+            "LCCD CORRELATION ENERGY": -0.08242726,  # dfocc
+            "LCCD SINGLES ENERGY": 0.0000000000,
+            "LCCD SAME-SPIN CORRELATION ENERGY": -0.00225350,  # dfocc
         },
     },
     {
@@ -1822,6 +1894,9 @@ _std_suite = [
                     -0.013129119537,
                 ]
             ).reshape((-1, 3)),
+            "LCCD CORRELATION ENERGY": -0.17475747,  # dfocc
+            "LCCD SINGLES ENERGY": 0.0000000000,
+            "LCCD SAME-SPIN CORRELATION ENERGY": -0.0334416820,  # dfocc
         },
     },
     {
@@ -1851,6 +1926,9 @@ _std_suite = [
                     -0.007367923065,
                 ]
             ).reshape((-1, 3)),
+            "LCCD CORRELATION ENERGY": -0.19170174,  # dfocc
+            "LCCD SINGLES ENERGY": 0.0000000000,
+            "LCCD SAME-SPIN CORRELATION ENERGY": -0.03676422,  # dfocc
         },
     },
     {
@@ -1963,6 +2041,8 @@ _std_suite = [
                 # dfmp2 findif-5 ae cd+df
                 [0.0, 0.0, 0.00279182, 0.0, 0.0, -0.00279182]
             ).reshape((-1, 3)),
+            "LCCD CORRELATION ENERGY": -0.2100441271,  # p4n
+            "LCCD SINGLES ENERGY": 0.0000000000,
             "CCSD CORRELATION ENERGY": -0.20887885,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.04845784,
@@ -1983,6 +2063,8 @@ _std_suite = [
             "MP2 CORRELATION ENERGY": -0.22188866,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.05674801,
+            "LCCD CORRELATION ENERGY": -0.2320256729,  # p4n
+            "LCCD SINGLES ENERGY": 0.0000000000,
             "CCSD CORRELATION ENERGY": -0.22954292,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.05010092,
@@ -2003,6 +2085,8 @@ _std_suite = [
             "MP2 CORRELATION ENERGY": -0.27017947,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.06530177,
+            "LCCD CORRELATION ENERGY": -0.2786865554,  # p4n
+            "LCCD SINGLES ENERGY": 0.0000000000,
             "CCSD CORRELATION ENERGY": -0.27570087,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.05800702,
@@ -2023,6 +2107,9 @@ _std_suite = [
             "MP2 CORRELATION ENERGY": -0.059456828193,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.00192025457659,
+            "LCCD CORRELATION ENERGY": -0.0835057932,  # p4n
+            "LCCD SINGLES ENERGY": 0.0000000000,
+            "LCCD SAME-SPIN CORRELATION ENERGY": -0.0024017496,  # dfocc
         },
     },
     {
@@ -2039,6 +2126,9 @@ _std_suite = [
             "MP2 CORRELATION ENERGY": -0.15484678,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.03523320,
+            "LCCD CORRELATION ENERGY": -0.1771099018,  # p4n
+            "LCCD SINGLES ENERGY": 0.0000000000,
+            "LCCD SAME-SPIN CORRELATION ENERGY": -0.0340807883,  # dfocc
         },
     },
     {
@@ -2055,6 +2145,9 @@ _std_suite = [
             "MP2 CORRELATION ENERGY": -0.19551841,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.04161663,
+            "LCCD CORRELATION ENERGY": -0.2167832515,  # p4n
+            "LCCD SINGLES ENERGY": 0.0000000000,
+            "LCCD SAME-SPIN CORRELATION ENERGY": -0.0401303480,  # dfocc
         },
     },
     {
@@ -2071,6 +2164,7 @@ _std_suite = [
             "MP2 CORRELATION ENERGY": -0.06044431529,
             "MP2 SINGLES ENERGY": -0.00069387098844,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.0020066063,
+            "LCCD CORRELATION ENERGY": -0.0834800819,  # p4n
         },
     },
     {
@@ -2087,6 +2181,7 @@ _std_suite = [
             "MP2 CORRELATION ENERGY": -0.15948219,
             "MP2 SINGLES ENERGY": -0.00282948,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.03544828,
+            "LCCD CORRELATION ENERGY": -0.1792705171,  # p4n
         },
     },
     {
@@ -2103,6 +2198,7 @@ _std_suite = [
             "MP2 CORRELATION ENERGY": -0.20052752,
             "MP2 SINGLES ENERGY": -0.00298373,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.04178566,
+            "LCCD CORRELATION ENERGY": -0.2190993784,  # p4n
         },
     },
     # <<<  CD-FC-DF  >>>
@@ -2124,6 +2220,8 @@ _std_suite = [
                 # dfmp2 findif-5 fc cd+df
                 [0.0, 0.0, 0.00314686, 0.0, 0.0, -0.00314686]
             ).reshape((-1, 3)),
+            "LCCD CORRELATION ENERGY": -0.2080964757,  # p4n
+            "LCCD SINGLES ENERGY": 0.0000000000,
             "CCSD CORRELATION ENERGY": -0.20695033,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.04775464,
@@ -2144,6 +2242,8 @@ _std_suite = [
             "MP2 CORRELATION ENERGY": -0.21939916,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.05588204,
+            "LCCD CORRELATION ENERGY": -0.2297520405,  # p4n
+            "LCCD SINGLES ENERGY": 0.0000000000,
             "CCSD CORRELATION ENERGY": -0.22730558,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.04932106,
@@ -2164,6 +2264,8 @@ _std_suite = [
             "MP2 CORRELATION ENERGY": -0.24514320,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.06126448,
+            "LCCD CORRELATION ENERGY": -0.2531926943,  # p4n
+            "LCCD SINGLES ENERGY": 0.0000000000,
             "CCSD CORRELATION ENERGY": -0.25032917,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.05405189,
@@ -2184,6 +2286,9 @@ _std_suite = [
             "MP2 CORRELATION ENERGY": -0.05839103061,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.00176895897,
+            "LCCD CORRELATION ENERGY": -0.0825023638,  # p4n
+            "LCCD SINGLES ENERGY": 0.0000000000,
+            "LCCD SAME-SPIN CORRELATION ENERGY": -0.0022546311,  # dfocc
         },
     },
     {
@@ -2200,6 +2305,9 @@ _std_suite = [
             "MP2 CORRELATION ENERGY": -0.15241445,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.03448512,
+            "LCCD CORRELATION ENERGY": -0.1748548876,  # p4n
+            "LCCD SINGLES ENERGY": 0.0000000000,
+            "LCCD SAME-SPIN CORRELATION ENERGY": -0.0333916888,  # dfocc
         },
     },
     {
@@ -2216,6 +2324,9 @@ _std_suite = [
             "MP2 CORRELATION ENERGY": -0.17117540,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.03822480,
+            "LCCD CORRELATION ENERGY": -0.1917007514,  # p4n
+            "LCCD SINGLES ENERGY": 0.0000000000,
+            "LCCD SAME-SPIN CORRELATION ENERGY": -0.0367593319,  # dfocc
         },
     },
     {
@@ -2232,6 +2343,7 @@ _std_suite = [
             "MP2 CORRELATION ENERGY": -0.05937342969795,
             "MP2 SINGLES ENERGY": -0.0006881934,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.001853561678,
+            "LCCD CORRELATION ENERGY": -0.0824761581,  # p4n
         },
     },
     {
@@ -2248,6 +2360,7 @@ _std_suite = [
             "MP2 CORRELATION ENERGY": -0.15701141,
             "MP2 SINGLES ENERGY": -0.00280584,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.03469416,
+            "LCCD CORRELATION ENERGY": -0.1770010376,  # p4n
         },
     },
     {
@@ -2264,6 +2377,7 @@ _std_suite = [
             "MP2 CORRELATION ENERGY": -0.17610756,
             "MP2 SINGLES ENERGY": -0.00294336,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.03837509,
+            "LCCD CORRELATION ENERGY": -0.1939904460,  # p4n
         },
     },
     # <<<  DF-AE-DF  >>>
@@ -2291,6 +2405,8 @@ _std_suite = [
                     -0.00279211492833,
                 ]
             ).reshape((-1, 3)),
+            "LCCD CORRELATION ENERGY": -0.2100337333,  # p4n
+            "LCCD SINGLES ENERGY": 0.0000000000,
             "CCSD CORRELATION ENERGY": -0.20886884012911314,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.04845491,
@@ -2325,6 +2441,8 @@ _std_suite = [
                     -0.004810913825,
                 ]
             ).reshape((-1, 3)),
+            "LCCD CORRELATION ENERGY": -0.2320149229,  # p4n
+            "LCCD SINGLES ENERGY": 0.0000000000,
             "CCSD CORRELATION ENERGY": -0.22953289,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.05009877,
@@ -2361,6 +2479,8 @@ _std_suite = [
                     0.000283328971,
                 ]
             ).reshape((-1, 3)),
+            "LCCD CORRELATION ENERGY": -0.2786671617,  # p4n
+            "LCCD SINGLES ENERGY": 0.0000000000,
             "CCSD CORRELATION ENERGY": -0.27568236,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.05800380,
@@ -2400,6 +2520,9 @@ _std_suite = [
                     -0.00022125614977,
                 ]
             ).reshape((-1, 3)),
+            "LCCD CORRELATION ENERGY": -0.0835030877,  # p4n
+            "LCCD SINGLES ENERGY": 0.0000000000,
+            "LCCD SAME-SPIN CORRELATION ENERGY": -0.0024016379,  # dfocc
         },
     },
     {
@@ -2429,6 +2552,9 @@ _std_suite = [
                     -0.012738024793,
                 ]
             ).reshape((-1, 3)),
+            "LCCD CORRELATION ENERGY": -0.1770997033,  # p4n
+            "LCCD SINGLES ENERGY": 0.0000000000,
+            "LCCD SAME-SPIN CORRELATION ENERGY": -0.0340788149,  # dfocc
         },
     },
     {
@@ -2458,6 +2584,9 @@ _std_suite = [
                     -0.006854415552,
                 ]
             ).reshape((-1, 3)),
+            "LCCD CORRELATION ENERGY": -0.2167706529,  # p4n
+            "LCCD SINGLES ENERGY": 0.0000000000,
+            "LCCD SAME-SPIN CORRELATION ENERGY": -0.0401283617,  # dfocc
         },
     },
     {
@@ -2490,6 +2619,7 @@ _std_suite = [
                     -0.00023478905531,
                 ]
             ).reshape((-1, 3)),
+            "LCCD CORRELATION ENERGY": -0.0834776542,  # p4n
         },
     },
     {
@@ -2519,6 +2649,7 @@ _std_suite = [
                     -0.012796760798,
                 ]
             ).reshape((-1, 3)),
+            "LCCD CORRELATION ENERGY": -0.1792603912,  # p4n
         },
     },
     {
@@ -2548,6 +2679,7 @@ _std_suite = [
                     -0.006932622956,
                 ]
             ).reshape((-1, 3)),
+            "LCCD CORRELATION ENERGY": -0.2190866990,  # p4n
         },
     },
     # <<<  DF-FC-DF  >>>
@@ -2575,6 +2707,8 @@ _std_suite = [
                     -0.00314716362539,
                 ]
             ).reshape((-1, 3)),
+            "LCCD CORRELATION ENERGY": -0.2080860831,  # p4n
+            "LCCD SINGLES ENERGY": 0.0000000000,
             "CCSD CORRELATION ENERGY": -0.20694032546082639,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.04775171,
@@ -2609,6 +2743,8 @@ _std_suite = [
                     -0.005121596913,
                 ]
             ).reshape((-1, 3)),
+            "LCCD CORRELATION ENERGY": -0.2297412879,  # p4n
+            "LCCD SINGLES ENERGY": 0.0000000000,
             "CCSD CORRELATION ENERGY": -0.22729554,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.04931891,
@@ -2645,6 +2781,8 @@ _std_suite = [
                     -0.00014913604,
                 ]
             ).reshape((-1, 3)),
+            "LCCD CORRELATION ENERGY": -0.2531777549,  # p4n
+            "LCCD SINGLES ENERGY": 0.0000000000,
             "CCSD CORRELATION ENERGY": -0.25031508,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.05404876,
@@ -2684,6 +2822,9 @@ _std_suite = [
                     -0.00022810972492,
                 ]
             ).reshape((-1, 3)),
+            "LCCD CORRELATION ENERGY": -0.0824996438,  # p4n
+            "LCCD SINGLES ENERGY": 0.0000000000,
+            "LCCD SAME-SPIN CORRELATION ENERGY": -0.0022545103,  # dfocc
         },
     },
     {
@@ -2713,6 +2854,9 @@ _std_suite = [
                     -0.013132433236,
                 ]
             ).reshape((-1, 3)),
+            "LCCD CORRELATION ENERGY": -0.1748446809,  # p4n
+            "LCCD SINGLES ENERGY": 0.0000000000,
+            "LCCD SAME-SPIN CORRELATION ENERGY": -0.0333897039,  # dfocc
         },
     },
     {
@@ -2742,6 +2886,9 @@ _std_suite = [
                     -0.00735860571,
                 ]
             ).reshape((-1, 3)),
+            "LCCD CORRELATION ENERGY": -0.1916908596,  # p4n
+            "LCCD SINGLES ENERGY": 0.0000000000,
+            "LCCD SAME-SPIN CORRELATION ENERGY": -0.0367574293,
         },
     },
     {
@@ -2774,6 +2921,7 @@ _std_suite = [
                     -0.00024176,
                 ]
             ).reshape((-1, 3)),
+            "LCCD CORRELATION ENERGY": -0.0824737155,  # p4n
         },
     },
     {
@@ -2803,6 +2951,7 @@ _std_suite = [
                     -0.013191064898,
                 ]
             ).reshape((-1, 3)),
+            "LCCD CORRELATION ENERGY": -0.1769909051,  # p4n
         },
     },
     {
@@ -2832,6 +2981,7 @@ _std_suite = [
                     -0.007435458089,
                 ]
             ).reshape((-1, 3)),
+            "LCCD CORRELATION ENERGY": -0.1939804718,  # p4n
         },
     },
     # <<<  lopsided SCF/CORL algorithms  >>>
@@ -3101,63 +3251,69 @@ for calc in _std_suite:
     if calc["data"]:
         if "MP2 CORRELATION ENERGY" in calc["data"]:
             calc["data"]["MP2 TOTAL ENERGY"] = calc["data"]["MP2 CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
-            calc["data"]["MP2 DOUBLES ENERGY"] = (
-                calc["data"]["MP2 CORRELATION ENERGY"] - calc["data"]["MP2 SINGLES ENERGY"]
-            )
-            calc["data"]["MP2 OPPOSITE-SPIN CORRELATION ENERGY"] = (
-                calc["data"]["MP2 CORRELATION ENERGY"]
-                - calc["data"]["MP2 SAME-SPIN CORRELATION ENERGY"]
-                - calc["data"]["MP2 SINGLES ENERGY"]
-            )
-            calc["data"]["SCS-MP2 CORRELATION ENERGY"] = (
-                (1 / 3) * calc["data"]["MP2 SAME-SPIN CORRELATION ENERGY"]
-                + (6 / 5) * calc["data"]["MP2 OPPOSITE-SPIN CORRELATION ENERGY"]
-                + calc["data"]["MP2 SINGLES ENERGY"]
-            )
-            calc["data"]["SCS-MP2 TOTAL ENERGY"] = (
-                calc["data"]["SCS-MP2 CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
-            )
+            if "MP2 SINGLES ENERGY" in calc["data"]:
+                calc["data"]["MP2 DOUBLES ENERGY"] = (
+                    calc["data"]["MP2 CORRELATION ENERGY"] - calc["data"]["MP2 SINGLES ENERGY"]
+                )
+                if "MP2 SAME-SPIN CORRELATION ENERGY" in calc["data"]:
+                    calc["data"]["MP2 OPPOSITE-SPIN CORRELATION ENERGY"] = (
+                        calc["data"]["MP2 CORRELATION ENERGY"]
+                        - calc["data"]["MP2 SAME-SPIN CORRELATION ENERGY"]
+                        - calc["data"]["MP2 SINGLES ENERGY"]
+                    )
+                    calc["data"]["SCS-MP2 CORRELATION ENERGY"] = (
+                        (1 / 3) * calc["data"]["MP2 SAME-SPIN CORRELATION ENERGY"]
+                        + (6 / 5) * calc["data"]["MP2 OPPOSITE-SPIN CORRELATION ENERGY"]
+                        + calc["data"]["MP2 SINGLES ENERGY"]
+                    )
+                    calc["data"]["SCS-MP2 TOTAL ENERGY"] = (
+                        calc["data"]["SCS-MP2 CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
+                    )
 
         if "LCCD CORRELATION ENERGY" in calc["data"]:
             calc["data"]["LCCD TOTAL ENERGY"] = (
                 calc["data"]["LCCD CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
             )
-            if "LCCD SAME-SPIN CORRELATION ENERGY" in calc["data"]:
+            if "LCCD SINGLES ENERGY" in calc["data"]:
                 calc["data"]["LCCD DOUBLES ENERGY"] = (
                     calc["data"]["LCCD CORRELATION ENERGY"] - calc["data"]["LCCD SINGLES ENERGY"]
                 )
-                calc["data"]["LCCD OPPOSITE-SPIN CORRELATION ENERGY"] = (
-                    calc["data"]["LCCD CORRELATION ENERGY"]
-                    - calc["data"]["LCCD SAME-SPIN CORRELATION ENERGY"]
-                    - calc["data"]["LCCD SINGLES ENERGY"]
-                )
+                if "LCCD SAME-SPIN CORRELATION ENERGY" in calc["data"]:
+                    calc["data"]["LCCD OPPOSITE-SPIN CORRELATION ENERGY"] = (
+                        calc["data"]["LCCD CORRELATION ENERGY"]
+                        - calc["data"]["LCCD SAME-SPIN CORRELATION ENERGY"]
+                        - calc["data"]["LCCD SINGLES ENERGY"]
+                    )
 
         if "LCCSD CORRELATION ENERGY" in calc["data"]:
             calc["data"]["LCCSD TOTAL ENERGY"] = (
                 calc["data"]["LCCSD CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
             )
-            if "LCCSD SAME-SPIN CORRELATION ENERGY" in calc["data"]:
+            if "LCCSD SINGLES ENERGY" in calc["data"]:
                 calc["data"]["LCCSD DOUBLES ENERGY"] = (
                     calc["data"]["LCCSD CORRELATION ENERGY"] - calc["data"]["LCCSD SINGLES ENERGY"]
                 )
-                calc["data"]["LCCSD OPPOSITE-SPIN CORRELATION ENERGY"] = (
-                    calc["data"]["LCCSD CORRELATION ENERGY"]
-                    - calc["data"]["LCCSD SAME-SPIN CORRELATION ENERGY"]
-                    - calc["data"]["LCCSD SINGLES ENERGY"]
-                )
+                if "LCCSD SAME-SPIN CORRELATION ENERGY" in calc["data"]:
+                    calc["data"]["LCCSD OPPOSITE-SPIN CORRELATION ENERGY"] = (
+                        calc["data"]["LCCSD CORRELATION ENERGY"]
+                        - calc["data"]["LCCSD SAME-SPIN CORRELATION ENERGY"]
+                        - calc["data"]["LCCSD SINGLES ENERGY"]
+                    )
 
         if "CCSD CORRELATION ENERGY" in calc["data"]:
             calc["data"]["CCSD TOTAL ENERGY"] = (
                 calc["data"]["CCSD CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
             )
-            calc["data"]["CCSD DOUBLES ENERGY"] = (
-                calc["data"]["CCSD CORRELATION ENERGY"] - calc["data"]["CCSD SINGLES ENERGY"]
-            )
-            calc["data"]["CCSD OPPOSITE-SPIN CORRELATION ENERGY"] = (
-                calc["data"]["CCSD CORRELATION ENERGY"]
-                - calc["data"]["CCSD SAME-SPIN CORRELATION ENERGY"]
-                - calc["data"]["CCSD SINGLES ENERGY"]
-            )
+            if "CCSD SINGLES ENERGY" in calc["data"]:
+                calc["data"]["CCSD DOUBLES ENERGY"] = (
+                    calc["data"]["CCSD CORRELATION ENERGY"] - calc["data"]["CCSD SINGLES ENERGY"]
+                )
+                if "CCSD SAME-SPIN CORRELATION ENERGY" in calc["data"]:
+                    calc["data"]["CCSD OPPOSITE-SPIN CORRELATION ENERGY"] = (
+                        calc["data"]["CCSD CORRELATION ENERGY"]
+                        - calc["data"]["CCSD SAME-SPIN CORRELATION ENERGY"]
+                        - calc["data"]["CCSD SINGLES ENERGY"]
+                    )
 
         if "(T) CORRECTION ENERGY" in calc["data"]:
             calc["data"]["CCSD(T) CORRELATION ENERGY"] = (

--- a/qcengine/programs/tests/standard_suite_ref.py
+++ b/qcengine/programs/tests/standard_suite_ref.py
@@ -754,6 +754,7 @@ _std_suite = [
                     -0.000074412594,
                 ]
             ).reshape((-1, 3)),
+            "(T) CORRECTION ENERGY": -0.00068823,  # cfour only
         },
     },
     {
@@ -781,6 +782,7 @@ _std_suite = [
             "CCSD TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.030051791297, 0.0, 0.016301545337, -0.015025895649, 0.0, -0.016301545337, -0.015025895649,]
             ).reshape((-1, 3)),
+            "(T) CORRECTION ENERGY": -0.003863167899,  # cfour only
         },
     },
     {
@@ -808,6 +810,7 @@ _std_suite = [
             "CCSD TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.017873897449, 0.0, 0.007653541045, -0.008936948724, 0.0, -0.007653541045, -0.008936948724,]
             ).reshape((-1, 3)),
+            "(T) CORRECTION ENERGY": -0.00504351,  # cfour only
         },
     },
     # <<<  CONV-AE-CD  >>>

--- a/qcengine/programs/tests/standard_suite_ref.py
+++ b/qcengine/programs/tests/standard_suite_ref.py
@@ -62,6 +62,24 @@ symmetry c1  # TODO for nwchem, manage another way
 }
 std_molecules["bh3p-xyz"] = std_molecules["bh3p"]
 
+_std_generics = {
+    "hf_cc-pvdz_ae": (19, 19, 5, 5),
+    "hf_cc-pvdz_fc": (19, 19, 5, 5),
+    "bh3p_cc-pvdz_ae": (29, 29, 4, 3),
+    "bh3p_cc-pvdz_fc": (29, 29, 4, 3),
+    "h2o_aug-cc-pvdz_ae": (41, 41, 5, 5),
+    "h2o_aug-cc-pvdz_fc": (41, 41, 5, 5),
+    "nh2_aug-cc-pvdz_ae": (41, 41, 5, 4),
+    "nh2_aug-cc-pvdz_fc": (41, 41, 5, 4),
+    "h2o_cfour-qz2p_ae": (48, 48, 5, 5),
+    "h2o_cfour-qz2p_fc": (48, 48, 5, 5),
+    "nh2_cfour-qz2p_ae": (48, 48, 5, 4),
+    "nh2_cfour-qz2p_fc": (48, 48, 5, 4),
+}
+_std_generics = {
+    k: dict(zip(["N BASIS FUNCTIONS", "N MOLECULAR ORBITALS", "N ALPHA ELECTRONS", "N BETA ELECTRONS"], v))
+    for k, v in _std_generics.items()
+}
 
 _scf_hf_dz_pk_rhf = -100.01941126902270
 _scf_bh3p_dz_pk_uhf = -25.94513842869638
@@ -2999,6 +3017,8 @@ for calc in _std_suite:
             calc["data"]["CCSD(T) TOTAL ENERGY"] = (
                 calc["data"]["CCSD(T) CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
             )
+
+    calc["data"].update(_std_generics[f"{calc['meta']['system']}_{calc['meta']['basis']}_{calc['meta']['fcae']}"])
 
 
 def answer_hash(**kwargs):

--- a/qcengine/programs/tests/standard_suite_ref.py
+++ b/qcengine/programs/tests/standard_suite_ref.py
@@ -131,6 +131,7 @@ _std_suite = [
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.04857419039,
             "CCSD TOTAL GRADIENT": np.array([0.0, 0.0, 0.001989217717, 0.0, 0.0, -0.001989217717,]).reshape((-1, 3)),
+            "(T) CORRECTION ENERGY": -0.0019363896542312043,
         },
     },
     {
@@ -156,6 +157,7 @@ _std_suite = [
             "CCSD TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.007512595487, 0.0, 0.004613769715, -0.003756297743, 0.0, -0.004613769715, -0.003756297743,]
             ).reshape((-1, 3)),
+            "(T) CORRECTION ENERGY": -0.00523856,
         },
     },
     {
@@ -181,6 +183,7 @@ _std_suite = [
             "CCSD TOTAL GRADIENT": np.array(
                 [0.0, 0.0, -0.003374258422, 0.0, -0.002334452569, 0.001687129211, 0.0, 0.002334452569, 0.001687129211,]
             ).reshape((-1, 3)),
+            "(T) CORRECTION ENERGY": -0.007263596331,
         },
     },
     {
@@ -232,6 +235,7 @@ _std_suite = [
                     -0.000069101625,
                 ]
             ).reshape((-1, 3)),
+            "(T) CORRECTION ENERGY": -0.00062614,
         },
     },
     {
@@ -257,6 +261,7 @@ _std_suite = [
             "CCSD TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.029278727285, 0.0, 0.015813927533, -0.014639363642, 0.0, -0.015813927533, -0.014639363642,]
             ).reshape((-1, 3)),
+            "(T) CORRECTION ENERGY": -0.00384378,
         },
     },
     {
@@ -282,6 +287,7 @@ _std_suite = [
             "CCSD TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.016842165003, 0.0, 0.007150136873, -0.008421082502, 0.0, -0.007150136873, -0.008421082502,]
             ).reshape((-1, 3)),
+            "(T) CORRECTION ENERGY": -0.00516659,
         },
     },
     {
@@ -334,6 +340,7 @@ _std_suite = [
                     -0.000068583796,
                 ]
             ).reshape((-1, 3)),
+            "(T) CORRECTION ENERGY": -0.000713766189,
         },
     },
     {
@@ -359,6 +366,7 @@ _std_suite = [
             "CCSD TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.029273628227, 0.0, 0.015808308241, -0.014636814114, 0.0, -0.015808308241, -0.014636814114,]
             ).reshape((-1, 3)),
+            "(T) CORRECTION ENERGY": -0.003901085777,
         },
     },
     {
@@ -384,6 +392,7 @@ _std_suite = [
             "CCSD TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.016833254665, 0.0, 0.007144029475, -0.008416627332, 0.0, -0.007144029475, -0.008416627332,]
             ).reshape((-1, 3)),
+            "(T) CORRECTION ENERGY": -0.005233938447,
         },
     },
     # <<<  CONV-FC-CONV  >>>
@@ -415,6 +424,7 @@ _std_suite = [
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.0478712079,
             "CCSD TOTAL GRADIENT": np.array([0.0, 0.0, 0.002335204281, 0.0, 0.0, -0.002335204281,]).reshape((-1, 3)),
+            "(T) CORRECTION ENERGY": -0.0019205007159748158,
         },
     },
     {
@@ -440,6 +450,7 @@ _std_suite = [
             "CCSD TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.008118157882, 0.0, 0.004988381189, -0.004059078941, 0.0, -0.004988381189, -0.004059078941,]
             ).reshape((-1, 3)),
+            "(T) CORRECTION ENERGY": -0.00521238,
         },
     },
     {
@@ -465,6 +476,7 @@ _std_suite = [
             "CCSD TOTAL GRADIENT": np.array(
                 [0.0, 0.0, -0.002486174824, 0.0, -0.001923330621, 0.001243087412, 0.0, 0.001923330621, 0.001243087412,]
             ).reshape((-1, 3)),
+            "(T) CORRECTION ENERGY": -0.007096579721,
         },
     },
     {
@@ -517,6 +529,7 @@ _std_suite = [
                     -0.000075015929,
                 ]
             ).reshape((-1, 3)),
+            "(T) CORRECTION ENERGY": -0.00060401,
         },
     },
     {
@@ -542,6 +555,7 @@ _std_suite = [
             "CCSD TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.030055915902, 0.0, 0.016307167756, -0.015027957951, 0.0, -0.016307167756, -0.015027957951,]
             ).reshape((-1, 3)),
+            "(T) CORRECTION ENERGY": -0.00381116,
         },
     },
     {
@@ -567,6 +581,7 @@ _std_suite = [
             "CCSD TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.017883390799, 0.0, 0.00765987541, -0.0089416954, 0.0, -0.00765987541, -0.0089416954,]
             ).reshape((-1, 3)),
+            "(T) CORRECTION ENERGY": -0.00498265,
         },
     },
     {
@@ -689,6 +704,7 @@ _std_suite = [
             "CCSD CORRELATION ENERGY": -0.20874537,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": 86,  # can't calc
+            "(T) CORRECTION ENERGY": -0.00193646,
         },
     },
     {
@@ -708,6 +724,7 @@ _std_suite = [
             "CCSD CORRELATION ENERGY": -0.22941330,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": 85,  # can't calc
+            "(T) CORRECTION ENERGY": -0.00523874,
         },
     },
     {
@@ -727,6 +744,7 @@ _std_suite = [
             "CCSD CORRELATION ENERGY": -0.27570541,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": 84,  # can't calc
+            "(T) CORRECTION ENERGY": -0.00726403,
         },
     },
     {
@@ -843,6 +861,7 @@ _std_suite = [
             "CCSD CORRELATION ENERGY": -0.20681721,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": 83,  # can't calc
+            "(T) CORRECTION ENERGY": -0.00192057,
         },
     },
     {
@@ -862,6 +881,7 @@ _std_suite = [
             "CCSD CORRELATION ENERGY": -0.22717646,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": 82,  # can't calc
+            "(T) CORRECTION ENERGY": -0.00521255,
         },
     },
     {
@@ -881,6 +901,7 @@ _std_suite = [
             "CCSD CORRELATION ENERGY": -0.25033052,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": 81,  # can't calc
+            "(T) CORRECTION ENERGY": -0.00709694,
         },
     },
     {
@@ -1000,6 +1021,7 @@ _std_suite = [
             "CCSD CORRELATION ENERGY": -0.20888438,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": 79,  # can't calc
+            "(T) CORRECTION ENERGY": -0.00193859,
         },
     },
     {
@@ -1019,6 +1041,7 @@ _std_suite = [
             "CCSD CORRELATION ENERGY": -0.22730597,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": 79,  # can't calc
+            "(T) CORRECTION ENERGY": -0.00521769,
         },
     },
     {
@@ -1038,6 +1061,7 @@ _std_suite = [
             "CCSD CORRELATION ENERGY": -0.25033030,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": 79,  # can't calc
+            "(T) CORRECTION ENERGY": -0.00709666,
         },
     },
     {
@@ -1157,6 +1181,7 @@ _std_suite = [
             "CCSD CORRELATION ENERGY": -0.20695586,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": 78,  # can't calc
+            "(T) CORRECTION ENERGY": -0.00192267,
         },
     },
     {
@@ -1176,6 +1201,7 @@ _std_suite = [
             "CCSD CORRELATION ENERGY": -0.22954333,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": 78,  # can't calc
+            "(T) CORRECTION ENERGY": -0.00524393,
         },
     },
     {
@@ -1195,6 +1221,7 @@ _std_suite = [
             "CCSD CORRELATION ENERGY": -0.27570207,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": 78,  # can't calc
+            "(T) CORRECTION ENERGY": -0.00726375,
         },
     },
     {
@@ -1315,9 +1342,7 @@ _std_suite = [
             "CCSD CORRELATION ENERGY": -0.20873986012771106,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.04857381,
-            # "CCSD(T) TOTAL ENERGY": -100.23006887311104,       # TEST
-            "(T) CORRECTION ENERGY": -0.0019363109218456449,  # TEST
-            # "CCSD(T) CORRELATION ENERGY": -0.21067617104955672 # TEST
+            "(T) CORRECTION ENERGY": -0.0019363109218456449,
         },
     },
     {
@@ -1341,6 +1366,7 @@ _std_suite = [
             "CCSD CORRELATION ENERGY": -0.22941290,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.05017955,
+            "(T) CORRECTION ENERGY": -0.00523867,
         },
     },
     {
@@ -1364,6 +1390,7 @@ _std_suite = [
             "CCSD CORRELATION ENERGY": -0.27570421,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.05801141,
+            "(T) CORRECTION ENERGY": -0.00726395,
         },
     },
     {
@@ -1557,9 +1584,7 @@ _std_suite = [
             "CCSD CORRELATION ENERGY": -0.2068117080298787,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.04787083,
-            # "CCSD(T) TOTAL ENERGY": -100.22812483046566,       # TEST
-            "(T) CORRECTION ENERGY": -0.0019204203743072874,  # TEST
-            # "CCSD(T) CORRELATION ENERGY": -0.20873212840418598 # TEST
+            "(T) CORRECTION ENERGY": -0.0019204203743072874,
         },
     },
     {
@@ -1583,6 +1608,7 @@ _std_suite = [
             "CCSD CORRELATION ENERGY": -0.22717607,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.04939986,
+            "(T) CORRECTION ENERGY": -0.00521248,
         },
     },
     {
@@ -1606,6 +1632,7 @@ _std_suite = [
             "CCSD CORRELATION ENERGY": -0.25032939,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.05405638,
+            "(T) CORRECTION ENERGY": -0.00709686,
         },
     },
     {
@@ -1812,6 +1839,7 @@ _std_suite = [
             "CCSD CORRELATION ENERGY": -0.20887885,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.04845784,
+            "(T) CORRECTION ENERGY": -0.00193844,
         },
     },
     {
@@ -1831,6 +1859,7 @@ _std_suite = [
             "CCSD CORRELATION ENERGY": -0.22954292,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.05010092,
+            "(T) CORRECTION ENERGY": -0.00524386,
         },
     },
     {
@@ -1850,6 +1879,7 @@ _std_suite = [
             "CCSD CORRELATION ENERGY": -0.27570087,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.05800702,
+            "(T) CORRECTION ENERGY": -0.00726367,
         },
     },
     {
@@ -1970,6 +2000,7 @@ _std_suite = [
             "CCSD CORRELATION ENERGY": -0.20695033,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.04775464,
+            "(T) CORRECTION ENERGY": -0.00192252,
         },
     },
     {
@@ -1989,6 +2020,7 @@ _std_suite = [
             "CCSD CORRELATION ENERGY": -0.22730558,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.04932106,
+            "(T) CORRECTION ENERGY": -0.00521762,
         },
     },
     {
@@ -2008,6 +2040,7 @@ _std_suite = [
             "CCSD CORRELATION ENERGY": -0.25032917,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.05405189,
+            "(T) CORRECTION ENERGY": -0.00709658,
         },
     },
     {
@@ -2135,6 +2168,7 @@ _std_suite = [
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.04845491,
             "CCSD TOTAL GRADIENT": np.array([0.0, 0.0, 0.001970675302, 0.0, 0.0, -0.001970675302,]).reshape((-1, 3)),
+            "(T) CORRECTION ENERGY": -0.0019380186429220421,
         },
     },
     {
@@ -2170,6 +2204,7 @@ _std_suite = [
             "CCSD TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.007518759967, 0.0, 0.004613106602, -0.003759379983, 0.0, -0.004613106602, -0.003759379983,]
             ).reshape((-1, 3)),
+            "(T) CORRECTION ENERGY": -0.00524345,
         },
     },
     {
@@ -2205,6 +2240,7 @@ _std_suite = [
             "CCSD TOTAL GRADIENT": np.array(
                 [0.0, 0.0, -0.003408844165, 0.0, -0.002343169064, 0.001704422083, 0.0, 0.002343169064, 0.001704422083]
             ).reshape((-1, 3)),
+            "(T) CORRECTION ENERGY": -0.00726213,
         },
     },
     {
@@ -2416,6 +2452,7 @@ _std_suite = [
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.04775171,
             "CCSD TOTAL GRADIENT": np.array([0.0, 0.0, 0.002316563628, 0.0, 0.0, -0.002316563628,]).reshape((-1, 3)),
+            "(T) CORRECTION ENERGY": -0.001922093564526723,
         },
     },
     {
@@ -2451,6 +2488,7 @@ _std_suite = [
             "CCSD TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.008124347934, 0.0, 0.004987676555, -0.004062173967, 0.0, -0.004987676555, -0.004062173967,]
             ).reshape((-1, 3)),
+            "(T) CORRECTION ENERGY": -0.00521721,
         },
     },
     {
@@ -2486,6 +2524,7 @@ _std_suite = [
             "CCSD TOTAL GRADIENT": np.array(
                 [0.0, 0.0, -0.002520920562, 0.0, -0.001932133533, 0.001260460281, 0.0, 0.001932133533, 0.001260460281,]
             ).reshape((-1, 3)),
+            "(T) CORRECTION ENERGY": -0.00709505,
         },
     },
     {
@@ -2921,21 +2960,24 @@ _std_suite = [
 
 for calc in _std_suite:
     if calc["data"]:
-        calc["data"]["MP2 TOTAL ENERGY"] = calc["data"]["MP2 CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
-        calc["data"]["MP2 DOUBLES ENERGY"] = calc["data"]["MP2 CORRELATION ENERGY"] - calc["data"]["MP2 SINGLES ENERGY"]
-        calc["data"]["MP2 OPPOSITE-SPIN CORRELATION ENERGY"] = (
-            calc["data"]["MP2 CORRELATION ENERGY"]
-            - calc["data"]["MP2 SAME-SPIN CORRELATION ENERGY"]
-            - calc["data"]["MP2 SINGLES ENERGY"]
-        )
-        calc["data"]["SCS-MP2 CORRELATION ENERGY"] = (
-            (1 / 3) * calc["data"]["MP2 SAME-SPIN CORRELATION ENERGY"]
-            + (6 / 5) * calc["data"]["MP2 OPPOSITE-SPIN CORRELATION ENERGY"]
-            + calc["data"]["MP2 SINGLES ENERGY"]
-        )
-        calc["data"]["SCS-MP2 TOTAL ENERGY"] = (
-            calc["data"]["SCS-MP2 CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
-        )
+        if "MP2 CORRELATION ENERGY" in calc["data"]:
+            calc["data"]["MP2 TOTAL ENERGY"] = calc["data"]["MP2 CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
+            calc["data"]["MP2 DOUBLES ENERGY"] = (
+                calc["data"]["MP2 CORRELATION ENERGY"] - calc["data"]["MP2 SINGLES ENERGY"]
+            )
+            calc["data"]["MP2 OPPOSITE-SPIN CORRELATION ENERGY"] = (
+                calc["data"]["MP2 CORRELATION ENERGY"]
+                - calc["data"]["MP2 SAME-SPIN CORRELATION ENERGY"]
+                - calc["data"]["MP2 SINGLES ENERGY"]
+            )
+            calc["data"]["SCS-MP2 CORRELATION ENERGY"] = (
+                (1 / 3) * calc["data"]["MP2 SAME-SPIN CORRELATION ENERGY"]
+                + (6 / 5) * calc["data"]["MP2 OPPOSITE-SPIN CORRELATION ENERGY"]
+                + calc["data"]["MP2 SINGLES ENERGY"]
+            )
+            calc["data"]["SCS-MP2 TOTAL ENERGY"] = (
+                calc["data"]["SCS-MP2 CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
+            )
 
         if "CCSD CORRELATION ENERGY" in calc["data"]:
             calc["data"]["CCSD TOTAL ENERGY"] = (
@@ -2948,6 +2990,14 @@ for calc in _std_suite:
                 calc["data"]["CCSD CORRELATION ENERGY"]
                 - calc["data"]["CCSD SAME-SPIN CORRELATION ENERGY"]
                 - calc["data"]["CCSD SINGLES ENERGY"]
+            )
+
+        if "(T) CORRECTION ENERGY" in calc["data"]:
+            calc["data"]["CCSD(T) CORRELATION ENERGY"] = (
+                calc["data"]["CCSD CORRELATION ENERGY"] + calc["data"]["(T) CORRECTION ENERGY"]
+            )
+            calc["data"]["CCSD(T) TOTAL ENERGY"] = (
+                calc["data"]["CCSD(T) CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
             )
 
 

--- a/qcengine/programs/tests/standard_suite_ref.py
+++ b/qcengine/programs/tests/standard_suite_ref.py
@@ -119,6 +119,7 @@ _scf_h2o_adz_cd_rhf = -76.04132169763341
 _scf_nh2_adz_cd_uhf = -55.57506886675886
 _scf_nh2_adz_cd_rohf = -55.57065536578708
 
+
 _std_suite = [
     # <<<  CONV-AE-CONV  >>>
     {
@@ -145,6 +146,9 @@ _std_suite = [
                     -0.0028193375,
                 ]
             ).reshape((-1, 3)),
+            "LCCD CORRELATION ENERGY": -0.2099060277,  # p4n
+            "LCCD SINGLES ENERGY": 0.0,
+            "LCCD SAME-SPIN CORRELATION ENERGY": -0.048339903547,  # fnocc
             "CCSD CORRELATION ENERGY": -0.208743643,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.04857419039,
@@ -169,6 +173,9 @@ _std_suite = [
             "MP2 TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.009624481085, 0.0, 0.005505796371, -0.004812240542, 0.0, -0.005505796371, -0.004812240542,]
             ).reshape((-1, 3)),
+            "LCCD CORRELATION ENERGY": -0.2318870702,  # p4n
+            "LCCD SINGLES ENERGY": 0.0,
+            "LCCD SAME-SPIN CORRELATION ENERGY": -0.049937236558,  # fnocc
             "CCSD CORRELATION ENERGY": -0.2294105794,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.050177977945205,
@@ -195,6 +202,9 @@ _std_suite = [
             "MP2 TOTAL GRADIENT": np.array(
                 [0.0, 0.0, -0.000531535533, 0.0, -0.000960201925, 0.000265767766, 0.0, 0.000960201925, 0.000265767766,]
             ).reshape((-1, 3)),
+            "LCCD CORRELATION ENERGY": -0.2786913134,  # p4n
+            "LCCD SINGLES ENERGY": 0.0,
+            "LCCD SAME-SPIN CORRELATION ENERGY": -0.057792990490,  # fnocc
             "CCSD CORRELATION ENERGY": -0.275705491773,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.058006927914493,
@@ -438,6 +448,9 @@ _std_suite = [
                     -0.00317450456474,
                 ]
             ).reshape((-1, 3)),
+            "LCCD CORRELATION ENERGY": -0.2079585027,  # p4n
+            "LCCD SINGLES ENERGY": 0.0,
+            "LCCD SAME-SPIN CORRELATION ENERGY": -0.047635656759,  # fnocc
             "CCSD CORRELATION ENERGY": -0.2068152041,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.0478712079,
@@ -462,6 +475,9 @@ _std_suite = [
             "MP2 TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.010245839621, 0.0, 0.005893268945, -0.00512291981, 0.0, -0.005893268945, -0.00512291981,]
             ).reshape((-1, 3)),
+            "LCCD CORRELATION ENERGY": -0.2296135965,  # p4n
+            "LCCD SINGLES ENERGY": 0.0,
+            "LCCD SAME-SPIN CORRELATION ENERGY": -0.049154543318,  # fnocc
             "CCSD CORRELATION ENERGY": -0.2271733460,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.049398348010672,
@@ -488,6 +504,9 @@ _std_suite = [
             "MP2 TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.00033347691, 0.0, -0.00056224437, -0.000166738455, 0.0, 0.00056224437, -0.000166738455,]
             ).reshape((-1, 3)),
+            "LCCD CORRELATION ENERGY": -0.2531942099,  # p4n
+            "LCCD SINGLES ENERGY": 0.0,
+            "LCCD SAME-SPIN CORRELATION ENERGY": -0.053842594884,  # fnocc
             "CCSD CORRELATION ENERGY": -0.250330548844,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.054051928864870,
@@ -2995,6 +3014,19 @@ for calc in _std_suite:
             )
             calc["data"]["SCS-MP2 TOTAL ENERGY"] = (
                 calc["data"]["SCS-MP2 CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
+            )
+
+        if "LCCD CORRELATION ENERGY" in calc["data"]:
+            calc["data"]["LCCD TOTAL ENERGY"] = (
+                calc["data"]["LCCD CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
+            )
+            calc["data"]["LCCD DOUBLES ENERGY"] = (
+                calc["data"]["LCCD CORRELATION ENERGY"] - calc["data"]["LCCD SINGLES ENERGY"]
+            )
+            calc["data"]["LCCD OPPOSITE-SPIN CORRELATION ENERGY"] = (
+                calc["data"]["LCCD CORRELATION ENERGY"]
+                - calc["data"]["LCCD SAME-SPIN CORRELATION ENERGY"]
+                - calc["data"]["LCCD SINGLES ENERGY"]
             )
 
         if "CCSD CORRELATION ENERGY" in calc["data"]:

--- a/qcengine/programs/tests/standard_suite_runner.py
+++ b/qcengine/programs/tests/standard_suite_runner.py
@@ -130,7 +130,7 @@ def runner_asserter(inp, subject, method, basis, tnm):
     if driver == "energy":
         compare_values(ref_block[f"{method.upper()} TOTAL ENERGY"], wfn["return_result"], tnm + " wfn", atol=atol)
         assert compare_values(
-            ref_block[f"{method.upper()} TOTAL ENERGY"], wfn["properties"]["return_energy"], tnm + " prop"
+            ref_block[f"{method.upper()} TOTAL ENERGY"], wfn["properties"]["return_energy"], tnm + " prop", atol=atol
         )
 
     elif driver == "gradient":
@@ -138,7 +138,7 @@ def runner_asserter(inp, subject, method, basis, tnm):
             ref_block[f"{method.upper()} TOTAL GRADIENT"], wfn["return_result"], tnm + " grad wfn", atol=atol
         )
         assert compare_values(
-            ref_block[f"{method.upper()} TOTAL ENERGY"], wfn["properties"]["return_energy"], tnm + " prop"
+            ref_block[f"{method.upper()} TOTAL ENERGY"], wfn["properties"]["return_energy"], tnm + " prop", atol=atol
         )
         assert compare_values(
             ref_block[f"{method.upper()} TOTAL GRADIENT"],

--- a/qcengine/programs/tests/test_standard_suite.py
+++ b/qcengine/programs/tests/test_standard_suite.py
@@ -107,6 +107,18 @@ def _trans_key(qc, bas, key):
     sys.exit(1)
 
 
+# http://patorjk.com/software/taag/#p=display&c=bash&f=Soft&t=MP3
+
+
+#
+#  ,--.   ,--.,------.  ,---.     ,------.
+#  |   `.'   ||  .--. ''.-.  \    |  .---',--,--,  ,---. ,--.--. ,---.,--. ,--.
+#  |  |'.'|  ||  '--' | .-' .'    |  `--, |      \| .-. :|  .--'| .-. |\  '  /
+#  |  |   |  ||  | --' /   '-.    |  `---.|  ||  |\   --.|  |   ' '-' ' \   '
+#  `--'   `--'`--'     '-----'    `------'`--''--' `----'`--'   .`-  /.-'  /
+#                                                               `---' `---'
+
+
 @pytest.mark.parametrize("dertype", [0,], ids=["ene0"])
 @pytest.mark.parametrize(
     "basis, subjects",
@@ -187,6 +199,15 @@ def test_mp2_energy_module(inp, dertype, basis, subjects, clsd_open_pmols, reque
     print("INP", inpcopy)
 
     runner_asserter(inpcopy, subject, method, basis, tnm)
+
+
+#
+#   ,-----. ,-----. ,---.  ,------.      ,------.
+#  '  .--./'  .--./'   .-' |  .-.  \     |  .---',--,--,  ,---. ,--.--. ,---.,--. ,--.
+#  |  |    |  |    `.  `-. |  |  \  :    |  `--, |      \| .-. :|  .--'| .-. |\  '  /
+#  '  '--'\'  '--'\.-'    ||  '--'  /    |  `---.|  ||  |\   --.|  |   ' '-' ' \   '
+#   `-----' `-----'`-----' `-------'     `------'`--''--' `----'`--'   .`-  /.-'  /
+#                                                                      `---' `---'
 
 
 @pytest.mark.parametrize("dertype", [0,], ids=["ene0"])


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
standard suite support for ccsd gradients and ccsd(t) energies (except fc rohf - only validated for cfour -- psi4 is 10^-6 different). also lccd, lccsd, olccd ref values. also fixed an error handling bug in psiapi mode.

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
