### PR TITLE
improving get_version for Molpro and Q-Chem

### DIFF
--- a/qcengine/mdi_server.py
+++ b/qcengine/mdi_server.py
@@ -11,11 +11,21 @@ from qcelemental.util import which_import
 from .compute import compute
 
 try:
-    from mdi import MDI_Init, MDI_Accept_Communicator, MDI_Recv_Command
-    from mdi import MDI_Recv, MDI_Send, MDI_Get_Intra_Code_MPI_Comm
-    from mdi import MDI_Register_Node, MDI_Register_Command
-    from mdi import MDI_DOUBLE, MDI_CHAR, MDI_INT
-    from mdi import MDI_COMMAND_LENGTH, MDI_MAJOR_VERSION
+    from mdi import (
+        MDI_CHAR,
+        MDI_COMMAND_LENGTH,
+        MDI_DOUBLE,
+        MDI_INT,
+        MDI_MAJOR_VERSION,
+        MDI_Accept_Communicator,
+        MDI_Get_Intra_Code_MPI_Comm,
+        MDI_Init,
+        MDI_Recv,
+        MDI_Recv_Command,
+        MDI_Register_Command,
+        MDI_Register_Node,
+        MDI_Send,
+    )
 
     use_mdi = True
 except ImportError:

--- a/qcengine/programs/dftd3.py
+++ b/qcengine/programs/dftd3.py
@@ -20,8 +20,9 @@ from . import empirical_dispersion_resources
 from .model import ProgramHarness
 
 if TYPE_CHECKING:
-    from ..config import TaskConfig
     from qcelemental.models import AtomicInput
+
+    from ..config import TaskConfig
 
 
 pp = pprint.PrettyPrinter(width=120, compact=True, indent=1)

--- a/qcengine/programs/entos.py
+++ b/qcengine/programs/entos.py
@@ -21,8 +21,9 @@ from .util import (
 )
 
 if TYPE_CHECKING:
-    from ..config import TaskConfig
     from qcelemental.models import AtomicInput
+
+    from ..config import TaskConfig
 
 
 def entos_ao_order_spherical(max_angular_momentum: int) -> Dict[int, List[int]]:

--- a/qcengine/programs/molpro.py
+++ b/qcengine/programs/molpro.py
@@ -3,8 +3,8 @@ Calls the Molpro executable.
 """
 
 import string
-import xml.etree.ElementTree as ET
 from typing import Any, Dict, List, Optional, Set, Tuple
+from xml.etree import ElementTree as ET
 
 from qcelemental.models import AtomicResult
 from qcelemental.util import parse_version, safe_version, which
@@ -88,6 +88,12 @@ class MolproHarness(ProgramHarness):
                 tree = ET.ElementTree(ET.fromstring(output["outfiles"]["version.xml"]))
                 root = tree.getroot()
                 version_tree = root.find("molpro_uri:job/molpro_uri:platform/molpro_uri:version", name_space)
+                if version_tree is None:
+                    # some older schema
+                    name_space = {"molpro_uri": "http://www.molpro.net/schema/molpro2006"}
+                    version_tree = root.find("molpro_uri:job//molpro_uri:version", name_space)
+                if version_tree is None:
+                    return safe_version("0.0.0")
                 year = version_tree.attrib["major"]
                 minor = version_tree.attrib["minor"]
                 molpro_version = year + "." + minor

--- a/qcengine/programs/openmm.py
+++ b/qcengine/programs/openmm.py
@@ -8,6 +8,7 @@ import hashlib
 import os
 from typing import TYPE_CHECKING, Dict
 
+import numpy as np
 from qcelemental.models import AtomicResult, Provenance
 from qcelemental.util import which_import
 
@@ -15,11 +16,11 @@ from ..exceptions import InputError
 from ..util import capture_stdout
 from .model import ProgramHarness
 from .rdkit import RDKitHarness
-import numpy as np
 
 if TYPE_CHECKING:
-    from ..config import TaskConfig
     from qcelemental.models import AtomicInput
+
+    from ..config import TaskConfig
 
 
 class OpenMMHarness(ProgramHarness):
@@ -123,8 +124,8 @@ class OpenMMHarness(ProgramHarness):
         Generate an OpenMM System object from the input molecule method and basis.
         """
         from openmmforcefields.generators import SystemGenerator
-        from simtk.openmm import app
         from simtk import unit
+        from simtk.openmm import app
 
         # create a hash based on the input options
         hashstring = molecule.to_smiles(isomeric=True, explicit_hydrogens=True, mapped=True) + method
