### PR TITLE
Add TorchANI's ANI2x built-in model

### DIFF
--- a/devtools/conda-envs/torchani.yaml
+++ b/devtools/conda-envs/torchani.yaml
@@ -1,6 +1,7 @@
 name: test
 channels:
   - conda-forge
+  - pytorch-nightly
 dependencies:
 
     # Core
@@ -12,10 +13,11 @@ dependencies:
   - qcelemental >=0.12.0
   - pydantic>=1.0.0
 
+  - pytorch
+
     # Testing
   - pytest
   - pytest-cov
   - codecov
   - pip:
-    - --pre torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
     - torchani

--- a/devtools/conda-envs/torchani.yaml
+++ b/devtools/conda-envs/torchani.yaml
@@ -19,4 +19,4 @@ dependencies:
   - pytest-cov
   - codecov
   - pip:
-    - torchani <2.0
+    - torchani

--- a/devtools/conda-envs/torchani.yaml
+++ b/devtools/conda-envs/torchani.yaml
@@ -12,7 +12,7 @@ dependencies:
   - qcelemental >=0.12.0
   - pydantic>=1.0.0
 
-  - pytorch-nightly::pytorch cpuonly
+  - pytorch cpuonly -c pytorch-nightly
 
     # Testing
   - pytest

--- a/devtools/conda-envs/torchani.yaml
+++ b/devtools/conda-envs/torchani.yaml
@@ -12,7 +12,7 @@ dependencies:
   - qcelemental >=0.12.0
   - pydantic>=1.0.0
 
-  - pytorch::pytorch-nightly-cpu
+  - pytorch-nightly::pytorch cpuonly
 
     # Testing
   - pytest

--- a/devtools/conda-envs/torchani.yaml
+++ b/devtools/conda-envs/torchani.yaml
@@ -12,11 +12,10 @@ dependencies:
   - qcelemental >=0.12.0
   - pydantic>=1.0.0
 
-  - pytorch cpuonly -c pytorch-nightly
-
     # Testing
   - pytest
   - pytest-cov
   - codecov
   - pip:
+    - --pre torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
     - torchani

--- a/qcengine/programs/torchani.py
+++ b/qcengine/programs/torchani.py
@@ -112,7 +112,7 @@ class TorchANIHarness(ProgramHarness):
         species = input_data.molecule.symbols
 
         known_sym = {"H", "C", "N", "O"}
-        if method.lower() == 'ani2x':
+        if method.lower() == "ani2x":
             known_sym.update({"S", "F", "CL"})
 
         unknown_sym = set(species) - known_sym

--- a/qcengine/programs/torchani.py
+++ b/qcengine/programs/torchani.py
@@ -91,10 +91,8 @@ class TorchANIHarness(ProgramHarness):
 
         # Check if existings and version
         self.found(raise_error=True)
-        if parse_version(self.get_version()) < parse_version("0.9"):
-            raise ResourceError("QCEngine's TorchANI wrapper requires version 0.9 or greater.")
-        if parse_version(self.get_version()) >= parse_version("2.0"):
-            raise ResourceError("QCEngine's TorchANI adaptor requires lesser than version 2.0.")
+        if parse_version(self.get_version()) < parse_version("2.1.1"):
+            raise ResourceError("QCEngine's TorchANI wrapper requires version 2.1.1 or greater.")
 
         import torch
         import torchani

--- a/qcengine/programs/torchani.py
+++ b/qcengine/programs/torchani.py
@@ -110,7 +110,7 @@ class TorchANIHarness(ProgramHarness):
 
         # Build species
         species = input_data.molecule.symbols
-        unknown_sym = set(species) - {"H", "C", "N", "O"}
+        unknown_sym = set(species) - {"H", "C", "N", "O", "S", "F", "CL"}
         if unknown_sym:
             raise InputError(f"TorchANI model '{input_data.model.method}' does not support symbols: {unknown_sym}.")
 

