### PR TITLE
Make all XC functionals lowercase

### DIFF
--- a/qcengine/programs/nwchem/germinate.py
+++ b/qcengine/programs/nwchem/germinate.py
@@ -46,7 +46,7 @@ _xc_functionals = [
     "m06-hf",
     "m06-L",
     "m06-2x",
-    "HFexch",
+    "hfexch",
     "becke88",
     "xperdew91",
     "xpbe96",


### PR DESCRIPTION
## Description
Make all xc_functionals lower case for NWChem. Otherwise, the muster_function will not detect it as a valid option for DFT calculations

## Changelog description
Minor bug fix for NWChem

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
