### PR TITLE
Psi4 error reporting pre-empted by KeyError

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -13,19 +13,6 @@ Changelog
 .. Bug Fixes
 .. +++++++++
 
-v0.15.0 / 2020-06-26
---------------------
-
-New Features
-++++++++++++
-
-Enhancements
-++++++++++++
-- (:pr:`239`) OpenMM - extracts CMILES from ``AtomicInput`` if possible for consistent atom ordering
-
-Bug Fixes
-+++++++++
-
 
 v0.16.0 / 2020-08-19
 --------------------

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -13,6 +13,19 @@ Changelog
 .. Bug Fixes
 .. +++++++++
 
+v0.15.0 / 2020-06-26
+--------------------
+
+New Features
+++++++++++++
+
+Enhancements
+++++++++++++
+- (:pr:`239`) OpenMM - extracts CMILES from ``AtomicInput`` if possible for consistent atom ordering
+
+Bug Fixes
++++++++++
+
 
 v0.16.0 / 2020-08-19
 --------------------

--- a/qcengine/programs/psi4.py
+++ b/qcengine/programs/psi4.py
@@ -164,7 +164,7 @@ class Psi4Harness(ProgramHarness):
                         else:
                             output_data["extras"]["qcvars"] = local_qcvars
 
-                    if output_data["success"] is False:
+                    if output_data.get("success", False) is False:
                         if "error_message" not in output_data["error"]:
                             error_message = output_data["error"]
                             error_type = "internal_error"
@@ -202,7 +202,7 @@ class Psi4Harness(ProgramHarness):
                         output_data = psi4.schema_wrapper.run_qcschema(input_model, postclean=False).dict()
                     # success here means execution returned. output_data may yet be qcel.models.AtomicResult or qcel.models.FailedOperation
                     success = True
-                    if output_data["success"]:
+                    if output_data.get("success", False):
                         output_data["extras"]["psiapi_evaluated"] = True
                     psi4.core.IOManager.shared_object().set_default_path(orig_scr)
                 else:
@@ -227,7 +227,7 @@ class Psi4Harness(ProgramHarness):
                         output_data = input_model.dict()
 
                 if success:
-                    if output_data["success"] is False:
+                    if output_data.get("success", False) is False:
                         error_message = output_data["error"]["error_message"]
                         error_type = output_data["error"]["error_type"]
                     else:

--- a/qcengine/programs/psi4.py
+++ b/qcengine/programs/psi4.py
@@ -99,6 +99,20 @@ class Psi4Harness(ProgramHarness):
 
         return candidate_version
 
+    def _handle_errors(self, output_data):
+        if "error" in output_data:
+            if "error_message" not in output_data["error"]:
+                error_message = output_data["error"]
+                error_type = "internal_error"
+            else:
+                error_message = output_data["error"]["error_message"]
+                error_type = output_data["error"].get("error_type", "unknown_error")
+        else:
+            error_message = "Unknown error, error message is not found"
+            error_type = "internal_error"
+
+        return error_message, error_type
+
     def compute(self, input_model: "AtomicInput", config: "TaskConfig") -> "AtomicResult":
         """
         Runs Psi4 in API mode
@@ -165,16 +179,7 @@ class Psi4Harness(ProgramHarness):
                             output_data["extras"]["qcvars"] = local_qcvars
 
                     if output_data.get("success", False) is False:
-                        if "error" in output_data["error"]:
-                            if "error_message" not in output_data["error"]:
-                                error_message = output_data["error"]
-                                error_type = "internal_error"
-                            else:
-                                error_message = output_data["error"]["error_message"]
-                                error_type = output_data["error"].get("error_type", "unknown_error")
-                        else:
-                            error_message = "Unknown error, error message is not found"
-                            error_type = "internal_error"
+                        error_message, error_type = self._handle_errors(output_data)
                     else:
                         compute_success = True
 
@@ -231,16 +236,7 @@ class Psi4Harness(ProgramHarness):
 
                 if success:
                     if output_data.get("success", False) is False:
-                        if "error" in output_data:
-                            if "error_message" not in output_data["error"]:
-                                error_message = output_data["error"]
-                                error_type = "internal_error"
-                            else:
-                                error_message = output_data["error"]["error_message"]
-                                error_type = output_data["error"]["error_type"]
-                        else:
-                            error_message = "Unknown error, error message is not found"
-                            error_type = "internal_error"
+                        error_message, error_type = self._handle_errors(output_data)
                     else:
                         compute_success = True
                 else:

--- a/qcengine/programs/psi4.py
+++ b/qcengine/programs/psi4.py
@@ -165,18 +165,21 @@ class Psi4Harness(ProgramHarness):
                             output_data["extras"]["qcvars"] = local_qcvars
 
                     if output_data.get("success", False) is False:
-                        if "error_message" not in output_data["error"]:
-                            error_message = output_data["error"]
-                            error_type = "internal_error"
+                        if "error" in output_data["error"]:
+                            if "error_message" not in output_data["error"]:
+                                error_message = output_data["error"]
+                                error_type = "internal_error"
+                            else:
+                                error_message = output_data["error"]["error_message"]
+                                error_type = output_data["error"].get("error_type", "unknown_error")
                         else:
-                            error_message = output_data["error"]["error_message"]
-                            error_type = output_data["error"]["error_type"]
-
+                            error_message = "Unknown error, error message is not found"
+                            error_type = "internal_error"
                     else:
                         compute_success = True
 
                 else:
-                    error_message = output["stderr"]
+                    error_message = output.get("stderr", "No STDERR output")
                     error_type = "execution_error"
 
                 # Reset the schema if required
@@ -228,12 +231,20 @@ class Psi4Harness(ProgramHarness):
 
                 if success:
                     if output_data.get("success", False) is False:
-                        error_message = output_data["error"]["error_message"]
-                        error_type = output_data["error"]["error_type"]
+                        if "error" in output_data:
+                            if "error_message" not in output_data["error"]:
+                                error_message = output_data["error"]
+                                error_type = "internal_error"
+                            else:
+                                error_message = output_data["error"]["error_message"]
+                                error_type = output_data["error"]["error_type"]
+                        else:
+                            error_message = "Unknown error, error message is not found"
+                            error_type = "internal_error"
                     else:
                         compute_success = True
                 else:
-                    error_message = output["stderr"]
+                    error_message = output.get("stderr", "No STDERR output")
                     error_type = "execution_error"
 
         # Dispatch errors, PSIO Errors are not recoverable for future runs


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->

Currently, useful error reporting with `psi4` under the `Psi4Harness` can be lost due to a missing `"success"` key on `output_data`. This PR makes attempted access of this key return `False` if not present.

Credit to @dgasmith for pointing this out.

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->
Error messages from `Psi4Harness` no longer swallowed by `KeyError`.

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