--- a/qcengine/programs/torchani.py
+++ b/qcengine/programs/torchani.py
@@ -76,6 +76,9 @@ class TorchANIHarness(ProgramHarness):
         elif name == "ani1ccx":
             self._CACHE[name] = torchani.models.ANI1ccx()
 
+        elif name == "ani2x":
+            self._CACHE[name] = torchani.models.ANI2x()
+
         else:
             return False
 
@@ -105,7 +108,7 @@ class TorchANIHarness(ProgramHarness):
         # Build model
         model = self.get_model(input_data.model.method)
         if model is False:
-            raise InputError("TorchANI only accepts the ANI1x or ANI1ccx method.")
+            raise InputError("TorchANI only accepts the ANI1x, ANI1ccx or ANI2x methods.")
 
         # Build species
         species = "".join(input_data.molecule.symbols)

--- a/qcengine/programs/torchani.py
+++ b/qcengine/programs/torchani.py
@@ -113,7 +113,7 @@ class TorchANIHarness(ProgramHarness):
 
         known_sym = {"H", "C", "N", "O"}
         if method.lower() == "ani2x":
-            known_sym.update({"S", "F", "CL"})
+            known_sym.update({"S", "F", "Cl"})
 
         unknown_sym = set(species) - known_sym
         if unknown_sym:

--- a/qcengine/programs/torchani.py
+++ b/qcengine/programs/torchani.py
@@ -92,8 +92,8 @@ class TorchANIHarness(ProgramHarness):
 
         # Check if existings and version
         self.found(raise_error=True)
-        if parse_version(self.get_version()) < parse_version("2.1.1"):
-            raise ResourceError("QCEngine's TorchANI wrapper requires version 2.1.1 or greater.")
+        if parse_version(self.get_version()) < parse_version("0.9"):
+            raise ResourceError("QCEngine's TorchANI wrapper requires version 0.9 or greater.")
 
         import torch
         import torchani

--- a/qcengine/programs/torchani.py
+++ b/qcengine/programs/torchani.py
@@ -109,7 +109,7 @@ class TorchANIHarness(ProgramHarness):
             raise InputError("TorchANI only accepts the ANI1x, ANI1ccx or ANI2x methods.")
 
         # Build species
-        species = "".join(input_data.molecule.symbols)
+        species = input_data.molecule.symbols
         unknown_sym = set(species) - {"H", "C", "N", "O"}
         if unknown_sym:
             raise InputError(f"TorchANI model '{input_data.model.method}' does not support symbols: {unknown_sym}.")

--- a/qcengine/testing.py
+++ b/qcengine/testing.py
@@ -160,7 +160,7 @@ _programs = {
     "qchem": is_program_new_enough("qchem", "5.2"),
     "rdkit": which_import("rdkit", return_bool=True),
     "terachem": which("terachem", return_bool=True),
-    "torchani": is_program_new_enough("torchani", "0.9"),
+    "torchani": is_program_new_enough("torchani", "2.1.1"),
     "turbomole": which("define", return_bool=True),
     "xtb": which_import("xtb", return_bool=True),
 }

--- a/qcengine/testing.py
+++ b/qcengine/testing.py
@@ -160,7 +160,7 @@ _programs = {
     "qchem": is_program_new_enough("qchem", "5.2"),
     "rdkit": which_import("rdkit", return_bool=True),
     "terachem": which("terachem", return_bool=True),
-    "torchani": is_program_new_enough("torchani", "2.1.1"),
+    "torchani": is_program_new_enough("torchani", "0.9"),
     "turbomole": which("define", return_bool=True),
     "xtb": which_import("xtb", return_bool=True),
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
TorchANI now supports ANI2x model as of our latest release ([2.1.1](https://github.com/aiqm/torchani/releases/tag/2.1.1)) 

This PR also fixes #247 

## Changelog description
[ANI2x](https://pubs.acs.org/doi/10.1021/acs.jctc.0c00121) model is added as an option in TorchANI interface in QCEngine

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [ ] Code base linted
- [ ] Ready to go
