### PR TITLE
standard suite for HF, MP2.5, MP3, LCCD grad

### DIFF
--- a/devtools/conda-envs/psi.yaml
+++ b/devtools/conda-envs/psi.yaml
@@ -14,7 +14,7 @@ dependencies:
   - pyyaml
   - py-cpuinfo
   - psutil
-  - qcelemental=0.12.0  # test minimum stated version.
+  - qcelemental=0.13.0  # test minimum stated version.
   - pydantic=1.2.0  # test minimun stated version. actually min is 1.0 but no py38 builds
 
     # Testing

--- a/devtools/conda-envs/psi.yaml
+++ b/devtools/conda-envs/psi.yaml
@@ -14,8 +14,8 @@ dependencies:
   - pyyaml
   - py-cpuinfo
   - psutil
-  - qcelemental >=0.13.0
-  - pydantic>=1.0.0
+  - qcelemental=0.12.0  # test minimum stated version.
+  - pydantic=1.2.0  # test minimun stated version. actually min is 1.0 but no py38 builds
 
     # Testing
   - pytest

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -14,6 +14,22 @@ Changelog
 .. +++++++++
 
 
+v0.16.0 / 2020-MM-DD
+--------------------
+
+New Features
+++++++++++++
+
+Enhancements
+++++++++++++
+- (:pr:`241`) NWChem - improved performance by turning on ``atoms_map=True``, which does seem to be true.
+- (:pr:`257`) TorchANI - learned the ANI2x model and to work with v2.
+- (:pr:`259`) Added MP2.5 & MP3 energies and HF, MP2.5, MP3, LCCD gradients reference data to stdsuite.
+
+Bug Fixes
++++++++++
+
+
 v0.15.0 / 2020-06-26
 --------------------
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -14,7 +14,7 @@ Changelog
 .. +++++++++
 
 
-v0.16.0 / 2020-MM-DD
+v0.16.0 / 2020-08-18
 --------------------
 
 New Features
@@ -25,9 +25,14 @@ Enhancements
 - (:pr:`241`) NWChem - improved performance by turning on ``atoms_map=True``, which does seem to be true.
 - (:pr:`257`) TorchANI - learned the ANI2x model and to work with v2.
 - (:pr:`259`) Added MP2.5 & MP3 energies and HF, MP2.5, MP3, LCCD gradients reference data to stdsuite.
+- (:pr:`261`) Q-Chem - learned to return more informative Provenance, learned to work with v5.1.
+- (:pr:`263`) NWChem - learned how to turn off automatic Z-Matrix coordinates with ``geometry__noautoz = True``.
 
 Bug Fixes
 +++++++++
+- (:pr:`261`) Molpro - learned to error cleanly if version too old fro XML parsing.
+- (:pr:`261`) Q-Chem - learned to extract version from output file instead of ``qchem -h`` since command isn't available
+  from a source install.
 
 
 v0.15.0 / 2020-06-26

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -14,7 +14,7 @@ Changelog
 .. +++++++++
 
 
-v0.16.0 / 2020-08-18
+v0.16.0 / 2020-08-19
 --------------------
 
 New Features
@@ -30,7 +30,7 @@ Enhancements
 
 Bug Fixes
 +++++++++
-- (:pr:`261`) Molpro - learned to error cleanly if version too old fro XML parsing.
+- (:pr:`261`) Molpro - learned to error cleanly if version too old for XML parsing.
 - (:pr:`261`) Q-Chem - learned to extract version from output file instead of ``qchem -h`` since command isn't available
   from a source install.
 

--- a/qcengine/programs/cfour/harvester.py
+++ b/qcengine/programs/cfour/harvester.py
@@ -208,6 +208,8 @@ def harvest_outfile_pass(outtext):
         psivar["MP3 TOTAL ENERGY"] = mobj.group(4)
         psivar["MP2.5 CORRELATION ENERGY"] = dmp2 + Decimal("0.500000000000") * dmp3
         psivar["MP2.5 TOTAL ENERGY"] = psivar["MP2.5 CORRELATION ENERGY"] + psivar["SCF TOTAL ENERGY"]
