### PR TITLE
added method field to terachem harness

### DIFF
--- a/qcengine/programs/terachem.py
+++ b/qcengine/programs/terachem.py
@@ -97,6 +97,7 @@ class TeraChemHarness(ProgramHarness):
 
         input_file.append("\n# model")
         input_file.append("basis " + str(input_model.model.basis))
+        input_file.append("method " + str(input_model.model.method))
 
         input_file.append("\n# driver")
         input_file.append("run " + input_model.driver)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
The terachem harness was not working do to the absence of a method filed in 
build_input, so I added the missing line.

## Changelog description


## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [ ] Code base linted
- [ ] Ready to go
