### PR TITLE
Prevent util.execute from reading output files

### DIFF
--- a/qcengine/tests/test_utils.py
+++ b/qcengine/tests/test_utils.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import time
+import pathlib
 
 import pytest
 from qcelemental.models import AtomicInput
@@ -64,17 +65,22 @@ def test_tmpdir():
         assert str(tmpdir).split(os.path.sep)[-1].endswith("this")
 
 
-def test_disk_files():
+@pytest.mark.parametrize("outfiles_load", [True, False])
+def test_disk_files(outfiles_load):
 
     infiles = {"thing1": "hello", "thing2": "world", "other": "everyone"}
     outfiles = {"thing*": None, "other": None}
     with util.temporary_directory(suffix="this") as tmpdir:
-        with util.disk_files(infiles=infiles, outfiles=outfiles, cwd=tmpdir):
+        with util.disk_files(infiles=infiles, outfiles=outfiles, cwd=tmpdir, outfiles_load=outfiles_load):
             pass
 
     assert outfiles.keys() == {"thing*", "other"}
-    assert outfiles["thing*"]["thing1"] == "hello"
-    assert outfiles["other"] == "everyone"
+    if outfiles_load:
+        assert outfiles["thing*"]["thing1"] == "hello"
+        assert outfiles["other"] == "everyone"
+    else:
+        assert isinstance(outfiles["thing*"]["thing1"], pathlib.PurePath)
+        assert isinstance(outfiles["other"], pathlib.PurePath)
 
 
 def test_popen_tee_output(capsys):

--- a/qcengine/util.py
+++ b/qcengine/util.py
@@ -566,7 +566,7 @@ def disk_files(
     cwd: Optional[str] = None,
     as_binary: Optional[List[str]] = None,
     outfiles_load: Optional[bool] = True,
-) -> Dict[str, Union[str, bytes]]:
+) -> Dict[str, Union[str, bytes, Path]]:
     """Write and collect files.
 
     Parameters
@@ -586,7 +586,7 @@ def disk_files(
         outfiles stores the path(s) instead.
     Yields
     ------
-    Dict[str] = str
+    Dict[str, Union[str, bytes, Path]]
         outfiles with RHS filled in.
 
     """
@@ -616,14 +616,14 @@ def disk_files(
                 try:
                     with open(filename, omode) as fp:
                         outfiles[fl] = fp.read()
-                        LOGGER.info(f"... Writing ({omode}): {filename}")
+                        LOGGER.info(f"... Reading ({omode}): {filename}")
                 except (OSError, FileNotFoundError):
                     if "*" in fl:
                         gfls = {}
                         for gfl in lwd.glob(fl):
                             with open(gfl, omode) as fp:
                                 gfls[gfl.name] = fp.read()
-                                LOGGER.info(f"... Writing ({omode}): {gfl}")
+                                LOGGER.info(f"... Reading ({omode}): {gfl}")
                         if not gfls:
                             gfls = None
                         outfiles[fl] = gfls

--- a/qcengine/util.py
+++ b/qcengine/util.py
@@ -431,7 +431,7 @@ def execute(
         The exit code above which the process is considered failure.
     outfiles_load: bool, optional
         Load output file(s) contents in outfiles. If set to False,
-        outfiles stores the posix path(s) instead.
+        outfiles stores the path(s) instead.
     Raises
     ------
     FileExistsError
@@ -583,7 +583,7 @@ def disk_files(
         Keys in `infiles` (`outfiles`) to be written (read) as bytes, not decoded.
     outfiles_load: bool = True
         Load output file(s) contents in outfiles. If set to False
-        outfiles stores the posix path(s) instead.
+        outfiles stores the path(s) instead.
     Yields
     ------
     Dict[str] = str
@@ -630,12 +630,15 @@ def disk_files(
                     else:
                         outfiles[fl] = None
             else:
-                if "*" in fl:
+                if filename.is_file():
+                    outfiles[fl] = filename
+                elif "*" in fl:
                     gfls = {}
                     for gfl in lwd.glob(fl):
-                        gfls[gfl.name] = gfl
+                        if gfl.is_file():
+                            gfls[gfl.name] = gfl
                     if not gfls:
                         gfls = None
                     outfiles[fl] = gfls
                 else:
-                    outfiles[fl] = filename
+                    outfiles[fl] = None


### PR DESCRIPTION
## Description
Adds  an extra keyword (`outfiles_load`) to [util.execute](https://github.com/MolSSI/QCEngine/blob/master/qcengine/util.py#L375)  that instructs [disk_files](https://github.com/MolSSI/QCEngine/blob/master/qcengine/util.py#L559) how to handle output files. If `outfiles_load=True` (default), the output files are read and their contents returned in `outfiles`. When `outfiles_load=False`, only the file paths are returned instead. This is useful and can be necessary when output files are large so keeping track of the output files while retaining the scratch dir becomes a viable alternative:

```python
inp = {
    "command": ...,
    "outfiles": [huge_data_file, ...],
    "outfiles_load": False, # do not load outfiles in memory
    "scratch_messy": True, # do not delete scratch dir
}

_, proc = execute(**inp)

proc["outfiles"][huge_data_file] -> Path
```

The default behavior is preserved (`outfiles_load=True` in `util.execute`), so by default `outfiles` stores the file contents i.e.

```python
inp = {
    "command": ...,
    "outfiles": [small_data_file, ...],
}

_, proc = execute(**inp)

proc["outfiles"][small_data_file] -> Union[str, bytes]
```

## Changelog description
util.execute supports  tracking output files without loading them in memory

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [ ] Code base linted
- [ ] Ready to go