+        psivar["MP3 SINGLES ENERGY"] = Decimal("0.0")
+        psivar["MP3 DOUBLES ENERGY"] = dmp2 + dmp3
 
     mobj = re.search(
         # fmt: off
@@ -227,6 +229,8 @@ def harvest_outfile_pass(outtext):
         psivar["MP3 TOTAL ENERGY"] = mobj.group(8)
         psivar["MP2.5 CORRELATION ENERGY"] = dmp2 + Decimal("0.500000000000") * dmp3
         psivar["MP2.5 TOTAL ENERGY"] = psivar["MP2.5 CORRELATION ENERGY"] + psivar["SCF TOTAL ENERGY"]
+        psivar["MP3 SINGLES ENERGY"] = Decimal(mobj.group(1)) + Decimal(mobj.group(5))
+        psivar["MP3 DOUBLES ENERGY"] = Decimal(mobj.group(3)) + Decimal(mobj.group(7))
 
     # Process MP4
     mobj = re.search(

--- a/qcengine/programs/psi4.py
+++ b/qcengine/programs/psi4.py
@@ -194,7 +194,7 @@ class Psi4Harness(ProgramHarness):
                     psi4.core.set_num_threads(config.ncores, quiet=True)
                     psi4.set_memory(f"{config.memory}GB", quiet=True)
                     # psi4.core.IOManager.shared_object().set_default_path(str(tmpdir))
-                    if pversion < parse_version("1.4a2.dev770"):  # adjust to where DDD merged
+                    if pversion < parse_version("1.4a3"):  # adjust to where DDD merged
                         # slightly dangerous in that if `qcng.compute({..., psiapi=True}, "psi4")` called *from psi4
                         #   session*, session could unexpectedly get its own files cleaned away.
                         output_data = psi4.schema_wrapper.run_qcschema(input_model).dict()

--- a/qcengine/programs/qcvar_identities_resources.py
+++ b/qcengine/programs/qcvar_identities_resources.py
@@ -155,8 +155,20 @@ def qcvar_identities() -> List[Dict[str, Any]]:
     #    'func': sum,
     #    'args': ['HF TOTAL ENERGY', 'DW-MP2 CORRELATION ENERGY']})
 
+    # MP3
+    pv0.extend(_solve_in_turn(args=["MP3 TOTAL ENERGY", "HF TOTAL ENERGY", "MP3 CORRELATION ENERGY"], coeff=[-1, 1, 1]))
+    pv0.extend(
+        _solve_in_turn(
+            args=["MP3 DOUBLES ENERGY", "MP3 SAME-SPIN CORRELATION ENERGY", "MP3 OPPOSITE-SPIN CORRELATION ENERGY"],
+            coeff=[-1, 1, 1],
+        )
+    )
+    pv0.extend(
+        _solve_in_turn(args=["MP3 CORRELATION ENERGY", "MP3 DOUBLES ENERGY", "MP3 SINGLES ENERGY"], coeff=[-1, 1, 1])
+    )
+
     # MPN
-    for mpn in range(3, 20):
+    for mpn in range(4, 20):
         pv0.extend(
             _solve_in_turn(
                 args=["MP{} TOTAL ENERGY".format(mpn), "HF TOTAL ENERGY", "MP{} CORRELATION ENERGY".format(mpn)],

--- a/qcengine/programs/tests/standard_suite_ref.py
+++ b/qcengine/programs/tests/standard_suite_ref.py
@@ -120,6 +120,47 @@ _scf_nh2_adz_cd_uhf = -55.57506886675886
 _scf_nh2_adz_cd_rohf = -55.57065536578708
 
 
+# fmt: off
+_grad_scf_hf_dz_pk_rhf = np.array([0.0, 0.0, -0.019789748774, -0.0, -0.0, 0.019789748774]).reshape((-1, 3))
+_grad_scf_bh3p_dz_pk_uhf = np.array([ 0.0, 0.0, 0.018283596898, 0.0, 0.0, -0.016914487538, -0.0, 0.004869782481, -0.00068455468, 0.0, -0.004869782481, -0.00068455468,]).reshape((-1, 3))
+_grad_scf_bh3p_dz_pk_rohf = np.array([ 0.0, 0.0, 0.022062218595, 0.0, 0.0, -0.02050835054, -0.0, 0.004706239974, -0.000776934027, 0.0, -0.004706239974, -0.000776934027,]).reshape((-1, 3))
+
+_grad_scf_hf_dz_df_rhf = np.array([0.0, -0.0, -0.0197887676, -0.0, 0.0, 0.0197887676]).reshape((-1, 3))
+_grad_scf_bh3p_dz_df_uhf = np.array([-0.0, 0.0, 0.018279955719, 0.0, 0.0, -0.016906923007, -0.0, 0.004865311963, -0.000686516356, 0.0, -0.004865311963, -0.000686516356,]).reshape((-1, 3))
+_grad_scf_bh3p_dz_df_rohf = np.array([-0.0, 0.0, 0.022058469913, 0.0, 0.0, -0.020500364247, -0.0, 0.004701465609, -0.000779052833, 0.0, -0.004701465609, -0.000779052833,]).reshape((-1, 3))
+
+_grad_scf_hf_dz_cd_rhf = np.array([0.0, 0.0, -0.019796742926, 0.0, 0.0, 0.019796742926]).reshape((-1, 3))
+_grad_scf_bh3p_dz_cd_uhf = np.array([ 0.0, 0.0, 0.018280917408, 0.0, 0.0, -0.016907239597, 0.0, 0.004874331571, -0.000686838905, 0.0, -0.004874331571, -0.000686838905,]).reshape((-1, 3))
+_grad_scf_bh3p_dz_cd_rohf = np.array([ 0.0, 0.0, 0.022058379283, 0.0, 0.0, -0.020499895346, 0.0, 0.004710759277, -0.000779241969, 0.0, -0.004710759277, -0.000779241969,]).reshape((-1, 3))
+
+
+_grad_scf_h2o_qz2p_pk_rhf = np.array([-0.0, 0.0, -0.026426043127, 0.0, -0.013943334328, 0.013213021564, -0.0, 0.013943334328, 0.013213021564]).reshape((-1, 3))
+_grad_scf_nh2_qz2p_pk_uhf = np.array([0.0, 0.0, 0.001550839727, -0.0, 0.000092404341, -0.000775419863, 0.0, -0.000092404341, -0.000775419863]).reshape((-1, 3))
+_grad_scf_nh2_qz2p_pk_rohf = np.array([-0.0, 0.0, 0.000683766715, 0.0, -0.000526016129, -0.000341883358, -0.0, 0.000526016129, -0.000341883358]).reshape((-1, 3))
+
+_grad_scf_h2o_qz2p_df_rhf = np.array([0.0, 0.0, -0.026454963718, 0.0, -0.013950706431, 0.013227481859, -0.0, 0.013950706431, 0.013227481859]).reshape((-1, 3))
+_grad_scf_nh2_qz2p_df_uhf = np.array([-0.0, 0.0, 0.001532526876, -0.0, 0.000082065307, -0.000766263438, 0.0, -0.000082065307, -0.000766263438]).reshape((-1, 3))
+_grad_scf_nh2_qz2p_df_rohf = np.array([0.0, 0.0, 0.000665139571, 0.0, -0.000536617267, -0.000332569786, -0.0, 0.000536617267, -0.000332569786]).reshape((-1, 3))
+
+_grad_scf_h2o_qz2p_cd_rhf = np.array([0.0, 0.0, -0.026440883169, 0.0, -0.013949099753, 0.013220441584, 0.0, 0.013949099753, 0.013220441584]).reshape((-1, 3))
+_grad_scf_nh2_qz2p_cd_uhf = np.array([0.0, 0.0, 0.001549105775, 0.0, 0.000091952809, -0.000774552887, 0.0, -0.000091952809, -0.000774552887]).reshape((-1, 3))
+_grad_scf_nh2_qz2p_cd_rohf = np.array([0.0, 0.0, 0.000681888827, 0.0, -0.000526508263, -0.000340944414, 0.0, 0.000526508263, -0.000340944414]).reshape((-1, 3))
+
+
+_grad_scf_h2o_adz_pk_rhf = np.array([-0.0, 0.0, -0.021391822417, 0.0, -0.011259127342, 0.010695911208, -0.0, 0.011259127342, 0.010695911208]).reshape((-1, 3))
+_grad_scf_nh2_adz_pk_uhf = np.array([-0.0, 0.0, 0.008498123792, -0.0, 0.004518040488, -0.004249061896, 0.0, -0.004518040488, -0.004249061896]).reshape((-1, 3))
+_grad_scf_nh2_adz_pk_rohf = np.array([-0.0, 0.0, 0.007678819724, -0.0, 0.003856927713, -0.003839409862, 0.0, -0.003856927713, -0.003839409862]).reshape((-1, 3))
+
+_grad_scf_h2o_adz_df_rhf = np.array([0.0, 0.0, -0.021402714298, 0.0, -0.011255158091, 0.010701357149, -0.0, 0.011255158091, 0.010701357149]).reshape((-1, 3))
+_grad_scf_nh2_adz_df_uhf = np.array([0.0, 0.0, 0.00848503512, -0.0, 0.004519001873, -0.00424251756, 0.0, -0.004519001873, -0.00424251756]).reshape((-1, 3))
+_grad_scf_nh2_adz_df_rohf = np.array([0.0, 0.0, 0.007664957774, -0.0, 0.003857593701, -0.003832478887, 0.0, -0.003857593701, -0.003832478887]).reshape((-1, 3))
+
+_grad_scf_h2o_adz_cd_rhf = np.array([0.0, 0.0, -0.021374103228, 0.0, -0.011265854947, 0.010687051614, 0.0, 0.011265854947, 0.010687051614]).reshape((-1, 3))
+_grad_scf_nh2_adz_cd_uhf = np.array([0.0, 0.0, 0.00848026807, 0.0, 0.004537635752, -0.004240134035, 0.0, -0.004537635752, -0.004240134035]).reshape((-1, 3))
+_grad_scf_nh2_adz_cd_rohf = np.array([0.0, 0.0, 0.007661397585, 0.0, 0.003876803846, -0.003830698792, 0.0, -0.003876803846, -0.003830698792]).reshape((-1, 3))
+# fmt: on
+
+
 _std_suite = [
     # <<<  CONV-AE-CONV  >>>
     {
@@ -133,6 +174,7 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_hf_dz_pk_rhf,
+            "HF TOTAL GRADIENT": _grad_scf_hf_dz_pk_rhf,
             "MP2 CORRELATION ENERGY": -0.203781911950,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.05427697023782003,
@@ -146,9 +188,14 @@ _std_suite = [
                     -0.0028193375,
                 ]
             ).reshape((-1, 3)),
+            "MP3 CORRELATION ENERGY": -0.20647996,  # fnocc
+            "MP3 SINGLES ENERGY": 0.0,
+            "MP3 SAME-SPIN CORRELATION ENERGY": -0.04989037,  # fnocc
+            "MP3 TOTAL GRADIENT": np.array([0.0, 0.0, -0.000917944631, 0.0, 0.0, 0.000917944631]).reshape((-1, 3)),
             "LCCD CORRELATION ENERGY": -0.2099060277,  # p4n
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.048339903547,  # fnocc
+            "LCCD TOTAL GRADIENT": np.array([0.0, -0.0, 0.002203664242, -0.0, 0.0, -0.002203664242]).reshape((-1, 3)),
             "LCCSD CORRELATION ENERGY": -0.2107436391,  # p4n
             "LCCSD SINGLES ENERGY": 0.0,
             "LCCSD SAME-SPIN CORRELATION ENERGY": -0.048460183760,  # fnocc
@@ -160,6 +207,7 @@ _std_suite = [
             "OLCCD REFERENCE CORRECTION ENERGY": 0.0005522939,  # p4n
             "OLCCD CORRELATION ENERGY": -0.2104417743,  # p4n
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.0484443079,  # occ
+            # "XXX TOTAL GRADIENT": np.zeros(6).reshape((-1, 3)),
         },
     },
     {
@@ -173,15 +221,25 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_h2o_adz_pk_rhf,
+            "HF TOTAL GRADIENT": _grad_scf_h2o_adz_pk_rhf,
             "MP2 CORRELATION ENERGY": -0.2218977246,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.05669988343022163,
             "MP2 TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.009624481085, 0.0, 0.005505796371, -0.004812240542, 0.0, -0.005505796371, -0.004812240542,]
             ).reshape((-1, 3)),
+            "MP3 SAME-SPIN CORRELATION ENERGY": -0.051851951707,  # fnocc
+            "MP3 SINGLES ENERGY": 0.0,
+            "MP3 CORRELATION ENERGY": -0.226431141430,  # fnocc
+            "MP3 TOTAL GRADIENT": np.array(
+                [0.0, 0.0, 0.003997280108, 0.0, 0.00255475829, -0.001998640054, 0.0, -0.00255475829, -0.001998640054]
+            ).reshape(-1, 3),
             "LCCD CORRELATION ENERGY": -0.2318870702,  # p4n
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.049937236558,  # fnocc
+            "LCCD TOTAL GRADIENT": np.array(
+                [0.0, 0.0, 0.008553750217, -0.0, 0.005238229687, -0.004276875109, 0.0, -0.005238229687, -0.004276875109]
+            ).reshape((-1, 3)),
             "LCCSD CORRELATION ENERGY": -0.2341051403,  # p4n
             "LCCSD SINGLES ENERGY": 0.0,
             "LCCSD SAME-SPIN CORRELATION ENERGY": -0.050442387759,  # fnocc
@@ -195,6 +253,7 @@ _std_suite = [
             "OLCCD REFERENCE CORRECTION ENERGY": 0.0011895155,  # p4n
             "OLCCD CORRELATION ENERGY": -0.2330452995,  # p4n
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.0503175223,  # occ
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     {
@@ -208,15 +267,25 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_h2o_qz2p_pk_rhf,
+            "HF TOTAL GRADIENT": _grad_scf_h2o_qz2p_pk_rhf,
             "MP2 CORRELATION ENERGY": -0.2701916672,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.06530131,
             "MP2 TOTAL GRADIENT": np.array(
                 [0.0, 0.0, -0.000531535533, 0.0, -0.000960201925, 0.000265767766, 0.0, 0.000960201925, 0.000265767766,]
             ).reshape((-1, 3)),
+            "MP3 CORRELATION ENERGY": -0.27294451,  # fnocc
+            "MP3 SINGLES ENERGY": 0.0,
+            "MP3 SAME-SPIN CORRELATION ENERGY": -0.05952936,  # fnocc
+            "MP3 TOTAL GRADIENT": np.array(
+                [0.0, 0.0, -0.007003320116, 0.0, -0.004485227443, 0.003501660058, 0.0, 0.004485227443, 0.003501660058]
+            ).reshape((-1, 3)),
             "LCCD CORRELATION ENERGY": -0.2786913134,  # p4n
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.057792990490,  # fnocc
+            "LCCD TOTAL GRADIENT": np.array(
+                [0.0, 0.0, -0.002309010869, 0.0, -0.0017745445, 0.001154505435, -0.0, 0.0017745445, 0.001154505435]
+            ).reshape((-1, 3)),
             "LCCSD CORRELATION ENERGY": -0.2808517417,  # p4n
             "LCCSD SINGLES ENERGY": 0.0,
             "LCCSD SAME-SPIN CORRELATION ENERGY": -0.058297242512,  # fnocc
@@ -230,6 +299,7 @@ _std_suite = [
             "OLCCD REFERENCE CORRECTION ENERGY": 0.0013521561,  # p4n
             "OLCCD CORRELATION ENERGY": -0.2800053174,  # p4n
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.0582676514,  # occ
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     {
@@ -243,6 +313,7 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_bh3p_dz_pk_uhf,
+            "HF TOTAL GRADIENT": _grad_scf_bh3p_dz_pk_uhf,
             "MP2 CORRELATION ENERGY": -0.05948928003552,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.001918693775,
@@ -262,9 +333,44 @@ _std_suite = [
                     -0.00022012333306,
                 ]
             ).reshape((-1, 3)),
+            "MP3 CORRELATION ENERGY": -0.07481556,  # occ
+            "MP3 SINGLES ENERGY": 0.0,
+            "MP3 SAME-SPIN CORRELATION ENERGY": -0.00235692,  # occ
+            "MP3 TOTAL GRADIENT": np.array(
+                [
+                    0.0,
+                    0.0,
+                    0.0093167821,
+                    0.0,
+                    0.0,
+                    -0.00908998793,
+                    0.0,
+                    0.012725715572,
+                    -0.000113397085,
+                    0.0,
+                    -0.012725715572,
+                    -0.000113397085,
+                ]
+            ).reshape((-1, 3)),
             "LCCD CORRELATION ENERGY": -0.0834347185,  # p4n
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0024003297,  # occ
+            "LCCD TOTAL GRADIENT": np.array(
+                [
+                    -0.0,
+                    0.0,
+                    0.004644430473,
+                    0.0,
+                    0.0,
+                    -0.004561891704,
+                    -0.0,
+                    0.015262723486,
+                    -0.000041269384,
+                    0.0,
+                    -0.015262723486,
+                    -0.000041269384,
+                ]
+            ).reshape((-1, 3)),
             "LCCSD CORRELATION ENERGY": -0.0848110820,  # p4n
             "LCCSD SINGLES ENERGY": 0.0,
             "CCSD CORRELATION ENERGY": -0.08217287869,
@@ -290,6 +396,7 @@ _std_suite = [
             "OLCCD REFERENCE CORRECTION ENERGY": 0.0014842084,  # p4n
             "OLCCD CORRELATION ENERGY": -0.0847413506,  # p4n
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.0024486744,  # occ
+            # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
         },
     },
     {
@@ -303,15 +410,25 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_nh2_adz_pk_uhf,
+            "HF TOTAL GRADIENT": _grad_scf_nh2_adz_pk_uhf,
             "MP2 CORRELATION ENERGY": -0.15485993330517828,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.03520162545964887,
             "MP2 TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.025490652204, 0.0, 0.013491755791, -0.012745326102, 0.0, -0.013491755791, -0.012745326102,]
             ).reshape((-1, 3)),
+            "MP3 CORRELATION ENERGY": -0.17091690,  # occ
+            "MP3 SINGLES ENERGY": 0.0,
+            "MP3 SAME-SPIN CORRELATION ENERGY": -0.03533349,  # occ
+            "MP3 TOTAL GRADIENT": np.array(
+                [0.0, 0.0, 0.027091204409, 0.0, 0.014414444742, -0.013545602205, 0.0, -0.014414444742, -0.013545602205]
+            ).reshape((-1, 3)),
             "LCCD CORRELATION ENERGY": -0.1770086091,  # p4n
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0341268118,  # occ
+            "LCCD TOTAL GRADIENT": np.array(
+                [0.0, 0.0, 0.030699807076, 0.0, 0.016626789229, -0.015349903538, 0.0, -0.016626789229, -0.015349903538]
+            ).reshape((-1, 3)),
             "LCCSD CORRELATION ENERGY": -0.1786081472,  # p4n
             "LCCSD SINGLES ENERGY": 0.0,
             "CCSD CORRELATION ENERGY": -0.17387203707017695,
@@ -324,6 +441,7 @@ _std_suite = [
             "OLCCD REFERENCE CORRECTION ENERGY": 0.0011118724,  # p4n
             "OLCCD CORRELATION ENERGY": -0.1781057943,  # p4n
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.0344689234,  # occ
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     {
@@ -337,15 +455,25 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_nh2_qz2p_pk_uhf,
+            "HF TOTAL GRADIENT": _grad_scf_nh2_qz2p_pk_uhf,
             "MP2 CORRELATION ENERGY": -0.195530391293,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.04161633,
             "MP2 TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.013731673196, 0.0, 0.005352105826, -0.006865836598, 0.0, -0.005352105826, -0.006865836598,]
             ).reshape((-1, 3)),
+            "MP3 CORRELATION ENERGY": -0.21084677,  # occ
+            "MP3 SINGLES ENERGY": 0.0,
+            "MP3 SAME-SPIN CORRELATION ENERGY": -0.04130360,  # occ
+            "MP3 TOTAL GRADIENT": np.array(
+                [0.0, 0.0, 0.014436297067, 0.0, 0.005622513341, -0.007218148534, 0.0, -0.005622513341, -0.007218148534]
+            ).reshape((-1, 3)),
             "LCCD CORRELATION ENERGY": -0.2167878305,  # p4n
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0401306050,  # occ
+            "LCCD TOTAL GRADIENT": np.array(
+                [0.0, 0.0, 0.018147039011, 0.0, 0.007823362162, -0.009073519505, 0.0, -0.007823362162, -0.009073519505]
+            ).reshape((-1, 3)),
             "LCCSD CORRELATION ENERGY": -0.2185061347,  # p4n
             "LCCSD SINGLES ENERGY": 0.0,
             "CCSD CORRELATION ENERGY": -0.213298055172,
@@ -358,6 +486,7 @@ _std_suite = [
             "OLCCD REFERENCE CORRECTION ENERGY": 0.0012856903,  # p4n
             "OLCCD CORRELATION ENERGY": -0.2180560836,  # p4n
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.0405122800,  # occ
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     {
@@ -371,6 +500,7 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_bh3p_dz_pk_rohf,
+            "HF TOTAL GRADIENT": _grad_scf_bh3p_dz_pk_rohf,
             "MP2 CORRELATION ENERGY": -0.060478115157,
             "MP2 SINGLES ENERGY": -0.000694049865,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.002004909679,
@@ -391,6 +521,8 @@ _std_suite = [
                     -0.000233556107879,
                 ]
             ).reshape((-1, 3)),
+            "MP3 CORRELATION ENERGY": -0.075906990477,  # cfour
+            "MP3 SINGLES ENERGY": -0.000916783719,  # cfour
             "LCCD CORRELATION ENERGY": -0.0834094914,  # p4n
             "LCCSD CORRELATION ENERGY": -0.0861427228,  # p4n
             "CCSD CORRELATION ENERGY": -0.08357160616,
@@ -416,6 +548,7 @@ _std_suite = [
             "OLCCD REFERENCE CORRECTION ENERGY": -0.0000399018,  # p4n
             "OLCCD CORRELATION ENERGY": -0.0862654609,  # p4n
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.0024486744,  # occ
+            # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
         },
     },
     {
@@ -429,12 +562,15 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_nh2_adz_pk_rohf,
+            "HF TOTAL GRADIENT": _grad_scf_nh2_adz_pk_rohf,
             "MP2 CORRELATION ENERGY": -0.15949744108346664,
             "MP2 SINGLES ENERGY": -0.0028296307982793997,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.03541709278508698,
             "MP2 TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.025609525826, 0.0, 0.013506941035, -0.012804762913, 0.0, -0.013506941035, -0.012804762913,]
             ).reshape((-1, 3)),
+            "MP3 CORRELATION ENERGY": -0.17571623051,  # cfour
+            "MP3 SINGLES ENERGY": -0.003236109562,  # cfour
             "LCCD CORRELATION ENERGY": -0.1791714105,  # p4n
             "LCCSD CORRELATION ENERGY": -0.1830545845,  # p4n
             "CCSD CORRELATION ENERGY": -0.178236032911,
@@ -447,6 +583,7 @@ _std_suite = [
             "OLCCD REFERENCE CORRECTION ENERGY": -0.0033018315,  # p4n
             "OLCCD CORRELATION ENERGY": -0.1825194982,  # p4n
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.0344689234,  # occ
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     {
@@ -460,12 +597,15 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_nh2_qz2p_pk_rohf,
+            "HF TOTAL GRADIENT": _grad_scf_nh2_qz2p_pk_rohf,
             "MP2 CORRELATION ENERGY": -0.2005395272,
             "MP2 SINGLES ENERGY": -0.00298375,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.04178535,
             "MP2 TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.0138883429, 0.0, 0.005389090661, -0.00694417145, 0.0, -0.005389090661, -0.00694417145,]
             ).reshape((-1, 3)),
+            "MP3 CORRELATION ENERGY": -0.215858882347,  # cfour
+            "MP3 SINGLES ENERGY": -0.003348697377,  # cfour
             "LCCD CORRELATION ENERGY": -0.2191039411,  # p4n
             "LCCSD CORRELATION ENERGY": -0.2231241199,  # p4n
             "CCSD CORRELATION ENERGY": -0.217849506326,
@@ -478,6 +618,7 @@ _std_suite = [
             "OLCCD REFERENCE CORRECTION ENERGY": -0.0033240178,  # p4n
             "OLCCD CORRELATION ENERGY": -0.2226657917,  # p4n
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.0405122800,  # occ
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     # <<<  CONV-FC-CONV  >>>
@@ -492,6 +633,7 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_hf_dz_pk_rhf,
+            "HF TOTAL GRADIENT": _grad_scf_hf_dz_pk_rhf,
             "MP2 CORRELATION ENERGY": -0.201627516796,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.0534895025483176,
@@ -505,9 +647,14 @@ _std_suite = [
                     -0.00317450456474,
                 ]
             ).reshape((-1, 3)),
+            "MP3 CORRELATION ENERGY": -0.20453611,  # fnocc
+            "MP3 SINGLES ENERGY": 0.0,
+            "MP3 SAME-SPIN CORRELATION ENERGY": -0.04918710,  # fnocc
+            "MP3 TOTAL GRADIENT": np.array([0.0, 0.0, -0.000579954803, 0.0, 0.0, 0.000579954803]).reshape((-1, 3)),
             "LCCD CORRELATION ENERGY": -0.2079585027,  # p4n
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.047635656759,  # fnocc
+            "LCCD TOTAL GRADIENT": np.array([0.0, 0.0, 0.002535502057, 0.0, 0.0, -0.002535502057]).reshape((-1, 3)),
             "LCCSD CORRELATION ENERGY": -0.2087915976,  # p4n
             "LCCSD SINGLES ENERGY": 0.0,
             "LCCSD SAME-SPIN CORRELATION ENERGY": -0.047754723454,  # fnocc
@@ -516,6 +663,7 @@ _std_suite = [
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.0478712079,
             "CCSD TOTAL GRADIENT": np.array([0.0, 0.0, 0.002335204281, 0.0, 0.0, -0.002335204281,]).reshape((-1, 3)),
             "(T) CORRECTION ENERGY": -0.0019205007159748158,
+            # "XXX TOTAL GRADIENT": np.zeros(6).reshape((-1, 3)),
         },
     },
     {
@@ -529,15 +677,25 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_h2o_adz_pk_rhf,
+            "HF TOTAL GRADIENT": _grad_scf_h2o_adz_pk_rhf,
             "MP2 CORRELATION ENERGY": -0.2194081478,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.055833980855745646,
             "MP2 TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.010245839621, 0.0, 0.005893268945, -0.00512291981, 0.0, -0.005893268945, -0.00512291981,]
             ).reshape((-1, 3)),
+            "MP3 CORRELATION ENERGY": -0.224155670726,  # fnocc
+            "MP3 SINGLES ENERGY": 0.0,
+            "MP3 SAME-SPIN CORRELATION ENERGY": -0.051069118695,  # fnocc
+            "MP3 TOTAL GRADIENT": np.array(
+                [0.0, 0.0, 0.004593346123, 0.0, 0.002925016535, -0.002296673061, 0.0, -0.002925016535, -0.002296673061]
+            ).reshape((-1, 3)),
             "LCCD CORRELATION ENERGY": -0.2296135965,  # p4n
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.049154543318,  # fnocc
+            "LCCD TOTAL GRADIENT": np.array(
+                [0.0, 0.0, 0.009143629163, 0.0, 0.005604924417, -0.004571814581, 0.0, -0.005604924417, -0.004571814581]
+            ).reshape((-1, 3)),
             "LCCSD CORRELATION ENERGY": -0.2318316308,  # p4n
             "LCCSD SINGLES ENERGY": 0.0,
             "LCCSD SAME-SPIN CORRELATION ENERGY": -0.049659952324,  # fnocc
@@ -548,6 +706,7 @@ _std_suite = [
                 [0.0, 0.0, 0.008118157882, 0.0, 0.004988381189, -0.004059078941, 0.0, -0.004988381189, -0.004059078941,]
             ).reshape((-1, 3)),
             "(T) CORRECTION ENERGY": -0.00521238,
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     {
@@ -561,15 +720,25 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_h2o_qz2p_pk_rhf,
+            "HF TOTAL GRADIENT": _grad_scf_h2o_qz2p_pk_rhf,
             "MP2 CORRELATION ENERGY": -0.24515185206,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.06126410,
             "MP2 TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.00033347691, 0.0, -0.00056224437, -0.000166738455, 0.0, 0.00056224437, -0.000166738455,]
             ).reshape((-1, 3)),
+            "MP3 CORRELATION ENERGY": -0.24747734,  # fnocc
+            "MP3 SINGLES ENERGY": 0.0,
+            "MP3 SAME-SPIN CORRELATION ENERGY": -0.05558309,  # fnocc
+            "MP3 TOTAL GRADIENT": np.array(
+                [0.0, 0.0, -0.006163797026, 0.0, -0.004106253706, 0.003081898513, 0.0, 0.004106253706, 0.003081898513]
+            ).reshape((-1, 3)),
             "LCCD CORRELATION ENERGY": -0.2531942099,  # p4n
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.053842594884,  # fnocc
+            "LCCD TOTAL GRADIENT": np.array(
+                [0.0, 0.0, -0.001471171285, 0.0, -0.001391395837, 0.000735585643, 0.0, 0.001391395837, 0.000735585643]
+            ).reshape((-1, 3)),
             "LCCSD CORRELATION ENERGY": -0.2553008820,  # p4n
             "LCCSD SINGLES ENERGY": 0.0,
             "LCCSD SAME-SPIN CORRELATION ENERGY": -0.054321637599,  # fnocc
@@ -580,6 +749,7 @@ _std_suite = [
                 [0.0, 0.0, -0.002486174824, 0.0, -0.001923330621, 0.001243087412, 0.0, 0.001923330621, 0.001243087412,]
             ).reshape((-1, 3)),
             "(T) CORRECTION ENERGY": -0.007096579721,
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     {
@@ -593,6 +763,7 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_bh3p_dz_pk_uhf,
+            "HF TOTAL GRADIENT": _grad_scf_bh3p_dz_pk_uhf,
             "MP2 CORRELATION ENERGY": -0.058423513790,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.001767468898,
@@ -613,9 +784,44 @@ _std_suite = [
                     -0.000226972977580,
                 ]
             ).reshape((-1, 3)),
+            "MP3 CORRELATION ENERGY": -0.07375810,  # occ
+            "MP3 SINGLES ENERGY": 0.0,
+            "MP3 SAME-SPIN CORRELATION ENERGY": -0.00220392,  # occ
+            "MP3 TOTAL GRADIENT": np.array(
+                [
+                    0.0,
+                    0.0,
+                    0.009100318483,
+                    0.0,
+                    0.0,
+                    -0.008860556313,
+                    0.0,
+                    0.012722119397,
+                    -0.000119881085,
+                    0.0,
+                    -0.012722119397,
+                    -0.000119881085,
+                ]
+            ).reshape((-1, 3)),
             "LCCD CORRELATION ENERGY": -0.0824313452,  # p4n
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0022532590,  # occ
+            "LCCD TOTAL GRADIENT": np.array(
+                [
+                    0.0,
+                    0.0,
+                    0.004402112418,
+                    0.0,
+                    0.0,
+                    -0.004307902536,
+                    0.0,
+                    0.015259701356,
+                    -0.000047104941,
+                    0.0,
+                    -0.015259701356,
+                    -0.000047104941,
+                ]
+            ).reshape((-1, 3)),
             "LCCSD CORRELATION ENERGY": -0.0837903430,  # p4n
             "LCCSD SINGLES ENERGY": 0.0,
             "CCSD CORRELATION ENERGY": -0.08117105566,
@@ -638,6 +844,7 @@ _std_suite = [
                 ]
             ).reshape((-1, 3)),
             "(T) CORRECTION ENERGY": -0.00060401,
+            # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
         },
     },
     {
@@ -651,15 +858,25 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_nh2_adz_pk_uhf,
+            "HF TOTAL GRADIENT": _grad_scf_nh2_adz_pk_uhf,
             "MP2 CORRELATION ENERGY": -0.15242755400188052,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.03445360441348938,
             "MP2 TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.026279427993, 0.0, 0.013998590506, -0.013139713997, 0.0, -0.013998590506, -0.013139713997,]
             ).reshape((-1, 3)),
+            "MP3 CORRELATION ENERGY": -0.16862935,  # occ
+            "MP3 SINGLES ENERGY": 0.0,
+            "MP3 SAME-SPIN CORRELATION ENERGY": -0.03463618,  # occ
+            "MP3 TOTAL GRADIENT": np.array(
+                [0.0, 0.0, 0.027862081662, 0.0, 0.014906293724, -0.013931040831, 0.0, -0.014906293724, -0.013931040831]
+            ).reshape((-1, 3)),
             "LCCD CORRELATION ENERGY": -0.1747537294,  # p4n
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0334378864,  # occ
+            "LCCD TOTAL GRADIENT": np.array(
+                [0.0, 0.0, 0.031468252099, 0.0, 0.017115261595, -0.015734126049, 0.0, -0.017115261595, -0.015734126049]
+            ).reshape((-1, 3)),
             "LCCSD CORRELATION ENERGY": -0.1763496376,  # p4n
             "LCCSD SINGLES ENERGY": 0.0,
             "CCSD CORRELATION ENERGY": -0.1716495276680232,
@@ -669,6 +886,7 @@ _std_suite = [
                 [0.0, 0.0, 0.030055915902, 0.0, 0.016307167756, -0.015027957951, 0.0, -0.016307167756, -0.015027957951,]
             ).reshape((-1, 3)),
             "(T) CORRECTION ENERGY": -0.00381116,
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     {
@@ -682,15 +900,25 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_nh2_qz2p_pk_uhf,
+            "HF TOTAL GRADIENT": _grad_scf_nh2_qz2p_pk_uhf,
             "MP2 CORRELATION ENERGY": -0.171184123093,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.03822454,
             "MP2 TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.014740098324, 0.0, 0.005852228009, -0.007370049162, 0.0, -0.005852228009, -0.007370049162,]
             ).reshape((-1, 3)),
+            "MP3 CORRELATION ENERGY": -0.18575628,  # occ
+            "MP3 SINGLES ENERGY": 0.0,
+            "MP3 SAME-SPIN CORRELATION ENERGY": -0.03792248,  # occ
+            "MP3 TOTAL GRADIENT": np.array(
+                [0.0, 0.0, 0.015431661276, 0.0, 0.006103353029, -0.007715830638, 0.0, -0.006103353029, -0.007715830638]
+            ).reshape((-1, 3)),
             "LCCD CORRELATION ENERGY": -0.1917024115,  # p4n
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0367596656,  # occ
+            "LCCD TOTAL GRADIENT": np.array(
+                [0.0, 0.0, 0.019152642358, 0.0, 0.008310773449, -0.009576321179, 0.0, -0.008310773449, -0.009576321179]
+            ).reshape((-1, 3)),
             "LCCSD CORRELATION ENERGY": -0.1933416962,  # p4n
             "LCCSD SINGLES ENERGY": 0.0,
             "CCSD CORRELATION ENERGY": -0.188317222733,
@@ -700,6 +928,7 @@ _std_suite = [
                 [0.0, 0.0, 0.017883390799, 0.0, 0.00765987541, -0.0089416954, 0.0, -0.00765987541, -0.0089416954,]
             ).reshape((-1, 3)),
             "(T) CORRECTION ENERGY": -0.00498265,
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     {
@@ -713,6 +942,7 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_bh3p_dz_pk_rohf,
+            "HF TOTAL GRADIENT": _grad_scf_bh3p_dz_pk_rohf,
             "MP2 CORRELATION ENERGY": -0.059407254257,
             "MP2 SINGLES ENERGY": -0.000688368657,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.001851937488,
@@ -733,6 +963,8 @@ _std_suite = [
                     -0.000240521034770,
                 ]
             ).reshape((-1, 3)),
+            "MP3 CORRELATION ENERGY": -0.074845418046,  # cfour
+            "MP3 SINGLES ENERGY": -0.000911987215,  # cfour
             "LCCD CORRELATION ENERGY": -0.0824056198,  # p4n
             "LCCSD CORRELATION ENERGY": -0.0851177481,  # p4n
             "CCSD CORRELATION ENERGY": -0.08256719,
@@ -755,6 +987,7 @@ _std_suite = [
                 ]
             ).reshape((-1, 3)),
             "(T) CORRECTION ENERGY": -0.00068823,  # cfour only
+            # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
         },
     },
     {
@@ -768,12 +1001,15 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_nh2_adz_pk_rohf,
+            "HF TOTAL GRADIENT": _grad_scf_nh2_adz_pk_rohf,
             "MP2 CORRELATION ENERGY": -0.15702660833165538,
             "MP2 SINGLES ENERGY": -0.0028059971624814647,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.03466304269235235,
             "MP2 TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.026398091851, 0.0, 0.014012163884, -0.013199045925, 0.0, -0.014012163884, -0.013199045925,]
             ).reshape((-1, 3)),
+            "MP3 CORRELATION ENERGY": -0.173406218947,  # cfour
+            "MP3 SINGLES ENERGY": -0.003217654547,  # cfour
             "LCCD CORRELATION ENERGY": -0.1769020687,  # p4n
             "LCCSD CORRELATION ENERGY": -0.1807707740,  # p4n
             "CCSD CORRELATION ENERGY": -0.175988485854028,
@@ -783,6 +1019,7 @@ _std_suite = [
                 [0.0, 0.0, 0.030051791297, 0.0, 0.016301545337, -0.015025895649, 0.0, -0.016301545337, -0.015025895649,]
             ).reshape((-1, 3)),
             "(T) CORRECTION ENERGY": -0.003863167899,  # cfour only
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     {
@@ -796,12 +1033,15 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_nh2_qz2p_pk_rohf,
+            "HF TOTAL GRADIENT": _grad_scf_nh2_qz2p_pk_rohf,
             "MP2 CORRELATION ENERGY": -0.1761163066,
             "MP2 SINGLES ENERGY": -0.00294339,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.03837483,
             "MP2 TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.014894057335, 0.0, 0.005886660707, -0.007447028667, 0.0, -0.005886660707, -0.007447028667,]
             ).reshape((-1, 3)),
+            "MP3 CORRELATION ENERGY": -0.190735179201,  # cfour
+            "MP3 SINGLES ENERGY": -0.003322599961,  # cfour
             "LCCD CORRELATION ENERGY": -0.1939920915,  # p4n
             "LCCSD CORRELATION ENERGY": -0.1979175937,  # p4n
             "CCSD CORRELATION ENERGY": -0.19282621471297376,
@@ -811,6 +1051,7 @@ _std_suite = [
                 [0.0, 0.0, 0.017873897449, 0.0, 0.007653541045, -0.008936948724, 0.0, -0.007653541045, -0.008936948724,]
             ).reshape((-1, 3)),
             "(T) CORRECTION ENERGY": -0.00504351,  # cfour only
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     # <<<  CONV-AE-CD  >>>
@@ -825,13 +1066,17 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_hf_dz_pk_rhf,
+            "HF TOTAL GRADIENT": _grad_scf_hf_dz_pk_rhf,
             "MP2 CORRELATION ENERGY": -0.203778449,
             "MP2 SINGLES ENERGY": 0.0,
+            "MP3 CORRELATION ENERGY": -0.20648138,  # dfocc
+            "MP3 SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.20990784,  # dfocc
             "LCCD SINGLES ENERGY": 0.0,
             "CCSD CORRELATION ENERGY": -0.20874537,
             "CCSD SINGLES ENERGY": 0.0,
             "(T) CORRECTION ENERGY": -0.00193646,
+            # "XXX TOTAL GRADIENT": np.zeros(6).reshape((-1, 3)),
         },
     },
     {
@@ -845,13 +1090,17 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_h2o_adz_pk_rhf,
+            "HF TOTAL GRADIENT": _grad_scf_h2o_adz_pk_rhf,
             "MP2 CORRELATION ENERGY": -0.22188844,
             "MP2 SINGLES ENERGY": 0.0,
+            "MP3 CORRELATION ENERGY": -0.22643352,  # dfocc
+            "MP3 SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.23188996,  # dfocc
             "LCCD SINGLES ENERGY": 0.0,
             "CCSD CORRELATION ENERGY": -0.22941330,
             "CCSD SINGLES ENERGY": 0.0,
             "(T) CORRECTION ENERGY": -0.00523874,
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     {
@@ -865,13 +1114,17 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_h2o_qz2p_pk_rhf,
+            "HF TOTAL GRADIENT": _grad_scf_h2o_qz2p_pk_rhf,
             "MP2 CORRELATION ENERGY": -0.27018509,
             "MP2 SINGLES ENERGY": 0.0,
+            "MP3 CORRELATION ENERGY": -0.27294541,  # dfocc
+            "MP3 SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.27869144,  # dfocc
             "LCCD SINGLES ENERGY": 0.0,
             "CCSD CORRELATION ENERGY": -0.27570541,
             "CCSD SINGLES ENERGY": 0.0,
             "(T) CORRECTION ENERGY": -0.00726403,
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     {
@@ -885,12 +1138,17 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_bh3p_dz_pk_uhf,
+            "HF TOTAL GRADIENT": _grad_scf_bh3p_dz_pk_uhf,
             "MP2 CORRELATION ENERGY": -0.059477703268,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.001918940186,
+            "MP3 CORRELATION ENERGY": -0.07481148,  # dfocc
+            "MP3 SINGLES ENERGY": 0.0,
+            "MP3 SAME-SPIN CORRELATION ENERGY": -0.00235724,  # dfocc
             "LCCD CORRELATION ENERGY": -0.08343267,  # dfocc
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.00240067,  # dfocc
+            # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
         },
     },
     {
@@ -904,12 +1162,17 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_nh2_adz_pk_uhf,
+            "HF TOTAL GRADIENT": _grad_scf_nh2_adz_pk_uhf,
             "MP2 CORRELATION ENERGY": -0.15485159,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.03520588,
+            "MP3 CORRELATION ENERGY": -0.17091968,  # dfocc
+            "MP3 SINGLES ENERGY": 0.0,
+            "MP3 SAME-SPIN CORRELATION ENERGY": -0.03533767,  # dfocc
             "LCCD CORRELATION ENERGY": -0.17701281,  # dfocc
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.03413088,  # dfocc
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     {
@@ -923,12 +1186,17 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_nh2_qz2p_pk_uhf,
+            "HF TOTAL GRADIENT": _grad_scf_nh2_qz2p_pk_uhf,
             "MP2 CORRELATION ENERGY": -0.19552518,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.04162160,
+            "MP3 CORRELATION ENERGY": -0.21084703,  # dfocc
+            "MP3 SINGLES ENERGY": 0.0,
+            "MP3 SAME-SPIN CORRELATION ENERGY": -0.04130865,  # dfocc
             "LCCD CORRELATION ENERGY": -0.21678793,  # dfocc
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.04013550,  # dfocc
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     {
@@ -942,9 +1210,11 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_bh3p_dz_pk_rohf,
+            "HF TOTAL GRADIENT": _grad_scf_bh3p_dz_pk_rohf,
             "MP2 CORRELATION ENERGY": -0.0604664810,
             "MP2 SINGLES ENERGY": -0.000694049858,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.002005152902,
+            # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
         },
     },
     {
@@ -958,9 +1228,11 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_nh2_adz_pk_rohf,
+            "HF TOTAL GRADIENT": _grad_scf_nh2_adz_pk_rohf,
             "MP2 CORRELATION ENERGY": -0.15948893,
             "MP2 SINGLES ENERGY": -0.00282963,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.03542136,
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     {
@@ -974,9 +1246,11 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_nh2_qz2p_pk_rohf,
+            "HF TOTAL GRADIENT": _grad_scf_nh2_qz2p_pk_rohf,
             "MP2 CORRELATION ENERGY": -0.20053428,
             "MP2 SINGLES ENERGY": -0.00298375,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.04179065,
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     # <<<  CONV-FC-CD  >>>
@@ -991,13 +1265,17 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_hf_dz_pk_rhf,
+            "HF TOTAL GRADIENT": _grad_scf_hf_dz_pk_rhf,
             "MP2 CORRELATION ENERGY": -0.20162439774,
             "MP2 SINGLES ENERGY": 0.0,
+            "MP3 CORRELATION ENERGY": -0.20453779,  # dfocc
+            "MP3 SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.20796060,  # dfocc
             "LCCD SINGLES ENERGY": 0.0,
             "CCSD CORRELATION ENERGY": -0.20681721,
             "CCSD SINGLES ENERGY": 0.0,
             "(T) CORRECTION ENERGY": -0.00192057,
+            # "XXX TOTAL GRADIENT": np.zeros(6).reshape((-1, 3)),
         },
     },
     {
@@ -1011,13 +1289,17 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_h2o_adz_pk_rhf,
+            "HF TOTAL GRADIENT": _grad_scf_h2o_adz_pk_rhf,
             "MP2 CORRELATION ENERGY": -0.21939933,
             "MP2 SINGLES ENERGY": 0.0,
+            "MP3 CORRELATION ENERGY": -0.22415842,  # dfocc
+            "MP3 SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.22961687,  # dfocc
             "LCCD SINGLES ENERGY": 0.0,
             "CCSD CORRELATION ENERGY": -0.22717646,
             "CCSD SINGLES ENERGY": 0.0,
             "(T) CORRECTION ENERGY": -0.00521255,
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     {
@@ -1031,13 +1313,17 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_h2o_qz2p_pk_rhf,
+            "HF TOTAL GRADIENT": _grad_scf_h2o_qz2p_pk_rhf,
             "MP2 CORRELATION ENERGY": -0.24514540,
             "MP2 SINGLES ENERGY": 0.0,
+            "MP3 CORRELATION ENERGY": -0.24747829,  # dfocc
+            "MP3 SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.25319438,  # dfocc
             "LCCD SINGLES ENERGY": 0.0,
             "CCSD CORRELATION ENERGY": -0.25033052,
             "CCSD SINGLES ENERGY": 0.0,
             "(T) CORRECTION ENERGY": -0.00709694,
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     {
@@ -1051,12 +1337,17 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_bh3p_dz_pk_uhf,
+            "HF TOTAL GRADIENT": _grad_scf_bh3p_dz_pk_uhf,
             "MP2 CORRELATION ENERGY": -0.05841222894,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.0017676971,
+            "MP3 CORRELATION ENERGY": -0.07375426,  # dfocc
+            "MP3 SINGLES ENERGY": 0.0,
+            "MP3 SAME-SPIN CORRELATION ENERGY": -0.00220422,  # dfocc
             "LCCD CORRELATION ENERGY": -0.08242955,  # dfocc
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.00225358,  # dfocc
+            # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
         },
     },
     {
@@ -1070,12 +1361,17 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_nh2_adz_pk_uhf,
+            "HF TOTAL GRADIENT": _grad_scf_nh2_adz_pk_uhf,
             "MP2 CORRELATION ENERGY": -0.15241971,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.03445776,
+            "MP3 CORRELATION ENERGY": -0.16863252,  # dfocc
+            "MP3 SINGLES ENERGY": 0.0,
+            "MP3 SAME-SPIN CORRELATION ENERGY": -0.03464025,  # dfocc
             "LCCD CORRELATION ENERGY": -0.17475833,  # dfocc
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.03344184,  # dfocc
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     {
@@ -1089,12 +1385,17 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_nh2_qz2p_pk_uhf,
+            "HF TOTAL GRADIENT": _grad_scf_nh2_qz2p_pk_uhf,
             "MP2 CORRELATION ENERGY": -0.17117906,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.03822980,
+            "MP3 CORRELATION ENERGY": -0.18575660,  # dfocc
+            "MP3 SINGLES ENERGY": 0.0,
+            "MP3 SAME-SPIN CORRELATION ENERGY": -0.03792752,  # dfocc
             "LCCD CORRELATION ENERGY": -0.19170259,  # dfocc
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.03676455,  # dfocc
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     {
@@ -1108,9 +1409,11 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_bh3p_dz_pk_rohf,
+            "HF TOTAL GRADIENT": _grad_scf_bh3p_dz_pk_rohf,
             "MP2 CORRELATION ENERGY": -0.059395907176,
             "MP2 SINGLES ENERGY": -0.00068836865,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.001852162877,
+            # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
         },
     },
     {
@@ -1124,9 +1427,11 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_nh2_adz_pk_rohf,
+            "HF TOTAL GRADIENT": _grad_scf_nh2_adz_pk_rohf,
             "MP2 CORRELATION ENERGY": -0.15701860,
             "MP2 SINGLES ENERGY": -0.00280600,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.03466721,
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     {
@@ -1140,9 +1445,11 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_nh2_qz2p_pk_rohf,
+            "HF TOTAL GRADIENT": _grad_scf_nh2_qz2p_pk_rohf,
             "MP2 CORRELATION ENERGY": -0.17611121,
             "MP2 SINGLES ENERGY": -0.00294339,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.03838011,
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     # <<<  CONV-AE-DF  >>>
@@ -1157,17 +1464,23 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_hf_dz_pk_rhf,
+            "HF TOTAL GRADIENT": _grad_scf_hf_dz_pk_rhf,
             "MP2 CORRELATION ENERGY": -0.20377997248921056,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.05431321036920538,
             "MP2 TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.0027998, 0.0, 0.0, -0.0027998]  # dfmp2 findif-5 ae pk+df
             ).reshape((-1, 3)),
+            "MP3 CORRELATION ENERGY": -0.20657694,  # dfocc
+            "MP3 SINGLES ENERGY": 0.0,
+            "MP3 TOTAL GRADIENT": np.array([0.0, 0.0, -0.000926859678, 0.0, 0.0, 0.000926859678]).reshape((-1, 3)),
             "LCCD CORRELATION ENERGY": -0.2100497124,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
+            "LCCD TOTAL GRADIENT": np.array([0.0, 0.0, 0.002190589954, 0.0, 0.0, -0.002190589954]).reshape((-1, 3)),
             "CCSD CORRELATION ENERGY": -0.20888438,
             "CCSD SINGLES ENERGY": 0.0,
             "(T) CORRECTION ENERGY": -0.00193859,
+            # "XXX TOTAL GRADIENT": np.zeros(6).reshape((-1, 3)),
         },
     },
     {
@@ -1181,14 +1494,18 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_h2o_adz_pk_rhf,
+            "HF TOTAL GRADIENT": _grad_scf_h2o_adz_pk_rhf,
             "MP2 CORRELATION ENERGY": -0.22188894,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.05674808,
+            "MP3 CORRELATION ENERGY": -0.22652962,  # dfocc
+            "MP3 SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.2320261414,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "CCSD CORRELATION ENERGY": -0.22954333,
             "CCSD SINGLES ENERGY": 0.0,
             "(T) CORRECTION ENERGY": -0.00524393,
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     {
@@ -1202,14 +1519,18 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_h2o_qz2p_pk_rhf,
+            "HF TOTAL GRADIENT": _grad_scf_h2o_qz2p_pk_rhf,
             "MP2 CORRELATION ENERGY": -0.27018057,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.06530212,
+            "MP3 CORRELATION ENERGY": -0.27294176,  # dfocc
+            "MP3 SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.2786878429,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "CCSD CORRELATION ENERGY": -0.27570207,
             "CCSD SINGLES ENERGY": 0.0,
             "(T) CORRECTION ENERGY": -0.00726375,
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     {
@@ -1223,12 +1544,17 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_bh3p_dz_pk_uhf,
+            "HF TOTAL GRADIENT": _grad_scf_bh3p_dz_pk_uhf,
             "MP2 CORRELATION ENERGY": -0.05945820694747983,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.0019203155958724552,
+            "MP3 CORRELATION ENERGY": -0.07486724,  # dfocc
+            "MP3 SINGLES ENERGY": 0.0,
+            "MP3 SAME-SPIN CORRELATION ENERGY": -0.00235854,  # dfocc
             "LCCD CORRELATION ENERGY": -0.0835080983,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0024018298,  # dfocc
+            # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
         },
     },
     {
@@ -1242,12 +1568,17 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_nh2_adz_pk_uhf,
+            "HF TOTAL GRADIENT": _grad_scf_nh2_adz_pk_uhf,
             "MP2 CORRELATION ENERGY": -0.15484736,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.03523329,
+            "MP3 CORRELATION ENERGY": -0.17098385,  # dfocc
+            "MP3 SINGLES ENERGY": 0.0,
+            "MP3 SAME-SPIN CORRELATION ENERGY": -0.03530465,  # dfocc
             "LCCD CORRELATION ENERGY": -0.1771107929,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0340809591,  # dfocc
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     {
@@ -1261,12 +1592,17 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_nh2_qz2p_pk_uhf,
+            "HF TOTAL GRADIENT": _grad_scf_nh2_qz2p_pk_uhf,
             "MP2 CORRELATION ENERGY": -0.19551918,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.04161696,
+            "MP3 CORRELATION ENERGY": -0.21084349,  # dfocc
+            "MP3 SINGLES ENERGY": 0.0,
+            "MP3 SAME-SPIN CORRELATION ENERGY": -0.04130382,  # dfocc
             "LCCD CORRELATION ENERGY": -0.2167841215,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0401306929,  # dfocc
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     {
@@ -1280,10 +1616,12 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_bh3p_dz_pk_rohf,
+            "HF TOTAL GRADIENT": _grad_scf_bh3p_dz_pk_rohf,
             "MP2 CORRELATION ENERGY": -0.0604460449537298,
             "MP2 SINGLES ENERGY": -0.0006940498589629459,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.0020066877639503184,
             "LCCD CORRELATION ENERGY": -0.0834825821,  # p4n
+            # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
         },
     },
     {
@@ -1297,10 +1635,12 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_nh2_adz_pk_rohf,
+            "HF TOTAL GRADIENT": _grad_scf_nh2_adz_pk_rohf,
             "MP2 CORRELATION ENERGY": -0.15948289,
             "MP2 SINGLES ENERGY": -0.00282963,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.03544835,
             "LCCD CORRELATION ENERGY": -0.1792713801,  # p4n
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     {
@@ -1314,10 +1654,12 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_nh2_qz2p_pk_rohf,
+            "HF TOTAL GRADIENT": _grad_scf_nh2_qz2p_pk_rohf,
             "MP2 CORRELATION ENERGY": -0.20052829,
             "MP2 SINGLES ENERGY": -0.00298375,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.04178599,
             "LCCD CORRELATION ENERGY": -0.2191002183,  # p4n
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     # <<<  CONV-FC-DF  >>>
@@ -1332,17 +1674,21 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_hf_dz_pk_rhf,
+            "HF TOTAL GRADIENT": _grad_scf_hf_dz_pk_rhf,
             "MP2 CORRELATION ENERGY": -0.20162566806258586,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.05352569481658172,
             "MP2 TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.00315485, 0.0, 0.0, -0.00315485]  # dfmp2 findif-5 fc pk+df
             ).reshape((-1, 3)),
+            "MP3 CORRELATION ENERGY": -0.20463304,  # dfocc
+            "MP3 SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.2081020566,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "CCSD CORRELATION ENERGY": -0.20695586,
             "CCSD SINGLES ENERGY": 0.0,
             "(T) CORRECTION ENERGY": -0.00192267,
+            # "XXX TOTAL GRADIENT": np.zeros(6).reshape((-1, 3)),
         },
     },
     {
@@ -1356,14 +1702,18 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_h2o_adz_pk_rhf,
+            "HF TOTAL GRADIENT": _grad_scf_h2o_adz_pk_rhf,
             "MP2 CORRELATION ENERGY": -0.21939942,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.05588210,
+            "MP3 CORRELATION ENERGY": -0.22425409,  # dfocc
+            "MP3 SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.2297524911,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "CCSD CORRELATION ENERGY": -0.22730597,
             "CCSD SINGLES ENERGY": 0.0,
             "(T) CORRECTION ENERGY": -0.00521769,
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     {
@@ -1377,14 +1727,18 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_h2o_qz2p_pk_rhf,
+            "HF TOTAL GRADIENT": _grad_scf_h2o_qz2p_pk_rhf,
             "MP2 CORRELATION ENERGY": -0.24514425,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.06126481,
+            "MP3 CORRELATION ENERGY": -0.24747778,  # dfocc
+            "MP3 SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.2531939249,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "CCSD CORRELATION ENERGY": -0.25033030,
             "CCSD SINGLES ENERGY": 0.0,
             "(T) CORRECTION ENERGY": -0.00709666,
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     {
@@ -1398,12 +1752,17 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_bh3p_dz_pk_uhf,
+            "HF TOTAL GRADIENT": _grad_scf_bh3p_dz_pk_uhf,
             "MP2 CORRELATION ENERGY": -0.058392397606538686,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.0017690135626491292,
+            "MP3 CORRELATION ENERGY": -0.07380965,  # dfocc
+            "MP3 SINGLES ENERGY": 0.0,
+            "MP3 SAME-SPIN CORRELATION ENERGY": -0.00220548,  # dfocc
             "LCCD CORRELATION ENERGY": -0.0825046579,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0022547041,  # dfocc
+            # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
         },
     },
     {
@@ -1417,12 +1776,17 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_nh2_adz_pk_uhf,
+            "HF TOTAL GRADIENT": _grad_scf_nh2_adz_pk_uhf,
             "MP2 CORRELATION ENERGY": -0.15241501,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.03448519,
+            "MP3 CORRELATION ENERGY": -0.16869625,  # dfocc
+            "MP3 SINGLES ENERGY": 0.0,
+            "MP3 SAME-SPIN CORRELATION ENERGY": -0.03460729,  # dfocc
             "LCCD CORRELATION ENERGY": -0.1748557523,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0333918420,  # dfocc
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     {
@@ -1436,12 +1800,17 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_nh2_qz2p_pk_uhf,
+            "HF TOTAL GRADIENT": _grad_scf_nh2_qz2p_pk_uhf,
             "MP2 CORRELATION ENERGY": -0.17117615,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.03822512,
+            "MP3 CORRELATION ENERGY": -0.18575590,  # dfocc
+            "MP3 SINGLES ENERGY": 0.0,
+            "MP3 SAME-SPIN CORRELATION ENERGY": -0.03792262,  # dfocc
             "LCCD CORRELATION ENERGY": -0.1917015960,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0367596684,  # dfocc
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     {
@@ -1455,10 +1824,12 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_bh3p_dz_pk_rohf,
+            "HF TOTAL GRADIENT": _grad_scf_bh3p_dz_pk_rohf,
             "MP2 CORRELATION ENERGY": -0.05937514348825628,
             "MP2 SINGLES ENERGY": -0.0006883686516107368,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.0018536363586657242,
             "LCCD CORRELATION ENERGY": -0.0824786458,  # p4n
+            # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
         },
     },
     {
@@ -1472,10 +1843,12 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_nh2_adz_pk_rohf,
+            "HF TOTAL GRADIENT": _grad_scf_nh2_adz_pk_rohf,
             "MP2 CORRELATION ENERGY": -0.15701209,
             "MP2 SINGLES ENERGY": -0.00280600,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.03469422,
             "LCCD CORRELATION ENERGY": -0.1770018748,  # p4n
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     {
@@ -1489,10 +1862,12 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_nh2_qz2p_pk_rohf,
+            "HF TOTAL GRADIENT": _grad_scf_nh2_qz2p_pk_rohf,
             "MP2 CORRELATION ENERGY": -0.17610830,
             "MP2 SINGLES ENERGY": -0.00294339,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.03837541,
             "LCCD CORRELATION ENERGY": -0.1939912613,  # p4n
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     # <<<  CD-AE-CD  >>>
@@ -1507,6 +1882,7 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_hf_dz_cd_rhf,
+            "HF TOTAL GRADIENT": _grad_scf_hf_dz_cd_rhf,
             "MP2 CORRELATION ENERGY": -0.20377328786815951,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.05427570,
@@ -1514,12 +1890,15 @@ _std_suite = [
                 # dfocc findif-5 ae cd+cd
                 [0.0, 0.0, 0.00281146, 0.0, 0.0, -0.00281146]
             ).reshape((-1, 3)),
+            "MP3 CORRELATION ENERGY": -0.20647618,  # dfocc
+            "MP3 SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.20990226,  # dfocc
             "LCCD SINGLES ENERGY": 0.0000000000,
             "CCSD CORRELATION ENERGY": -0.20873986012771106,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.04857381,
             "(T) CORRECTION ENERGY": -0.0019363109218456449,
+            # "XXX TOTAL GRADIENT": np.zeros(6).reshape((-1, 3)),
         },
     },
     {
@@ -1533,6 +1912,7 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_h2o_adz_cd_rhf,
+            "HF TOTAL GRADIENT": _grad_scf_h2o_adz_cd_rhf,
             "MP2 CORRELATION ENERGY": -0.22188817,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.05670210,
@@ -1540,12 +1920,15 @@ _std_suite = [
                 # dfocc findif-5 ae cd+cd
                 [0.0, 0.0, 0.009643414073, 0.0, 0.005501440694, -0.004821707036, 0.0, -0.005501440694, -0.004821707036,]
             ).reshape((-1, 3)),
+            "MP3 CORRELATION ENERGY": -0.22643303,  # dfocc
+            "MP3 SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.23188949,  # dfocc
             "LCCD SINGLES ENERGY": 0.0000000000,
             "CCSD CORRELATION ENERGY": -0.22941290,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.05017955,
             "(T) CORRECTION ENERGY": -0.00523867,
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     {
@@ -1559,6 +1942,7 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_h2o_qz2p_cd_rhf,
+            "HF TOTAL GRADIENT": _grad_scf_h2o_qz2p_cd_rhf,
             "MP2 CORRELATION ENERGY": -0.27018399,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.06530655,
@@ -1566,12 +1950,15 @@ _std_suite = [
                 # dfocc findif-5 ae cd+cd
                 [0.0, 0.0, -0.000546229785, 0.0, -0.000967320028, 0.000273114892, 0.0, 0.000967320028, 0.000273114892,]
             ).reshape((-1, 3)),
+            "MP3 CORRELATION ENERGY": -0.27294416,  # dfocc
+            "MP3 SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.27869015,  # dfocc
             "LCCD SINGLES ENERGY": 0.0000000000,
             "CCSD CORRELATION ENERGY": -0.27570421,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.05801141,
             "(T) CORRECTION ENERGY": -0.00726395,
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     {
@@ -1585,6 +1972,7 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_bh3p_dz_cd_uhf,
+            "HF TOTAL GRADIENT": _grad_scf_bh3p_dz_cd_uhf,
             "MP2 CORRELATION ENERGY": -0.059476326350818454,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.0019188791023,
@@ -1605,9 +1993,45 @@ _std_suite = [
                     -0.00022204,
                 ]
             ).reshape((-1, 3)),
+            "MP3 CORRELATION ENERGY": -0.07480952,  # dfocc
+            "MP3 SINGLES ENERGY": 0.0,
+            "MP3 SAME-SPIN CORRELATION ENERGY": -0.00235716,  # dfocc
+            "MP3 TOTAL GRADIENT": np.array(
+                [
+                    0.0,
+                    0.0,
+                    0.009315056264,
+                    0.0,
+                    0.0,
+                    -0.009084753984,
+                    0.0,
+                    0.012696375212,
+                    -0.00011515114,
+                    0.0,
+                    -0.012696375212,
+                    -0.00011515114,
+                ]
+            ).reshape((-1, 3)),
             "LCCD CORRELATION ENERGY": -0.08343038,  # dfocc
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.00240059,  # dfocc
+            "LCCD TOTAL GRADIENT": np.array(
+                [
+                    0.0,
+                    0.0,
+                    0.004643130768,
+                    0.0,
+                    0.0,
+                    -0.004557062257,
+                    0.0,
+                    0.015239807714,
+                    -0.000043034255,
+                    0.0,
+                    -0.015239807714,
+                    -0.000043034255,
+                ]
+            ).reshape((-1, 3)),
+            # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
         },
     },
     {
@@ -1621,6 +2045,7 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_nh2_adz_cd_uhf,
+            "HF TOTAL GRADIENT": _grad_scf_nh2_adz_cd_uhf,
             "MP2 CORRELATION ENERGY": -0.15485101,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.03520580,
@@ -1637,9 +2062,13 @@ _std_suite = [
                     -0.012735031905,
                 ]
             ).reshape((-1, 3)),
+            "MP3 CORRELATION ENERGY": -0.17091879,  # dfocc
+            "MP3 SINGLES ENERGY": 0.0,
+            "MP3 SAME-SPIN CORRELATION ENERGY": -0.03533750,  # dfocc
             "LCCD CORRELATION ENERGY": -0.17701192,  # dfocc
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.03413070,  # dfocc
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     {
@@ -1653,6 +2082,7 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_nh2_qz2p_cd_uhf,
+            "HF TOTAL GRADIENT": _grad_scf_nh2_qz2p_cd_uhf,
             "MP2 CORRELATION ENERGY": -0.19552441,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.04162127,
@@ -1669,9 +2099,13 @@ _std_suite = [
                     -0.006863712188,
                 ]
             ).reshape((-1, 3)),
+            "MP3 CORRELATION ENERGY": -0.21084618,  # dfocc
+            "MP3 SINGLES ENERGY": 0.0,
+            "MP3 SAME-SPIN CORRELATION ENERGY": -0.04130830,  # dfocc
             "LCCD CORRELATION ENERGY": -0.21678706,  # dfocc
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.04013515,  # dfocc
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     {
@@ -1685,6 +2119,7 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_bh3p_dz_cd_rohf,
+            "HF TOTAL GRADIENT": _grad_scf_bh3p_dz_cd_rohf,
             "MP2 CORRELATION ENERGY": -0.06046475293245379,
             "MP2 SINGLES ENERGY": -0.00069387098844,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.002005071400,
@@ -1692,6 +2127,7 @@ _std_suite = [
                 # dfocc findif-5 ae cd+cd
                 [0.0, 0.0, 0.01359215, 0.0, 0.0, -0.01312116, 0.0, 0.01031541, -0.0002355, 0.0, -0.01031541, -0.0002355]
             ).reshape((-1, 3)),
+            # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
         },
     },
     {
@@ -1705,6 +2141,7 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_nh2_adz_cd_rohf,
+            "HF TOTAL GRADIENT": _grad_scf_nh2_adz_cd_rohf,
             "MP2 CORRELATION ENERGY": -0.15948823,
             "MP2 SINGLES ENERGY": -0.00282948,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.03542128,
@@ -1721,6 +2158,7 @@ _std_suite = [
                     -0.012794480501,
                 ]
             ).reshape((-1, 3)),
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     {
@@ -1734,6 +2172,7 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_nh2_qz2p_cd_rohf,
+            "HF TOTAL GRADIENT": _grad_scf_nh2_qz2p_cd_rohf,
             "MP2 CORRELATION ENERGY": -0.20053352,
             "MP2 SINGLES ENERGY": -0.00298373,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.04179032,
@@ -1750,6 +2189,7 @@ _std_suite = [
                     -0.006942026833,
                 ]
             ).reshape((-1, 3)),
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     # <<<  CD-FC-CD  >>>
@@ -1764,6 +2204,7 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_hf_dz_cd_rhf,
+            "HF TOTAL GRADIENT": _grad_scf_hf_dz_cd_rhf,
             "MP2 CORRELATION ENERGY": -0.201619244596,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.05348825,
@@ -1771,12 +2212,15 @@ _std_suite = [
                 # dfocc findif-5 fc cd+cd
                 [0.0, 0.0, 0.00316665, 0.0, 0.0, -0.00316665]
             ).reshape((-1, 3)),
+            "MP3 CORRELATION ENERGY": -0.20453260,  # dfocc
+            "MP3 SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.20795503,  # dfocc
             "LCCD SINGLES ENERGY": 0.0000000000,
             "CCSD CORRELATION ENERGY": -0.2068117080298787,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.04787083,
             "(T) CORRECTION ENERGY": -0.0019204203743072874,
+            # "XXX TOTAL GRADIENT": np.zeros(6).reshape((-1, 3)),
         },
     },
     {
@@ -1790,6 +2234,7 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_h2o_adz_cd_rhf,
+            "HF TOTAL GRADIENT": _grad_scf_h2o_adz_cd_rhf,
             "MP2 CORRELATION ENERGY": -0.21939907,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.05583617,
@@ -1797,12 +2242,15 @@ _std_suite = [
                 # dfocc findif-5 fc cd+cd
                 [0.0, 0.0, 0.010264703011, 0.0, 0.00588885358, -0.005132351506, 0.0, -0.00588885358, -0.005132351506,]
             ).reshape((-1, 3)),
+            "MP3 CORRELATION ENERGY": -0.22415794,  # dfocc
+            "MP3 SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.22961642,  # dfocc
             "LCCD SINGLES ENERGY": 0.0000000000,
             "CCSD CORRELATION ENERGY": -0.22717607,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.04939986,
             "(T) CORRECTION ENERGY": -0.00521248,
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     {
@@ -1816,6 +2264,7 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_h2o_qz2p_cd_rhf,
+            "HF TOTAL GRADIENT": _grad_scf_h2o_qz2p_cd_rhf,
             "MP2 CORRELATION ENERGY": -0.24514436,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.06126931,
@@ -1823,12 +2272,15 @@ _std_suite = [
                 # dfocc findif-5 fc cd+cd
                 [0.0, 0.0, 0.000318778691, 0.0, -0.000569356625, -0.000159389346, 0.0, 0.000569356625, -0.000159389346,]
             ).reshape((-1, 3)),
+            "MP3 CORRELATION ENERGY": -0.24747710,  # dfocc
+            "MP3 SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.25319315,  # dfocc
             "LCCD SINGLES ENERGY": 0.0000000000,
             "CCSD CORRELATION ENERGY": -0.25032939,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.05405638,
             "(T) CORRECTION ENERGY": -0.00709686,
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     {
@@ -1842,6 +2294,7 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_bh3p_dz_cd_uhf,
+            "HF TOTAL GRADIENT": _grad_scf_bh3p_dz_cd_uhf,
             "MP2 CORRELATION ENERGY": -0.058410863785614,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.001767642489,
@@ -1862,9 +2315,45 @@ _std_suite = [
                     -0.00022889,
                 ]
             ).reshape((-1, 3)),
+            "MP3 CORRELATION ENERGY": -0.07375232,  # dfocc
+            "MP3 SINGLES ENERGY": 0.0,
+            "MP3 SAME-SPIN CORRELATION ENERGY": -0.00220415,  # dfocc
+            "MP3 TOTAL GRADIENT": np.array(
+                [
+                    0.0,
+                    0.0,
+                    0.009099123102,
+                    0.0,
+                    0.0,
+                    -0.008855857257,
+                    0.0,
+                    0.012692779327,
+                    -0.000121632922,
+                    0.0,
+                    -0.012692779327,
+                    -0.000121632922,
+                ]
+            ).reshape((-1, 3)),
             "LCCD CORRELATION ENERGY": -0.08242726,  # dfocc
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.00225350,  # dfocc
+            "LCCD TOTAL GRADIENT": np.array(
+                [
+                    0.0,
+                    0.0,
+                    0.004401363786,
+                    0.0,
+                    0.0,
+                    -0.004303629299,
+                    0.0,
+                    0.015236787233,
+                    -0.000048867243,
+                    0.0,
+                    -0.015236787233,
+                    -0.000048867243,
+                ]
+            ).reshape((-1, 3)),
+            # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
         },
     },
     {
@@ -1878,6 +2367,7 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_nh2_adz_cd_uhf,
+            "HF TOTAL GRADIENT": _grad_scf_nh2_adz_cd_uhf,
             "MP2 CORRELATION ENERGY": -0.15241915,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.03445770,
@@ -1894,9 +2384,13 @@ _std_suite = [
                     -0.013129119537,
                 ]
             ).reshape((-1, 3)),
+            "MP3 CORRELATION ENERGY": -0.16863165,  # dfocc
+            "MP3 SINGLES ENERGY": 0.0,
+            "MP3 SAME-SPIN CORRELATION ENERGY": -0.03464009,  # dfocc
             "LCCD CORRELATION ENERGY": -0.17475747,  # dfocc
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0334416820,  # dfocc
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     {
@@ -1910,6 +2404,7 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_nh2_qz2p_cd_uhf,
+            "HF TOTAL GRADIENT": _grad_scf_nh2_qz2p_cd_uhf,
             "MP2 CORRELATION ENERGY": -0.17117831,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.03822948,
@@ -1926,9 +2421,13 @@ _std_suite = [
                     -0.007367923065,
                 ]
             ).reshape((-1, 3)),
+            "MP3 CORRELATION ENERGY": -0.18575577,  # dfocc
+            "MP3 SINGLES ENERGY": 0.0,
+            "MP3 SAME-SPIN CORRELATION ENERGY": -0.03792717,  # dfocc
             "LCCD CORRELATION ENERGY": -0.19170174,  # dfocc
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.03676422,  # dfocc
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     {
@@ -1942,6 +2441,7 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_bh3p_dz_cd_rohf,
+            "HF TOTAL GRADIENT": _grad_scf_bh3p_dz_cd_rohf,
             "MP2 CORRELATION ENERGY": -0.05939419492939635,
             "MP2 SINGLES ENERGY": -0.0006881934,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.0018520881544,
@@ -1962,6 +2462,7 @@ _std_suite = [
                     -0.00024246,
                 ]
             ).reshape((-1, 3)),
+            # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
         },
     },
     {
@@ -1975,6 +2476,7 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_nh2_adz_cd_rohf,
+            "HF TOTAL GRADIENT": _grad_scf_nh2_adz_cd_rohf,
             "MP2 CORRELATION ENERGY": -0.15701792,
             "MP2 SINGLES ENERGY": -0.00280584,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.03466715,
@@ -1991,6 +2493,7 @@ _std_suite = [
                     -0.01318846179,
                 ]
             ).reshape((-1, 3)),
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     {
@@ -2004,6 +2507,7 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_nh2_qz2p_cd_rohf,
+            "HF TOTAL GRADIENT": _grad_scf_nh2_qz2p_cd_rohf,
             "MP2 CORRELATION ENERGY": -0.17611046,
             "MP2 SINGLES ENERGY": -0.00294336,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.03837979,
@@ -2020,6 +2524,7 @@ _std_suite = [
                     -0.007444881162,
                 ]
             ).reshape((-1, 3)),
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     # <<<  CD-AE-DF  >>>
@@ -2034,6 +2539,7 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_hf_dz_cd_rhf,
+            "HF TOTAL GRADIENT": _grad_scf_hf_dz_cd_rhf,
             "MP2 CORRELATION ENERGY": -0.2037748110768,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.054311870576,
@@ -2041,12 +2547,17 @@ _std_suite = [
                 # dfmp2 findif-5 ae cd+df
                 [0.0, 0.0, 0.00279182, 0.0, 0.0, -0.00279182]
             ).reshape((-1, 3)),
+            "MP3 CORRELATION ENERGY": -0.20657173,  # dfocc
+            "MP3 SINGLES ENERGY": 0.0,
+            "MP3 TOTAL GRADIENT": np.array([0.0, 0.0, -0.000934631868, 0.0, 0.0, 0.000934631868]).reshape((-1, 3)),
             "LCCD CORRELATION ENERGY": -0.2100441271,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
+            "LCCD TOTAL GRADIENT": np.array([0.0, 0.0, 0.00218256974, 0.0, 0.0, -0.00218256974]).reshape((-1, 3)),
             "CCSD CORRELATION ENERGY": -0.20887885,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.04845784,
             "(T) CORRECTION ENERGY": -0.00193844,
+            # "XXX TOTAL GRADIENT": np.zeros(6).reshape((-1, 3)),
         },
     },
     {
@@ -2060,15 +2571,19 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_h2o_adz_cd_rhf,
+            "HF TOTAL GRADIENT": _grad_scf_h2o_adz_cd_rhf,
             "MP2 CORRELATION ENERGY": -0.22188866,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.05674801,
+            "MP3 CORRELATION ENERGY": -0.22652912,  # dfocc
+            "MP3 SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.2320256729,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "CCSD CORRELATION ENERGY": -0.22954292,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.05010092,
             "(T) CORRECTION ENERGY": -0.00524386,
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     {
@@ -2082,15 +2597,19 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_h2o_qz2p_cd_rhf,
+            "HF TOTAL GRADIENT": _grad_scf_h2o_qz2p_cd_rhf,
             "MP2 CORRELATION ENERGY": -0.27017947,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.06530177,
+            "MP3 CORRELATION ENERGY": -0.27294050,  # dfocc
+            "MP3 SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.2786865554,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "CCSD CORRELATION ENERGY": -0.27570087,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.05800702,
             "(T) CORRECTION ENERGY": -0.00726367,
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     {
@@ -2104,12 +2623,17 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_bh3p_dz_cd_uhf,
+            "HF TOTAL GRADIENT": _grad_scf_bh3p_dz_cd_uhf,
             "MP2 CORRELATION ENERGY": -0.059456828193,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.00192025457659,
+            "MP3 CORRELATION ENERGY": -0.07486528,  # dfocc
+            "MP3 SINGLES ENERGY": 0.0,
+            "MP3 SAME-SPIN CORRELATION ENERGY": -0.00235846,  # dfocc
             "LCCD CORRELATION ENERGY": -0.0835057932,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0024017496,  # dfocc
+            # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
         },
     },
     {
@@ -2123,12 +2647,17 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_nh2_adz_cd_uhf,
+            "HF TOTAL GRADIENT": _grad_scf_nh2_adz_cd_uhf,
             "MP2 CORRELATION ENERGY": -0.15484678,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.03523320,
+            "MP3 CORRELATION ENERGY": -0.17098295,  # dfocc
+            "MP3 SINGLES ENERGY": 0.0,
+            "MP3 SAME-SPIN CORRELATION ENERGY": -0.03530448,  # dfocc
             "LCCD CORRELATION ENERGY": -0.1771099018,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0340807883,  # dfocc
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     {
@@ -2142,12 +2671,17 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_nh2_qz2p_cd_uhf,
+            "HF TOTAL GRADIENT": _grad_scf_nh2_qz2p_cd_uhf,
             "MP2 CORRELATION ENERGY": -0.19551841,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.04161663,
+            "MP3 CORRELATION ENERGY": -0.21084263,  # dfocc
+            "MP3 SINGLES ENERGY": 0.0,
+            "MP3 SAME-SPIN CORRELATION ENERGY": -0.04130347,  # dfocc
             "LCCD CORRELATION ENERGY": -0.2167832515,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0401303480,  # dfocc
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     {
@@ -2161,10 +2695,12 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_bh3p_dz_cd_rohf,
+            "HF TOTAL GRADIENT": _grad_scf_bh3p_dz_cd_rohf,
             "MP2 CORRELATION ENERGY": -0.06044431529,
             "MP2 SINGLES ENERGY": -0.00069387098844,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.0020066063,
             "LCCD CORRELATION ENERGY": -0.0834800819,  # p4n
+            # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
         },
     },
     {
@@ -2178,10 +2714,12 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_nh2_adz_cd_rohf,
+            "HF TOTAL GRADIENT": _grad_scf_nh2_adz_cd_rohf,
             "MP2 CORRELATION ENERGY": -0.15948219,
             "MP2 SINGLES ENERGY": -0.00282948,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.03544828,
             "LCCD CORRELATION ENERGY": -0.1792705171,  # p4n
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     {
@@ -2195,10 +2733,12 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_nh2_qz2p_cd_rohf,
+            "HF TOTAL GRADIENT": _grad_scf_nh2_qz2p_cd_rohf,
             "MP2 CORRELATION ENERGY": -0.20052752,
             "MP2 SINGLES ENERGY": -0.00298373,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.04178566,
             "LCCD CORRELATION ENERGY": -0.2190993784,  # p4n
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     # <<<  CD-FC-DF  >>>
@@ -2213,6 +2753,7 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_hf_dz_cd_rhf,
+            "HF TOTAL GRADIENT": _grad_scf_hf_dz_cd_rhf,
             "MP2 CORRELATION ENERGY": -0.2016205147678,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.0535243575,
@@ -2220,12 +2761,15 @@ _std_suite = [
                 # dfmp2 findif-5 fc cd+df
                 [0.0, 0.0, 0.00314686, 0.0, 0.0, -0.00314686]
             ).reshape((-1, 3)),
+            "MP3 CORRELATION ENERGY": -0.20462784,  # dfocc
+            "MP3 SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.2080964757,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "CCSD CORRELATION ENERGY": -0.20695033,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.04775464,
             "(T) CORRECTION ENERGY": -0.00192252,
+            # "XXX TOTAL GRADIENT": np.zeros(6).reshape((-1, 3)),
         },
     },
     {
@@ -2239,15 +2783,19 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_h2o_adz_cd_rhf,
+            "HF TOTAL GRADIENT": _grad_scf_h2o_adz_cd_rhf,
             "MP2 CORRELATION ENERGY": -0.21939916,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.05588204,
+            "MP3 CORRELATION ENERGY": -0.22425360,  # dfocc
+            "MP3 SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.2297520405,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "CCSD CORRELATION ENERGY": -0.22730558,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.04932106,
             "(T) CORRECTION ENERGY": -0.00521762,
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     {
@@ -2261,15 +2809,19 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_h2o_qz2p_cd_rhf,
+            "HF TOTAL GRADIENT": _grad_scf_h2o_qz2p_cd_rhf,
             "MP2 CORRELATION ENERGY": -0.24514320,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.06126448,
+            "MP3 CORRELATION ENERGY": -0.24747659,  # dfocc
+            "MP3 SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.2531926943,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "CCSD CORRELATION ENERGY": -0.25032917,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.05405189,
             "(T) CORRECTION ENERGY": -0.00709658,
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     {
@@ -2283,12 +2835,17 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_bh3p_dz_cd_uhf,
+            "HF TOTAL GRADIENT": _grad_scf_bh3p_dz_cd_uhf,
             "MP2 CORRELATION ENERGY": -0.05839103061,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.00176895897,
+            "MP3 CORRELATION ENERGY": -0.07380770,  # dfocc
+            "MP3 SINGLES ENERGY": 0.0,
+            "MP3 SAME-SPIN CORRELATION ENERGY": -0.00220541,  # dfocc
             "LCCD CORRELATION ENERGY": -0.0825023638,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0022546311,  # dfocc
+            # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
         },
     },
     {
@@ -2302,12 +2859,17 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_nh2_adz_cd_uhf,
+            "HF TOTAL GRADIENT": _grad_scf_nh2_adz_cd_uhf,
             "MP2 CORRELATION ENERGY": -0.15241445,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.03448512,
+            "MP3 CORRELATION ENERGY": -0.16869538,  # dfocc
+            "MP3 SINGLES ENERGY": 0.0,
+            "MP3 SAME-SPIN CORRELATION ENERGY": -0.03460714,  # dfocc
             "LCCD CORRELATION ENERGY": -0.1748548876,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0333916888,  # dfocc
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     {
@@ -2321,12 +2883,17 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_nh2_qz2p_cd_uhf,
+            "HF TOTAL GRADIENT": _grad_scf_nh2_qz2p_cd_uhf,
             "MP2 CORRELATION ENERGY": -0.17117540,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.03822480,
+            "MP3 CORRELATION ENERGY": -0.18575507,  # dfocc
+            "MP3 SINGLES ENERGY": 0.0,
+            "MP3 SAME-SPIN CORRELATION ENERGY": -0.03792228,  # dfocc
             "LCCD CORRELATION ENERGY": -0.1917007514,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0367593319,  # dfocc
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     {
@@ -2340,10 +2907,12 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_bh3p_dz_cd_rohf,
+            "HF TOTAL GRADIENT": _grad_scf_bh3p_dz_cd_rohf,
             "MP2 CORRELATION ENERGY": -0.05937342969795,
             "MP2 SINGLES ENERGY": -0.0006881934,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.001853561678,
             "LCCD CORRELATION ENERGY": -0.0824761581,  # p4n
+            # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
         },
     },
     {
@@ -2357,10 +2926,12 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_nh2_adz_cd_rohf,
+            "HF TOTAL GRADIENT": _grad_scf_nh2_adz_cd_rohf,
             "MP2 CORRELATION ENERGY": -0.15701141,
             "MP2 SINGLES ENERGY": -0.00280584,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.03469416,
             "LCCD CORRELATION ENERGY": -0.1770010376,  # p4n
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     {
@@ -2374,10 +2945,12 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_nh2_qz2p_cd_rohf,
+            "HF TOTAL GRADIENT": _grad_scf_nh2_qz2p_cd_rohf,
             "MP2 CORRELATION ENERGY": -0.17610756,
             "MP2 SINGLES ENERGY": -0.00294336,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.03837509,
             "LCCD CORRELATION ENERGY": -0.1939904460,  # p4n
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     # <<<  DF-AE-DF  >>>
@@ -2392,6 +2965,7 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_hf_dz_df_rhf,
+            "HF TOTAL GRADIENT": _grad_scf_hf_dz_df_rhf,
             "MP2 CORRELATION ENERGY": -0.2037649370559149,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.05430875283333263,
@@ -2405,13 +2979,18 @@ _std_suite = [
                     -0.00279211492833,
                 ]
             ).reshape((-1, 3)),
+            "MP3 CORRELATION ENERGY": -0.20656153,  # dfocc
+            "MP3 SINGLES ENERGY": 0.0,
+            "MP3 TOTAL GRADIENT": np.array([0.0, 0.0, -0.000933466293, 0.0, 0.0, 0.000933466293]).reshape((-1, 3)),
             "LCCD CORRELATION ENERGY": -0.2100337333,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
+            "LCCD TOTAL GRADIENT": np.array([0.0, 0.0, 0.002183232102, 0.0, 0.0, -0.002183232102]).reshape((-1, 3)),
             "CCSD CORRELATION ENERGY": -0.20886884012911314,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.04845491,
             "CCSD TOTAL GRADIENT": np.array([0.0, 0.0, 0.001970675302, 0.0, 0.0, -0.001970675302,]).reshape((-1, 3)),
             "(T) CORRECTION ENERGY": -0.0019380186429220421,
+            # "XXX TOTAL GRADIENT": np.zeros(6).reshape((-1, 3)),
         },
     },
     {
@@ -2425,6 +3004,7 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_h2o_adz_df_rhf,
+            "HF TOTAL GRADIENT": _grad_scf_h2o_adz_df_rhf,
             "MP2 CORRELATION ENERGY": -0.22187976,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.05674571,
@@ -2441,8 +3021,16 @@ _std_suite = [
                     -0.004810913825,
                 ]
             ).reshape((-1, 3)),
+            "MP3 CORRELATION ENERGY": -0.22651881,  # dfocc
+            "MP3 SINGLES ENERGY": 0.0,
+            "MP3 TOTAL GRADIENT": np.array(
+                [0.0, 0.0, 0.004009128141, 0.0, 0.002552803039, -0.00200456407, 0.0, -0.002552803039, -0.00200456407]
+            ).reshape((-1, 3)),
             "LCCD CORRELATION ENERGY": -0.2320149229,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
+            "LCCD TOTAL GRADIENT": np.array(
+                [0.0, 0.0, 0.008561006838, 0.0, 0.005236802973, -0.004280503419, 0.0, -0.005236802973, -0.004280503419]
+            ).reshape((-1, 3)),
             "CCSD CORRELATION ENERGY": -0.22953289,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.05009877,
@@ -2450,6 +3038,7 @@ _std_suite = [
                 [0.0, 0.0, 0.007518759967, 0.0, 0.004613106602, -0.003759379983, 0.0, -0.004613106602, -0.003759379983,]
             ).reshape((-1, 3)),
             "(T) CORRECTION ENERGY": -0.00524345,
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     {
@@ -2463,6 +3052,7 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_h2o_qz2p_df_rhf,
+            "HF TOTAL GRADIENT": _grad_scf_h2o_qz2p_df_rhf,
             "MP2 CORRELATION ENERGY": -0.27016105,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.06529808,
@@ -2479,8 +3069,16 @@ _std_suite = [
                     0.000283328971,
                 ]
             ).reshape((-1, 3)),
+            "MP3 CORRELATION ENERGY": -0.27292175,  # dfocc
+            "MP3 SINGLES ENERGY": 0.0,
+            "MP3 TOTAL GRADIENT": np.array(
+                [0.0, 0.0, -0.007037747646, 0.0, -0.004494031919, 0.003518873823, 0.0, 0.004494031919, 0.003518873823]
+            ).reshape((-1, 3)),
             "LCCD CORRELATION ENERGY": -0.2786671617,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
+            "LCCD TOTAL GRADIENT": np.array(
+                [0.0, 0.0, -0.002344345036, 0.0, -0.001783728285, 0.001172172518, 0.0, 0.001783728285, 0.001172172518]
+            ).reshape((-1, 3)),
             "CCSD CORRELATION ENERGY": -0.27568236,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.05800380,
@@ -2488,6 +3086,7 @@ _std_suite = [
                 [0.0, 0.0, -0.003408844165, 0.0, -0.002343169064, 0.001704422083, 0.0, 0.002343169064, 0.001704422083]
             ).reshape((-1, 3)),
             "(T) CORRECTION ENERGY": -0.00726213,
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     {
@@ -2501,6 +3100,7 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_bh3p_dz_df_uhf,
+            "HF TOTAL GRADIENT": _grad_scf_bh3p_dz_df_uhf,
             "MP2 CORRELATION ENERGY": -0.0594557966607590,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.001920220330437888,
@@ -2520,9 +3120,45 @@ _std_suite = [
                     -0.00022125614977,
                 ]
             ).reshape((-1, 3)),
+            "MP3 CORRELATION ENERGY": -0.07486350,  # dfocc
+            "MP3 SINGLES ENERGY": 0.0,
+            "MP3 SAME-SPIN CORRELATION ENERGY": -0.00235837,  # dfocc
+            "MP3 TOTAL GRADIENT": np.array(
+                [
+                    0.0,
+                    0.0,
+                    0.009311184271,
+                    0.0,
+                    0.0,
+                    -0.009082434632,
+                    0.0,
+                    0.012724190366,
+                    -0.00011437482,
+                    0.0,
+                    -0.012724190366,
+                    -0.00011437482,
+                ]
+            ).reshape((-1, 3)),
             "LCCD CORRELATION ENERGY": -0.0835030877,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0024016379,  # dfocc
+            "LCCD TOTAL GRADIENT": np.array(
+                [
+                    0.0,
+                    0.0,
+                    0.004636606273,
+                    0.0,
+                    0.0,
+                    -0.004551154292,
+                    0.0,
+                    0.015266304532,
+                    -0.00004272599,
+                    0.0,
+                    -0.015266304532,
+                    -0.00004272599,
+                ]
+            ).reshape((-1, 3)),
+            # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
         },
     },
     {
@@ -2536,6 +3172,7 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_nh2_adz_df_uhf,
+            "HF TOTAL GRADIENT": _grad_scf_nh2_adz_df_uhf,
             "MP2 CORRELATION ENERGY": -0.15483909,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.03523134,
@@ -2552,9 +3189,19 @@ _std_suite = [
                     -0.012738024793,
                 ]
             ).reshape((-1, 3)),
+            "MP3 CORRELATION ENERGY": -0.17097347,  # dfocc
+            "MP3 SINGLES ENERGY": 0.0,
+            "MP3 SAME-SPIN CORRELATION ENERGY": -0.03530244,  # dfocc
+            "MP3 TOTAL GRADIENT": np.array(
+                [0.0, 0.0, 0.027082665714, 0.0, 0.014406579724, -0.013541332857, 0.0, -0.014406579724, -0.013541332857]
+            ).reshape((-1, 3)),
             "LCCD CORRELATION ENERGY": -0.1770997033,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0340788149,  # dfocc
+            "LCCD TOTAL GRADIENT": np.array(
+                [0.0, 0.0, 0.030686886723, 0.0, 0.016619966665, -0.015343443362, 0.0, -0.016619966665, -0.015343443362]
+            ).reshape((-1, 3)),
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     {
@@ -2568,6 +3215,7 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_nh2_qz2p_df_uhf,
+            "HF TOTAL GRADIENT": _grad_scf_nh2_qz2p_df_uhf,
             "MP2 CORRELATION ENERGY": -0.19550726,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.04161470,
@@ -2584,9 +3232,19 @@ _std_suite = [
                     -0.006854415552,
                 ]
             ).reshape((-1, 3)),
+            "MP3 CORRELATION ENERGY": -0.21083057,  # dfocc
+            "MP3 SINGLES ENERGY": 0.0,
+            "MP3 SAME-SPIN CORRELATION ENERGY": -0.04130147,  # dfocc
+            "MP3 TOTAL GRADIENT": np.array(
+                [0.0, 0.0, 0.014412459072, 0.0, 0.005610368822, -0.007206229536, 0.0, -0.005610368822, -0.007206229536]
+            ).reshape((-1, 3)),
             "LCCD CORRELATION ENERGY": -0.2167706529,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0401283617,  # dfocc
+            "LCCD TOTAL GRADIENT": np.array(
+                [0.0, 0.0, 0.018122428755, 0.0, 0.007810952273, -0.009061214377, 0.0, -0.007810952273, -0.009061214377]
+            ).reshape((-1, 3)),
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     {
@@ -2600,6 +3258,7 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_bh3p_dz_df_rohf,
+            "HF TOTAL GRADIENT": _grad_scf_bh3p_dz_df_rohf,
             "MP2 CORRELATION ENERGY": -0.0604436327328384,
             "MP2 SINGLES ENERGY": -0.0006940750313001934,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.0020065676314032863,
@@ -2620,6 +3279,8 @@ _std_suite = [
                 ]
             ).reshape((-1, 3)),
             "LCCD CORRELATION ENERGY": -0.0834776542,  # p4n
+            "LCCD TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
+            # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
         },
     },
     {
@@ -2633,6 +3294,7 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_nh2_adz_df_rohf,
+            "HF TOTAL GRADIENT": _grad_scf_nh2_adz_df_rohf,
             "MP2 CORRELATION ENERGY": -0.15947485,
             "MP2 SINGLES ENERGY": -0.00282982,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.03544639,
@@ -2650,6 +3312,7 @@ _std_suite = [
                 ]
             ).reshape((-1, 3)),
             "LCCD CORRELATION ENERGY": -0.1792603912,  # p4n
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     {
@@ -2663,6 +3326,7 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_nh2_qz2p_df_rohf,
+            "HF TOTAL GRADIENT": _grad_scf_nh2_qz2p_df_rohf,
             "MP2 CORRELATION ENERGY": -0.20051655,
             "MP2 SINGLES ENERGY": -0.00298400,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.04178365,
@@ -2680,6 +3344,7 @@ _std_suite = [
                 ]
             ).reshape((-1, 3)),
             "LCCD CORRELATION ENERGY": -0.2190866990,  # p4n
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     # <<<  DF-FC-DF  >>>
@@ -2694,6 +3359,7 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_hf_dz_df_rhf,
+            "HF TOTAL GRADIENT": _grad_scf_hf_dz_df_rhf,
             "MP2 CORRELATION ENERGY": -0.201610660387,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.0535212487451535,