@@ -191,11 +192,10 @@ class OpenMMHarness(ProgramHarness):
         """
         self.found(raise_error=True)
 
-        from simtk import openmm
-        from simtk import unit
+        from simtk import openmm, unit
 
         with capture_stdout():
-            import openforcefield.topology as offtop
+            from openforcefield import topology as offtop
 
         # Failure flag
         ret_data = {"success": False}

--- a/qcengine/programs/psi4.py
+++ b/qcengine/programs/psi4.py
@@ -15,8 +15,9 @@ from ..util import execute, popen, temporary_directory
 from .model import ProgramHarness
 
 if TYPE_CHECKING:
-    from ..config import TaskConfig
     from qcelemental.models import AtomicInput
+
+    from ..config import TaskConfig
 
 
 class Psi4Harness(ProgramHarness):

--- a/qcengine/programs/qchem.py
+++ b/qcengine/programs/qchem.py
@@ -11,9 +11,11 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
 from qcelemental import constants
-from qcelemental.models import AtomicInput, AtomicResult, Molecule
+from qcelemental.models import AtomicInput, AtomicResult, Molecule, Provenance
 from qcelemental.molparse import regex
-from qcelemental.util import parse_version, provenance_stamp, safe_version, which
+from qcelemental.util import parse_version, safe_version, which
+
+from qcengine.config import TaskConfig, get_config
 
 from ..exceptions import InputError, UnknownError
 from ..util import disk_files, execute, popen, temporary_directory
@@ -61,19 +63,30 @@ class QChemHarness(ProgramHarness):
     def get_version(self) -> str:
         self.found(raise_error=True)
 
+        # Get the node configuration
+        config = get_config()
+
         which_prog = which("qchem")
         if which_prog not in self.version_cache:
-            with popen([which_prog, "-h"], popen_kwargs={"env": self._get_qc_path()}) as exc:
-                exc["proc"].wait(timeout=15)
+            success, exc = execute(
+                [which_prog, "v.in"],
+                {"v.in": "$rem\n"},
+                scratch_directory=config.scratch_directory,
+                environment=self._get_qc_path(),
+                timeout=15,
+            )
 
-            if "QC not defined" in exc["stdout"]:
+            mobj = re.search(r"Q-Chem\s+([\d.]+)\s+for", exc["stdout"])
+            if mobj:
+                self.version_cache[which_prog] = safe_version(mobj.group(1))
+
+            # if "QC not defined" in exc["stdout"]:
+            else:
                 return safe_version("0.0.0")
-
-            self.version_cache[which_prog] = safe_version(exc["stdout"].splitlines()[0].split()[-1])
 
         return self.version_cache[which_prog]
 
-    def compute(self, input_model: "AtomicInput", config: "TaskConfig") -> "AtomicResult":
+    def compute(self, input_model: "AtomicInput", config: TaskConfig) -> "AtomicResult":
         """
         Run qchem
         """
@@ -165,7 +178,7 @@ class QChemHarness(ProgramHarness):
         return exe_success, proc
 
     def build_input(
-        self, input_model: "AtomicInput", config: "TaskConfig", template: Optional[str] = None
+        self, input_model: "AtomicInput", config: TaskConfig, template: Optional[str] = None
     ) -> Dict[str, Any]:
 
         # Check some bounds on what cannot be parsed
@@ -257,9 +270,20 @@ $end
             "return_energy": bdata["99.0"][-1],
         }
 
+        qcvars = {}
         _mp2_methods = {"mp2", "rimp2"}
         if input_model.model.method.lower() in _mp2_methods:
-            properties["mp2_total_energy"] = properties["return_energy"]
+            emp2 = bdata["99.0"][-1]
+            properties["mp2_total_energy"] = emp2
+            qcvars["MP2 TOTAL ENERGY"] = emp2
+            qcvars["CURRENT ENERGY"] = emp2
+            ehf = bdata["99.0"][1]
+            qcvars["HF TOTAL ENERGY"] = ehf
+            qcvars["SCF TOTAL ENERGY"] = ehf
+            qcvars["CURRENT REFERENCE ENERGY"] = ehf
+            qcvars["MP2 CORRELATION ENERGY"] = emp2 - ehf
+            qcvars["CURRENT CORRELATION ENERGY"] = emp2 - ehf
+            properties["mp2_correlation_energy"] = emp2 - ehf
 
         # Correct CCSD because its odd?
         # if input_model.model.method.lower() == "ccsd":
@@ -273,7 +297,10 @@ $end
         output_data["stdout"] = outfiles["dispatch.out"]
         output_data["success"] = True
 
-        return AtomicResult(**{**input_model.dict(), **output_data})
+        merged_data = {**input_model.dict(), **output_data}
+        merged_data["extras"]["qcvars"] = qcvars
+
+        return AtomicResult(**merged_data)
 
     def _parse_logfile_common(self, outtext: str, input_dict: Dict[str, Any]):
         """
