### PR TITLE
Turbomole energy fix, Hessian, Memory managment

### DIFF
--- a/qcengine/programs/tests/test_turbomole.py
+++ b/qcengine/programs/tests/test_turbomole.py
@@ -76,6 +76,7 @@ def test_turbomole_gradient(method, keywords, ref_norm, h2o):
 
     assert res.driver == "gradient"
     assert res.success is True
+    assert res.properties.return_energy
 
     grad = res.return_result
     grad_norm = np.linalg.norm(grad)
@@ -138,6 +139,7 @@ def test_turbomole_hessian(method, keywords, ref_eigvals, h2o):
 
     assert res.driver == "hessian"
     assert res.success is True
+    assert res.properties.return_energy
     assert_hessian(H, ref_eigvals, size)
 
 
@@ -166,4 +168,5 @@ def test_turbomole_num_hessian(method, keywords, ref_eigvals, h2o_ricc2_def2svp)
 
     assert res.driver == "hessian"
     assert res.success is True
+    assert res.properties.return_energy
     assert_hessian(H, ref_eigvals, size)

--- a/qcengine/programs/tests/test_turbomole.py
+++ b/qcengine/programs/tests/test_turbomole.py
@@ -43,7 +43,7 @@ def test_turbomole_energy(method, keywords, ref_energy, h2o):
     "method, keywords, ref_norm",
     [
         pytest.param("hf", {}, 0.099340, marks=using("turbomole")),
-        pytest.param("pbe0", {"grid": "m5"}, 0.060631, marks=using("turbomole")),
+        pytest.param("pbe0", {"grid": "m5"}, 0.0606266, marks=using("turbomole")),
         pytest.param("ricc2", {}, 0.059378, marks=using("turbomole")),
         pytest.param("rimp2", {}, 0.061576, marks=using("turbomole")),
     ],

--- a/qcengine/programs/tests/test_turbomole.py
+++ b/qcengine/programs/tests/test_turbomole.py
@@ -26,7 +26,7 @@ def h2o_ricc2_def2svp():
     can be used to run NumForce with ricc2.  """
 
     mol = qcelemental.models.Molecule.from_data(
-    """
+        """
         O     0.0000000    0.0000000   -0.0835835
         H     0.7501772    0.0000000    0.5210589
         H    -0.7501772    0.0000000    0.5210589
@@ -117,19 +117,16 @@ def assert_hessian(H, ref_eigvals, ref_size):
 @pytest.mark.parametrize(
     "method, keywords, ref_eigvals",
     [
-        ("hf", {}, (2.00771683e-01,  7.77977644e-01, 9.91091318e-01)),
-        ("pbe0", {"grid": "m5"}, (1.72092719e-01,  7.38603449e-01, 9.73783598e-01)),
-        ("b-p", {"grid": "m5", "ri": True}, (1.59729409e-01,  7.21364827e-01, 9.63399519e-01)),
+        ("hf", {}, (2.00771683e-01, 7.77977644e-01, 9.91091318e-01)),
+        ("pbe0", {"grid": "m5"}, (1.72092719e-01, 7.38603449e-01, 9.73783598e-01)),
+        ("b-p", {"grid": "m5", "ri": True}, (1.59729409e-01, 7.21364827e-01, 9.63399519e-01)),
     ],
 )
 def test_turbomole_hessian(method, keywords, ref_eigvals, h2o):
     resi = {
         "molecule": h2o,
         "driver": "hessian",
-        "model": {
-            "method": method,
-            "basis": "def2-SVP",
-        },
+        "model": {"method": method, "basis": "def2-SVP",},
         "keywords": keywords,
     }
 
@@ -145,19 +142,13 @@ def test_turbomole_hessian(method, keywords, ref_eigvals, h2o):
 
 @using("turbomole")
 @pytest.mark.parametrize(
-    "method, keywords, ref_eigvals",
-    [
-        ("ricc2", {}, (1.65405531e-01,  9.63690706e-01, 1.24676634e+00)),
-    ],
+    "method, keywords, ref_eigvals", [("ricc2", {}, (1.65405531e-01, 9.63690706e-01, 1.24676634e00)),],
 )
 def test_turbomole_num_hessian(method, keywords, ref_eigvals, h2o_ricc2_def2svp):
     resi = {
         "molecule": h2o_ricc2_def2svp,
         "driver": "hessian",
-        "model": {
-            "method": method,
-            "basis": "def2-SVP",
-        },
+        "model": {"method": method, "basis": "def2-SVP",},
         "keywords": keywords,
     }
 

--- a/qcengine/programs/tests/test_turbomole.py
+++ b/qcengine/programs/tests/test_turbomole.py
@@ -118,6 +118,7 @@ def assert_hessian(H, ref_eigvals, ref_size):
     [
         ("hf", {}, (2.00771683e-01,  7.77977644e-01, 9.91091318e-01)),
         ("pbe0", {"grid": "m5"}, (1.72092719e-01,  7.38603449e-01, 9.73783598e-01)),
+        ("b-p", {"grid": "m5", "ri": True}, (1.59729409e-01,  7.21364827e-01, 9.63399519e-01)),
     ],
 )
 def test_turbomole_hessian(method, keywords, ref_eigvals, h2o):

--- a/qcengine/programs/turbomole/runner.py
+++ b/qcengine/programs/turbomole/runner.py
@@ -12,6 +12,7 @@ from qcelemental.util import safe_version, which
 
 from ...util import execute, temporary_directory
 from ..model import ProgramHarness
+from ..qcvar_identities_resources import build_atomicproperties, build_out
 from .define import execute_define, prepare_stdin
 from .harvester import harvest
 from .methods import KEYWORDS, METHODS
@@ -168,7 +169,6 @@ class TurbomoleHarness(ProgramHarness):
 
         stdout = outfiles.pop("stdout")
 
-        # nwmol, if it exists, is dinky, just a clue to geometry of nwchem results
         qcvars, gradient, hessian = harvest(input_model.molecule, stdout, **outfiles)
 
         if gradient is not None:
@@ -181,9 +181,12 @@ class TurbomoleHarness(ProgramHarness):
         if isinstance(retres, Decimal):
             retres = float(retres)
 
+        build_out(qcvars)
+        atprop = build_atomicproperties(qcvars)
+
         output_data = input_model.dict()
         output_data["extras"]["outfiles"] = outfiles
-        output_data["properties"] = {}
+        output_data["properties"] = atprop
         output_data["provenance"] = Provenance(creator="Turbomole", version=self.get_version(), routine="turbomole")
         output_data["return_result"] = retres
         output_data["stdout"] = stdout


### PR DESCRIPTION
##  Description
Receiving the paper Draft led me to revisit the TurbomoleHarness. As my own code [pysisyphus](https://github.com/eljost/pysisyphus) also supports QCEngine I noticed a bug. In gradient/Hessian calculations the current_energy wasn't set in the output properties, only the repsective energy derivative was returned ... Now the the runner uses "build_atomicproperties" and "build_out" from qcvar_identities_resources to be more consistent.

Furthermore I added support for Hessian calculations (analytical via aoforce for HF/DFT and numerical via NumForce via ricc2). Corresponding tests are provided. The Harness now also has basic memory management.

## Changelog description
Fixed missing current_energy in gradient calculation, added basic memory management and support for Hessian calculations.

## Status
- [x] Code base linted
- [x] Ready to go