@@ -2707,13 +3373,18 @@ _std_suite = [
                     -0.00314716362539,
                 ]
             ).reshape((-1, 3)),
+            "MP3 CORRELATION ENERGY": -0.20461763,  # dfocc
+            "MP3 SINGLES ENERGY": 0.0,
+            "MP3 TOTAL GRADIENT": np.array([0.0, 0.0, -0.000595617648, 0.0, 0.0, 0.000595617648]).reshape((-1, 3)),
             "LCCD CORRELATION ENERGY": -0.2080860831,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
+            "LCCD TOTAL GRADIENT": np.array([0.0, 0.0, 0.002514968877, 0.0, 0.0, -0.002514968877]).reshape((-1, 3)),
             "CCSD CORRELATION ENERGY": -0.20694032546082639,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.04775171,
             "CCSD TOTAL GRADIENT": np.array([0.0, 0.0, 0.002316563628, 0.0, 0.0, -0.002316563628,]).reshape((-1, 3)),
             "(T) CORRECTION ENERGY": -0.001922093564526723,
+            # "XXX TOTAL GRADIENT": np.zeros(6).reshape((-1, 3)),
         },
     },
     {
@@ -2727,6 +3398,7 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_h2o_adz_df_rhf,
+            "HF TOTAL GRADIENT": _grad_scf_h2o_adz_df_rhf,
             "MP2 CORRELATION ENERGY": -0.21939028,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.05587974,
@@ -2743,8 +3415,16 @@ _std_suite = [
                     -0.005121596913,
                 ]
             ).reshape((-1, 3)),