@@ -281,7 +308,7 @@ $end
         """
 
         properties = {}
-        provenance = provenance_stamp(__name__)
+        provenance = Provenance(creator="QChem", version=self.get_version(), routine="qchem").dict()
         mobj = re.search(r"This is a multi-thread run using ([0-9]+) threads", outtext)
         if mobj:
             provenance["nthreads"] = int(mobj.group(1))

--- a/qcengine/programs/qchem.py
+++ b/qcengine/programs/qchem.py
@@ -18,7 +18,7 @@ from qcelemental.util import parse_version, safe_version, which
 from qcengine.config import TaskConfig, get_config
 
 from ..exceptions import InputError, UnknownError
-from ..util import disk_files, execute, popen, temporary_directory
+from ..util import disk_files, execute, temporary_directory
 from .model import ProgramHarness
 
 NUMBER = r"(?x:" + regex.NUMBER + ")"
@@ -61,6 +61,11 @@ class QChemHarness(ProgramHarness):
         return paths
 
     def get_version(self) -> str:
+        # excuse missing Q-Chem for QCEngineRecords tests
+        found = self.found()
+        if not found:
+            return safe_version("0.0.0")
+
         self.found(raise_error=True)
 
         # Get the node configuration
@@ -94,7 +99,7 @@ class QChemHarness(ProgramHarness):
         self.found(raise_error=True)
 
         # Check qchem version
-        qceng_ver = "5.2"
+        qceng_ver = "5.1"
         if parse_version(self.get_version()) < parse_version(qceng_ver):
             raise TypeError(f"Q-Chem version <{qceng_ver} not supported (found version {self.get_version()})")
 

--- a/qcengine/programs/qcvar_identities_resources.py
+++ b/qcengine/programs/qcvar_identities_resources.py
@@ -1,9 +1,10 @@
 from decimal import Decimal as Dm
 from typing import Any, Dict, List
-import numpy as np
-from .util import PreservingDict
 
+import numpy as np
 from qcelemental.models import AtomicResultProperties
+
+from .util import PreservingDict
 
 
 def _difference(args):

--- a/qcengine/programs/rdkit.py
+++ b/qcengine/programs/rdkit.py
@@ -12,8 +12,9 @@ from ..units import ureg
 from .model import ProgramHarness
 
 if TYPE_CHECKING:
-    from ..config import TaskConfig
     from qcelemental.models import AtomicInput
+
+    from ..config import TaskConfig
 
 
 class RDKitHarness(ProgramHarness):

--- a/qcengine/programs/terachem.py
+++ b/qcengine/programs/terachem.py
@@ -9,7 +9,7 @@ from qcelemental.models import AtomicResult, FailedOperation
 from qcelemental.molparse.regex import DECIMAL, NUMBER
 from qcelemental.util import parse_version, safe_version, which
 
-import qcengine.util as uti
+from qcengine import util as uti
 
 from ..exceptions import UnknownError
 from ..util import popen

--- a/qcengine/programs/tests/standard_suite_contracts.py
+++ b/qcengine/programs/tests/standard_suite_contracts.py
@@ -145,7 +145,12 @@ def contractual_mp2(
                 and pv in ["MP2 SAME-SPIN CORRELATION ENERGY", "MP2 OPPOSITE-SPIN CORRELATION ENERGY"]
             )
             or (
-                ((qc_module == "psi4-detci" and method == "mp2"))
+                (
+                    (qc_module == "psi4-detci" and method == "mp2")
+                    or (
+                        qc_module == "qchem" and method == "mp2"
+                    )  # for structured -- can probably get these from parsing
+                )
                 and pv
                 in [
                     "MP2 SAME-SPIN CORRELATION ENERGY",

--- a/qcengine/programs/tests/standard_suite_runner.py
+++ b/qcengine/programs/tests/standard_suite_runner.py
@@ -81,7 +81,9 @@ def runner_asserter(inp, subject, method, basis, tnm):
     # <<<  Comparison Tests  >>>
 
     assert wfn["success"] is True
-    assert wfn["provenance"]["creator"].lower() == qcprog
+    assert (
+        wfn["provenance"]["creator"].lower() == qcprog
+    ), f'Creator ({wfn["provenance"]["creator"].lower()}) not expected ({qcprog})'
 
     ref_block = std_suite[chash]
 

--- a/qcengine/programs/tests/test_qchem.py
+++ b/qcengine/programs/tests/test_qchem.py
@@ -14,6 +14,8 @@ qchem_forgive = [
     "root.molecule.provenance.routine",
     "root.provenance.version",
     "root.provenance.routine",
+    "root.provenance.creator",
+    "root.extras",
 ]
 
 
@@ -30,6 +32,8 @@ def test_qchem_output_parser(test_case):
 
     output_ref = qcel.models.AtomicResult.parse_raw(data["output.json"]).dict()
     output_ref.pop("provenance", None)
+    output_ref.pop("extras", None)
+    output.pop("extras", None)
 
     check, message = compare_recursive(output_ref, output, return_message=True)
     assert check, message

--- a/qcengine/programs/tests/test_standard_suite.py
+++ b/qcengine/programs/tests/test_standard_suite.py
@@ -31,9 +31,10 @@
 #   result: runner checks assertion fails at expected result and triggers pytest.xfail
 
 
+import sys
+
 import pytest
 import qcelemental as qcel
-import sys
 
 import qcengine as qcng
 from qcengine.programs.tests.standard_suite_ref import std_molecules, std_refs

--- a/qcengine/programs/tests/test_xtb.py
+++ b/qcengine/programs/tests/test_xtb.py
@@ -5,10 +5,8 @@ Most of the tests use mindless molecules for the diversity of element species
 to test as much different interactions as possible.
 """
 
