### PR TITLE
Properly handle compute errors raised in berny optimization procedure

### DIFF
--- a/qcengine/tests/test_procedures.py
+++ b/qcengine/tests/test_procedures.py
@@ -3,7 +3,7 @@ Tests the DQM compute dispatch module
 """
 
 import pytest
-from qcelemental.models import OptimizationInput
+from qcelemental.models import OptimizationInput, FailedOperation
 
 import qcengine as qcng
 from qcengine.testing import failure_engine, using
@@ -92,6 +92,23 @@ def test_berny_stdout(input_data):
     ret = qcng.compute_procedure(input_data, "berny", raise_error=True)
     assert ret.success is True
     assert "All criteria matched" in ret.stdout
+
+
+@using("psi4")
+@using("berny")
+def test_berny_failed_gradient_computation(input_data):
+
+    input_data["initial_molecule"] = qcng.get_molecule("water")
+    input_data["input_specification"]["model"] = {"method": "HF", "basis": "sto-3g"}
+    input_data["input_specification"]["keywords"] = {"badpsi4key", "badpsi4value"}
+    input_data["keywords"]["program"] = "psi4"
+
+    input_data = OptimizationInput(**input_data)
+
+    ret = qcng.compute_procedure(input_data, "berny", raise_error=False)
+    assert isinstance(ret, FailedOperation)
+    assert ret.success is False
+    assert ret.error.error_type == qcng.exceptions.InputError.error_type
 
 
 @using("geometric")

--- a/qcengine/tests/test_procedures.py
+++ b/qcengine/tests/test_procedures.py
@@ -100,7 +100,7 @@ def test_berny_failed_gradient_computation(input_data):
 
     input_data["initial_molecule"] = qcng.get_molecule("water")
     input_data["input_specification"]["model"] = {"method": "HF", "basis": "sto-3g"}
-    input_data["input_specification"]["keywords"] = {"badpsi4key", "badpsi4value"}
+    input_data["input_specification"]["keywords"] = {"badpsi4key": "badpsi4value"}
     input_data["keywords"]["program"] = "psi4"
 
     input_data = OptimizationInput(**input_data)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
Closes #300 .

## Changelog description
Handle gradient computation errors correctly inside of `BernyProcedure.compute()` method

## Note on decisions
- Updated the `.compute()` call signature to reflect the possibility of returning a `FailedOperation`. While the `OptimizationResult` object may have `success=False`, it still requires `trajectory` and `energies` attributes, both of which cannot be `None`, and if a gradient computation fails on its first iteration it is not possible to create any `AtomicResult` or `energies` values; thus it is not possible to return an `OptimizationResult` object, even with `success=False` set on the object.

## Open Questions
- Is it necessary to declare types in the function signature using the "" employed previously in this method? Seems more canonical to declare return types without "" values unless they are the class being defined in a @classmethod. I have followed the convention already in the code but would consider updating it to remove the "" if allowed. 

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [ x] Code base linted
- [ x] Ready to go