+            "MP3 CORRELATION ENERGY": -0.22424330,  # dfocc
+            "MP3 SINGLES ENERGY": 0.0,
+            "MP3 TOTAL GRADIENT": np.array(
+                [0.0, 0.0, 0.004605219936, 0.0, 0.002923029606, -0.002302609968, 0.0, -0.002923029606, -0.002302609968]
+            ).reshape((-1, 3)),
             "LCCD CORRELATION ENERGY": -0.2297412879,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
+            "LCCD TOTAL GRADIENT": np.array(
+                [0.0, 0.0, 0.009150916979, 0.0, 0.005603501036, -0.00457545849, 0.0, -0.005603501036, -0.00457545849]
+            ).reshape((-1, 3)),
             "CCSD CORRELATION ENERGY": -0.22729554,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.04931891,
@@ -2752,6 +3432,7 @@ _std_suite = [
                 [0.0, 0.0, 0.008124347934, 0.0, 0.004987676555, -0.004062173967, 0.0, -0.004987676555, -0.004062173967,]
             ).reshape((-1, 3)),
             "(T) CORRECTION ENERGY": -0.00521721,
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     {
@@ -2765,6 +3446,7 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_h2o_qz2p_df_rhf,
+            "HF TOTAL GRADIENT": _grad_scf_h2o_qz2p_df_rhf,
             "MP2 CORRELATION ENERGY": -0.24512893,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.06126089,
@@ -2781,8 +3463,16 @@ _std_suite = [
                     -0.00014913604,
                 ]
             ).reshape((-1, 3)),