-import pytest
-
 import numpy as np
-
+import pytest
 import qcelemental as qcel
 from qcelemental.testing import compare_recursive
 

--- a/qcengine/programs/torchani.py
+++ b/qcengine/programs/torchani.py
@@ -12,8 +12,9 @@ from ..units import ureg
 from .model import ProgramHarness
 
 if TYPE_CHECKING:
-    from ..config import TaskConfig
     from qcelemental.models import AtomicInput
+
+    from ..config import TaskConfig
 
 
 class TorchANIHarness(ProgramHarness):
@@ -95,9 +96,9 @@ class TorchANIHarness(ProgramHarness):
         if parse_version(self.get_version()) < parse_version("0.9"):
             raise ResourceError("QCEngine's TorchANI wrapper requires version 0.9 or greater.")
 
+        import numpy as np
         import torch
         import torchani
-        import numpy as np
 
         device = torch.device("cpu")
 

--- a/qcengine/programs/xtb.py
+++ b/qcengine/programs/xtb.py
@@ -12,10 +12,10 @@ visit `its documentation <https://xtb-python.readthedocs.io>`_.
 from typing import Dict
 
 from qcelemental.models import AtomicInput, AtomicResult
-from qcelemental.util import which_import, safe_version
+from qcelemental.util import safe_version, which_import
 
-from .model import ProgramHarness
 from ..config import TaskConfig
+from .model import ProgramHarness
 
 
 class XTBHarness(ProgramHarness):

--- a/qcengine/testing.py
+++ b/qcengine/testing.py
@@ -157,7 +157,7 @@ _programs = {
     "psi4_runqcsk": is_program_new_enough("psi4", "1.4a2.dev160"),
     "psi4_mp2qcsk": is_program_new_enough("psi4", "1.4a2.dev580"),
     "qcdb": which_import("qcdb", return_bool=True),
-    "qchem": is_program_new_enough("qchem", "5.2"),
+    "qchem": is_program_new_enough("qchem", "5.1"),
     "rdkit": which_import("rdkit", return_bool=True),
     "terachem": which("terachem", return_bool=True),
     "torchani": is_program_new_enough("torchani", "0.9"),


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->

## Changelog description
- [x] at least won't throw xml errors in the presence of an old molpro when probing presence/version
- [x] modernize Provenance for Q-Chem (have to cheat for qcer tests)
- [x] for mp2 energies, get Q-Chem passing stdsuite
- [x] switch to extracting Q-Chem version from output file, not `qchem -h` since the last isn't available from a source install
- [x] catch up on `isort`
- [x] lower qchem requirements to v5.1 (works at GT). former v5.2 was simply the version at which the harness was developed.

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
