### PR TITLE
Be able to work without using NWChem's line search

### DIFF
--- a/qcengine/procedures/nwchem_opt/harvester.py
+++ b/qcengine/procedures/nwchem_opt/harvester.py
@@ -32,7 +32,7 @@ def harvest_output(outtext: str) -> Tuple[List[PreservingDict], List[Molecule], 
     pass_coord = []
     pass_grad = []
     version = error = None
-    for outpass in re.split(r" Line search:", outtext, re.MULTILINE):
+    for outpass in re.split(r"Step +\d", outtext, re.MULTILINE)[1:]:
         psivar, nwcoord, nwgrad, version, error = harvest_outfile_pass(outpass)
         pass_psivar.append(psivar)
         pass_coord.append(nwcoord)

--- a/qcengine/programs/tests/test_nwchem.py
+++ b/qcengine/programs/tests/test_nwchem.py
@@ -292,7 +292,7 @@ def test_error_correction():
             "molecule": mol,
             "model": {"method": "hf", "basis": "sto-3g"},
             "driver": "energy",
-            "keywords": {"scf__maxiter": 250, "scf__thresh": 1e-2},
+            "keywords": {"scf__maxiter": 250, "scf__thresh": 1e-1},
         },
         "nwchem",
         raise_error=True,
@@ -300,3 +300,4 @@ def test_error_correction():
 
     assert result.success
     assert "geom_binvr" in result.extras["observed_errors"]
+    assert result.extras["observed_errors"]["geom_binvr"]["keyword_updates"] == {"geometry__noautoz": True}

--- a/qcengine/tests/test_procedures.py
+++ b/qcengine/tests/test_procedures.py
@@ -240,10 +240,12 @@ def test_geometric_generic(input_data, program, model, bench):
 
 
 @using("nwchem")
-def test_nwchem_relax():
+@pytest.mark.parametrize('linopt', [0, 1])
+def test_nwchem_relax(linopt):
     # Make the input file
     input_data = {
-        "input_specification": {"model": {"method": "HF", "basis": "sto-3g", "keywords": {"driver:linopt": 0}}},
+        "input_specification": {"model": {"method": "HF", "basis": "sto-3g"},
+                                "keywords": {"set__driver:linopt": linopt}},
         "initial_molecule": qcng.get_molecule("hydrogen"),
     }
     input_data = OptimizationInput(**input_data)

--- a/qcengine/tests/test_procedures.py
+++ b/qcengine/tests/test_procedures.py
@@ -240,12 +240,14 @@ def test_geometric_generic(input_data, program, model, bench):
 
 
 @using("nwchem")
-@pytest.mark.parametrize('linopt', [0, 1])
+@pytest.mark.parametrize("linopt", [0, 1])
 def test_nwchem_relax(linopt):
     # Make the input file
     input_data = {
-        "input_specification": {"model": {"method": "HF", "basis": "sto-3g"},
-                                "keywords": {"set__driver:linopt": linopt}},
+        "input_specification": {
+            "model": {"method": "HF", "basis": "sto-3g"},
+            "keywords": {"set__driver:linopt": linopt},
+        },
         "initial_molecule": qcng.get_molecule("hydrogen"),
     }
     input_data = OptimizationInput(**input_data)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
Fixes a bug where we retrieved only the initial geometry if you turn off the line-search option in NWChem's driver.

## Changelog description
Bug fix: Was retrieving only the first step in a geometry relaxation

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