+            "MP3 CORRELATION ENERGY": -0.24746227,  # dfocc
+            "MP3 SINGLES ENERGY": 0.0,
+            "MP3 TOTAL GRADIENT": np.array(
+                [0.0, 0.0, -0.006198368687, 0.0, -0.004115138427, 0.003099184344, 0.0, 0.004115138427, 0.003099184344]
+            ).reshape((-1, 3)),
             "LCCD CORRELATION ENERGY": -0.2531777549,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
+            "LCCD TOTAL GRADIENT": np.array(
+                [0.0, 0.0, -0.001506644114, 0.0, -0.001400658245, 0.000753322057, 0.0, 0.001400658245, 0.000753322057]
+            ).reshape((-1, 3)),
             "CCSD CORRELATION ENERGY": -0.25031508,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.05404876,
@@ -2790,6 +3480,7 @@ _std_suite = [
                 [0.0, 0.0, -0.002520920562, 0.0, -0.001932133533, 0.001260460281, 0.0, 0.001932133533, 0.001260460281,]
             ).reshape((-1, 3)),
             "(T) CORRECTION ENERGY": -0.00709505,
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     {
@@ -2803,6 +3494,7 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_bh3p_dz_df_uhf,
+            "HF TOTAL GRADIENT": _grad_scf_bh3p_dz_df_uhf,
             "MP2 CORRELATION ENERGY": -0.058390006825,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.001768919072594215,
@@ -2822,9 +3514,45 @@ _std_suite = [
                     -0.00022810972492,
                 ]
             ).reshape((-1, 3)),
