### PR TITLE
Migrate to the C-F OpenFF Toolkit Package

### DIFF
--- a/devtools/conda-envs/openmm.yaml
+++ b/devtools/conda-envs/openmm.yaml
@@ -1,13 +1,12 @@
 name: test
 channels:
   - conda-forge
-  - omnia
 dependencies:
-  - conda-forge::rdkit
-  - omnia::openmm
-  - omnia::openforcefield
-  - omnia::openforcefields
-  - omnia::openmmforcefields
+  - rdkit
+  - openmm
+  - openff-toolkit
+  - openff-forcefields
+  - openmmforcefields
 
     # Core
   - python

--- a/docs/source/programs_molecular_mechanics.rst
+++ b/docs/source/programs_molecular_mechanics.rst
@@ -35,7 +35,7 @@ OpenMM
 ------
 
 Currently OpenMM only supports the smirnoff typing engine from the
-``openforcefield`` toolkit. Currently available force fields are the following:
+``openff-toolkit``. Currently available force fields are the following:
 
 +----------------------------+------------+
 | Method                     | Basis      |
@@ -47,7 +47,7 @@ Currently OpenMM only supports the smirnoff typing engine from the
 | openff_unconstrained-1.0.0 | smirnoff   |
 +----------------------------+------------+
 
-Other forcefields may be available depending on your version of the ``openforcefield`` toolkit, see their `docs <https://open-forcefield-toolkit.readthedocs.io>`_ for more information.
+Other forcefields may be available depending on your version of the ``openff-toolkit``, see their `docs <https://open-forcefield-toolkit.readthedocs.io>`_ for more information.
 
 RDKit
 -----

--- a/qcengine/programs/openmm.py
+++ b/qcengine/programs/openmm.py
@@ -42,7 +42,7 @@ class OpenMMHarness(ProgramHarness):
 
     # def _get_off_forcefield(self, hashstring, offxml):
     #
-    #     from openforcefield.typing.engines import smirnoff
+    #     from openff.toolkit.typing.engines import smirnoff
     #
     #     key = hashlib.sha256(hashstring.encode()).hexdigest()
     #
@@ -91,10 +91,10 @@ class OpenMMHarness(ProgramHarness):
         rdkit_found = RDKitHarness.found(raise_error=raise_error)
 
         openff_found = which_import(
-            "openforcefield",
+            "openff.toolkit",
             return_bool=True,
             raise_error=raise_error,
-            raise_msg="Please install via `conda install openforcefield -c omnia`.",
+            raise_msg="Please install via `conda install openff-toolkit`.",
         )
 
         openmm_found = which_import(
@@ -193,7 +193,7 @@ class OpenMMHarness(ProgramHarness):
         from simtk import openmm, unit
 
         with capture_stdout():
-            from openforcefield import topology as offtop
+            from openff.toolkit import topology as offtop
 
         # Failure flag
         ret_data = {"success": False}

--- a/qcengine/programs/tests/test_programs.py
+++ b/qcengine/programs/tests/test_programs.py
@@ -277,7 +277,7 @@ def test_openmm_task_url_basis():
         "model": {
             "method": "openmm",
             "basis": "openff-1.0.0",
-            "url": "https://raw.githubusercontent.com/openforcefield/openforcefields/1.0.0/openforcefields/offxml/openff-1.0.0.offxml",
+            "url": "https://raw.githubusercontent.com/openforcefield/openff-forcefields/1.0.0/openforcefields/offxml/openff-1.0.0.offxml",
         },
         "keywords": {},
     }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->

This PR handles the migrations needed to use the `openff-toolkit` package (formerly named `openforcefield`)  which is now available on conda-forge. 

The only real difference between the `openforcefield` package previously used here and the new `openff-toolkit` package is all instances of `import openforcefield.XXX` and `from openforcefield.XXX` are now replaced by `import openff.toolkit.XXX` and `from openff.toolkit.XXX`

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->

Migrate to the conda-forge openff-toolkit package.

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [X] Code base linted
- [ ] Ready to go
