### PR TITLE
[WIP] GAMESS Evaluate EFP Energy

### DIFF
--- a/qcengine/programs/gamess/germinate.py
+++ b/qcengine/programs/gamess/germinate.py
@@ -1,5 +1,7 @@
 from typing import Any, Dict
 
+from ...exceptions import InputError
+
 
 def muster_modelchem(method: str, derint: int) -> Dict[str, Any]:
     """Converts the QC method into GAMESS keywords."""
@@ -34,5 +36,11 @@ def muster_modelchem(method: str, derint: int) -> Dict[str, Any]:
 
     elif method == "ccsd(t)":
         opts["contrl__cctyp"] = "ccsd(t)"
+
+    elif method == "efp":
+        opts["contrl__coord"] = "fragonly"
+
+    else:
+        raise InputError(f"Unrecognized method type '{method}'.")
 
     return opts

--- a/qcengine/programs/gamess/runner.py
+++ b/qcengine/programs/gamess/runner.py
@@ -107,7 +107,16 @@ class GAMESSHarness(ProgramHarness):
         # Handle conversion from schema (flat key/value) keywords into local format
         optcmd = format_keywords(opts)
 
-        gamessrec["infiles"]["gamess.inp"] = optcmd + molcmd
+        # Temporary hack: EFP command passed in as input_data.extras.efp
+        # In the future, should be passed in as input_data.molecule.extras.efp (or input_data.molecule.efp)
+        #
+        # Currently passing in the entire GAMESS-formatted EFP command (i.e. the $EFRAG section)
+        # In the future, should be passed in as actual data fragments, coordinates, etc.)
+        if "efp" in input_model.molecule.extras:
+            efpcmd = input_model.molecule.extras["efp"]
+            gamessrec["infiles"]["gamess.inp"] = optcmd + efpcmd + molcmd
+        else:
+            gamessrec["infiles"]["gamess.inp"] = optcmd + molcmd
         gamessrec["command"] = [which("rungms"), "gamess"]  # rungms JOB VERNO NCPUS >& JOB.log &
 
         return gamessrec


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->
Add support for GAMESS's EFP method, which calculates the interaction energy between multiple molecular fragments using a specified potential for each fragment.

A couple things have to happen before this PR is ready (see https://github.com/MolSSI/QCElemental/pull/124)

- Support for "empty" QCElemental `Molecule` (EFP fragments will be stored in `Molecule.extras`)
- Agreement on how to specify of EFP fragment geometries/orientations, and if/how they should be validated.
- Agreement on how to handle the actual fragment potentials (i.e. the output of GAMESS's makefp command). Is the user expected to provide the potential(s)? If so, in what format. If not, QCEngine needs a library of potentials.

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->
GAMESS EFP Support

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [ ] Code base linted
- [ ] Ready to go