+            "MP3 CORRELATION ENERGY": -0.07380592,  # dfocc
+            "MP3 SINGLES ENERGY": 0.0,
+            "MP3 SAME-SPIN CORRELATION ENERGY": -0.00220531,  # dfocc
+            "MP3 TOTAL GRADIENT": np.array(
+                [
+                    0.0,
+                    0.0,
+                    0.00909477332,
+                    0.0,
+                    0.0,
+                    -0.008853050692,
+                    0.0,
+                    0.012720593477,
+                    -0.000120861314,
+                    0.0,
+                    -0.012720593477,
+                    -0.000120861314,
+                ]
+            ).reshape((-1, 3)),
             "LCCD CORRELATION ENERGY": -0.0824996438,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0022545103,  # dfocc
+            "LCCD TOTAL GRADIENT": np.array(
+                [
+                    0.0,
+                    0.0,
+                    0.004394350773,
+                    0.0,
+                    0.0,
+                    -0.004297223912,
+                    0.0,
+                    0.0152632844,
+                    -0.000048563431,
+                    0.0,
+                    -0.0152632844,
+                    -0.000048563431,
+                ]
+            ).reshape((-1, 3)),
+            # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
         },
     },
     {
@@ -2838,6 +3566,7 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_nh2_adz_df_uhf,
+            "HF TOTAL GRADIENT": _grad_scf_nh2_adz_df_uhf,
             "MP2 CORRELATION ENERGY": -0.15240678,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.03448325,
@@ -2854,9 +3583,19 @@ _std_suite = [
                     -0.013132433236,
                 ]
             ).reshape((-1, 3)),
