### PR TITLE
Update "brand" to "brand_raw" after py-cpuinfo 6.0.0

### DIFF
--- a/qcengine/config.py
+++ b/qcengine/config.py
@@ -49,7 +49,11 @@ def get_global(key: Optional[str] = None) -> Union[str, Dict[str, Any]]:
         _global_values["nnodes"] = 1
 
         _global_values["cpuinfo"] = cpuinfo.get_cpu_info()
-        _global_values["cpu_brand"] = _global_values["cpuinfo"]["brand_raw"]
+        try:
+            _global_values["cpu_brand"] = _global_values["cpuinfo"]["brand_raw"]
+        except KeyError:
+            # Remove this if py-cpuinfo is pinned to >=6.0.0
+            _global_values["cpu_brand"] = _global_values["cpuinfo"]["brand"]
 
     if key is None:
         return _global_values.copy()

--- a/qcengine/config.py
+++ b/qcengine/config.py
@@ -49,7 +49,7 @@ def get_global(key: Optional[str] = None) -> Union[str, Dict[str, Any]]:
         _global_values["nnodes"] = 1
 
         _global_values["cpuinfo"] = cpuinfo.get_cpu_info()
-        _global_values["cpu_brand"] = _global_values["cpuinfo"]["brand"]
+        _global_values["cpu_brand"] = _global_values["cpuinfo"]["brand_raw"]
 
     if key is None:
         return _global_values.copy()

--- a/qcengine/programs/psi4.py
+++ b/qcengine/programs/psi4.py
@@ -193,7 +193,7 @@ class Psi4Harness(ProgramHarness):
                     psi4.core.set_num_threads(config.ncores, quiet=True)
                     psi4.set_memory(f"{config.memory}GB", quiet=True)
                     # psi4.core.IOManager.shared_object().set_default_path(str(tmpdir))
-                    if pversion < parse_version("1.4a2.dev750"):  # adjust to where DDD merged
+                    if pversion < parse_version("1.4a2.dev770"):  # adjust to where DDD merged
                         # slightly dangerous in that if `qcng.compute({..., psiapi=True}, "psi4")` called *from psi4
                         #   session*, session could unexpectedly get its own files cleaned away.
                         output_data = psi4.schema_wrapper.run_qcschema(input_model).dict()

--- a/qcengine/programs/psi4.py
+++ b/qcengine/programs/psi4.py
@@ -193,7 +193,7 @@ class Psi4Harness(ProgramHarness):
                     psi4.core.set_num_threads(config.ncores, quiet=True)
                     psi4.set_memory(f"{config.memory}GB", quiet=True)
                     # psi4.core.IOManager.shared_object().set_default_path(str(tmpdir))
-                    if pversion < parse_version("1.4a2.dev650"):  # adjust to where DDD merged
+                    if pversion < parse_version("1.4a2.dev750"):  # adjust to where DDD merged
                         # slightly dangerous in that if `qcng.compute({..., psiapi=True}, "psi4")` called *from psi4
                         #   session*, session could unexpectedly get its own files cleaned away.
                         output_data = psi4.schema_wrapper.run_qcschema(input_model).dict()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->
Updates the API after `py-cpuinfo` was bumped to 6.0.0, resolves #252 

## Changelog description
`"brand"` key -> `"brand_raw"`
## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