+            "MP3 CORRELATION ENERGY": -0.16868589,  # dfocc
+            "MP3 SINGLES ENERGY": 0.0,
+            "MP3 SAME-SPIN CORRELATION ENERGY": -0.03460509,  # dfocc
+            "MP3 TOTAL GRADIENT": np.array(
+                [0.0, 0.0, 0.027853586058, 0.0, 0.014898421791, -0.013926793029, 0.0, -0.014898421791, -0.013926793029]
+            ).reshape((-1, 3)),
             "LCCD CORRELATION ENERGY": -0.1748446809,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0333897039,  # dfocc
+            "LCCD TOTAL GRADIENT": np.array(
+                [0.0, 0.0, 0.031455324295, 0.0, 0.017108389967, -0.015727662148, 0.0, -0.017108389967, -0.015727662148]
+            ).reshape((-1, 3)),
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     {
@@ -2870,6 +3609,7 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_nh2_qz2p_df_uhf,
+            "HF TOTAL GRADIENT": _grad_scf_nh2_qz2p_df_uhf,
             "MP2 CORRELATION ENERGY": -0.17116675,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.03822296,
@@ -2886,9 +3626,19 @@ _std_suite = [
                     -0.00735860571,
                 ]
             ).reshape((-1, 3)),
+            "MP3 CORRELATION ENERGY": -0.18574570,  # dfocc
+            "MP3 SINGLES ENERGY": 0.0,
+            "MP3 SAME-SPIN CORRELATION ENERGY": -0.03792036,  # dfocc
+            "MP3 TOTAL GRADIENT": np.array(
+                [0.0, 0.0, 0.015407701186, 0.0, 0.006091123422, -0.007703850593, 0.0, -0.006091123422, -0.007703850593]
+            ).reshape((-1, 3)),
             "LCCD CORRELATION ENERGY": -0.1916908596,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0367574293,
+            "LCCD TOTAL GRADIENT": np.array(
+                [0.0, 0.0, 0.019127907852, 0.0, 0.00829827557, -0.009563953926, 0.0, -0.00829827557, -0.009563953926]
+            ).reshape((-1, 3)),
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     {
@@ -2902,6 +3652,7 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_bh3p_dz_df_rohf,
+            "HF TOTAL GRADIENT": _grad_scf_bh3p_dz_df_rohf,
             "MP2 CORRELATION ENERGY": -0.059372748391,
             "MP2 SINGLES ENERGY": -0.000688391888527046,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.0018535174789756292,
@@ -2922,6 +3673,7 @@ _std_suite = [
                 ]
             ).reshape((-1, 3)),
             "LCCD CORRELATION ENERGY": -0.0824737155,  # p4n
+            # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
         },
     },
     {
@@ -2935,6 +3687,7 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_nh2_adz_df_rohf,
+            "HF TOTAL GRADIENT": _grad_scf_nh2_adz_df_rohf,
             "MP2 CORRELATION ENERGY": -0.15700408,
             "MP2 SINGLES ENERGY": -0.00280619,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.03469227,
@@ -2952,6 +3705,7 @@ _std_suite = [
                 ]
             ).reshape((-1, 3)),
             "LCCD CORRELATION ENERGY": -0.1769909051,  # p4n
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     {
@@ -2965,6 +3719,7 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_nh2_qz2p_df_rohf,
+            "HF TOTAL GRADIENT": _grad_scf_nh2_qz2p_df_rohf,
             "MP2 CORRELATION ENERGY": -0.17609909,
             "MP2 SINGLES ENERGY": -0.00294363,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.03837317,
@@ -2982,6 +3737,7 @@ _std_suite = [
                 ]
             ).reshape((-1, 3)),
             "LCCD CORRELATION ENERGY": -0.1939804718,  # p4n
+            # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
         },
     },
     # <<<  lopsided SCF/CORL algorithms  >>>
@@ -2996,12 +3752,17 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_hf_dz_df_rhf,
+            "HF TOTAL GRADIENT": _grad_scf_hf_dz_df_rhf,
             "MP2 CORRELATION ENERGY": -0.201612517228,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.05348507322421174,
             "MP2 TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.00316682, 0.0, 0.0, -0.00316682]  # occ findif-5 fc df+conv
             ).reshape((-1, 3)),
+            "MP3 CORRELATION ENERGY": -0.20452073,
+            "MP3 SINGLES ENERGY": 0.0,
+            "MP3 SAME-SPIN CORRELATION ENERGY": -0.04918306,
+            # "XXX TOTAL GRADIENT": np.zeros(6).reshape((-1, 3)),
         },
     },
     {
@@ -3015,12 +3776,17 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_hf_dz_cd_rhf,
+            "HF TOTAL GRADIENT": _grad_scf_hf_dz_cd_rhf,
             "MP2 CORRELATION ENERGY": -0.20162236483,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.053488165399,
             "MP2 TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.00316652, 0.0, 0.0, -0.00316652]  # occ findif-5 fc cd+conv
             ).reshape((-1, 3)),
+            "MP3 CORRELATION ENERGY": -0.20453091,
+            "MP3 SINGLES ENERGY": 0.0,
+            "MP3 SAME-SPIN CORRELATION ENERGY": -0.04918609,
+            # "XXX TOTAL GRADIENT": np.zeros(6).reshape((-1, 3)),
         },
     },
     # {
@@ -3119,21 +3885,28 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_hf_dz_df_rhf,
+            "HF TOTAL GRADIENT": _grad_scf_hf_dz_df_rhf,
             "MP2 CORRELATION ENERGY": -0.2037668844651997,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.05427252944164894,
             "MP2 TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.00281165, 0.0, 0.0, -0.00281165]  # occ findif-5 ae df+conv
             ).reshape((-1, 3)),
+            "MP3 CORRELATION ENERGY": -0.20646457,  # dfocc
+            "MP3 SINGLES ENERGY": 0.0,
+            "MP3 SAME-SPIN CORRELATION ENERGY": -0.04988633,  # dfocc
+            "MP3 TOTAL GRADIENT": np.array([0.0, 0.0, -0.000924553428, 0.0, 0.0, 0.000924553428]).reshape((-1, 3)),
             "LCCD CORRELATION ENERGY": -0.2098900858,  # p4n
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.048336089041,  # fnocc
+            "LCCD TOTAL GRADIENT": np.array([0.0, 0.0, 0.002196305414, 0.0, 0.0, -0.002196305414]).reshape((-1, 3)),
             "LCCSD CORRELATION ENERGY": -0.2107275173,  # p4n
             "LCCSD SINGLES ENERGY": 0.0,
             "LCCSD SAME-SPIN CORRELATION ENERGY": -0.048456320034,  # fnocc
             "CCSD CORRELATION ENERGY": -0.20872812,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.04857038,
+            # "XXX TOTAL GRADIENT": np.zeros(6).reshape((-1, 3)),
         },
     },
     {
@@ -3147,21 +3920,28 @@ _std_suite = [
         },
         "data": {
             "HF TOTAL ENERGY": _scf_hf_dz_cd_rhf,
+            "HF TOTAL GRADIENT": _grad_scf_hf_dz_cd_rhf,
             "MP2 CORRELATION ENERGY": -0.2037767503537,
             "MP2 SINGLES ENERGY": 0.0,
             "MP2 SAME-SPIN CORRELATION ENERGY": -0.05427563053,
             "MP2 TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.00281136, 0.0, 0.0, -0.00281136]  # occ findif-5 ae cd+conv
             ).reshape((-1, 3)),
+            "MP3 CORRELATION ENERGY": -0.20647475,  # dfocc
+            "MP3 SINGLES ENERGY": 0.0,
+            "MP3 SAME-SPIN CORRELATION ENERGY": -0.04988936,  # dfocc
+            "MP3 TOTAL GRADIENT": np.array([0.0, 0.0, -0.00092571521, 0.0, 0.0, 0.00092571521]).reshape((-1, 3)),
             "LCCD CORRELATION ENERGY": -0.2099004485,  # p4n
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.048339111990,  # fnocc
+            "LCCD TOTAL GRADIENT": np.array([0.0, 0.0, 0.002195646447, 0.0, 0.0, -0.002195646447]).reshape((-1, 3)),
             "LCCSD CORRELATION ENERGY": -0.2107380019,  # p4n
             "LCCSD SINGLES ENERGY": 0.0,
             "LCCSD SAME-SPIN CORRELATION ENERGY": -0.048459381537,  # fnocc
             "CCSD CORRELATION ENERGY": -0.20873814,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.04857333,
+            # "XXX TOTAL GRADIENT": np.zeros(6).reshape((-1, 3)),
         },
     },
     #    {
@@ -3269,6 +4049,53 @@ for calc in _std_suite:
                     calc["data"]["SCS-MP2 TOTAL ENERGY"] = (
                         calc["data"]["SCS-MP2 CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
                     )
+
+        if "MP3 CORRELATION ENERGY" in calc["data"]:
+            calc["data"]["MP3 TOTAL ENERGY"] = calc["data"]["MP3 CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
+            if "MP2 CORRELATION ENERGY" in calc["data"]:
+                calc["data"]["MP2.5 CORRELATION ENERGY"] = 0.5 * (
+                    calc["data"]["MP3 CORRELATION ENERGY"] + calc["data"]["MP2 CORRELATION ENERGY"]
+                )
+                calc["data"]["MP2.5 TOTAL ENERGY"] = (
+                    calc["data"]["MP2.5 CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
+                )
+
+            if "MP3 SINGLES ENERGY" in calc["data"]:
+                calc["data"]["MP3 DOUBLES ENERGY"] = (
+                    calc["data"]["MP3 CORRELATION ENERGY"] - calc["data"]["MP3 SINGLES ENERGY"]
+                )
+                if "MP2 SINGLES ENERGY" in calc["data"]:
+                    calc["data"]["MP2.5 SINGLES ENERGY"] = 0.5 * (
+                        calc["data"]["MP3 SINGLES ENERGY"] + calc["data"]["MP2 SINGLES ENERGY"]
+                    )
+                    calc["data"]["MP2.5 DOUBLES ENERGY"] = (
+                        calc["data"]["MP2.5 CORRELATION ENERGY"] - calc["data"]["MP2.5 SINGLES ENERGY"]
+                    )
+                if "MP3 SAME-SPIN CORRELATION ENERGY" in calc["data"]:
+                    calc["data"]["MP3 OPPOSITE-SPIN CORRELATION ENERGY"] = (
+                        calc["data"]["MP3 CORRELATION ENERGY"]
+                        - calc["data"]["MP3 SAME-SPIN CORRELATION ENERGY"]
+                        - calc["data"]["MP3 SINGLES ENERGY"]
+                    )
+                    if "MP2 SAME-SPIN CORRELATION ENERGY" in calc["data"]:
+                        calc["data"]["MP2.5 SAME-SPIN CORRELATION ENERGY"] = 0.5 * (
+                            calc["data"]["MP3 SAME-SPIN CORRELATION ENERGY"]
+                            + calc["data"]["MP2 SAME-SPIN CORRELATION ENERGY"]
+                        )
+                        calc["data"]["MP2.5 OPPOSITE-SPIN CORRELATION ENERGY"] = (
+                            calc["data"]["MP2.5 CORRELATION ENERGY"]
+                            - calc["data"]["MP2.5 SAME-SPIN CORRELATION ENERGY"]
+                            - calc["data"]["MP2.5 SINGLES ENERGY"]
+                        )
+
+        if (
+            "MP3 TOTAL GRADIENT" in calc["data"]
+            and "MP2 TOTAL GRADIENT" in calc["data"]
+            and "HF TOTAL GRADIENT" in calc["data"]
+        ):
+            calc["data"]["MP2.5 TOTAL GRADIENT"] = 0.5 * (
+                calc["data"]["MP3 TOTAL GRADIENT"] + calc["data"]["MP2 TOTAL GRADIENT"]
+            )
 
         if "LCCD CORRELATION ENERGY" in calc["data"]:
             calc["data"]["LCCD TOTAL ENERGY"] = (

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ if __name__ == "__main__":
         cmdclass=versioneer.get_cmdclass(),
         packages=setuptools.find_packages(),
         setup_requires=[] + pytest_runner,
-        install_requires=["pyyaml", "py-cpuinfo", "psutil", "qcelemental>=0.12.0", "pydantic>=1.0.0"],
+        install_requires=["pyyaml", "py-cpuinfo", "psutil", "qcelemental>=0.13.0", "pydantic>=1.0.0"],
         entry_points={"console_scripts": ["qcengine=qcengine.cli:main"]},
         extras_require={
             "docs": [


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
Add reference data for HF gradients, MP3 energies & gradients, and LCCD gradients. Expand contract machinery for HF, MP2.5, MP3, LCCD. Harvest MP3 from Cfour

Also converted the psi4 (non-nightly) conda-env into a "minimum" testing environment.

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
