### PR TITLE
Get compute program from InputSpecification instead of keywords for b…

### DIFF
--- a/qcengine/procedures/berny.py
+++ b/qcengine/procedures/berny.py
@@ -54,7 +54,7 @@ class BernyProcedure(ProcedureHarness):
         input_data = input_data.dict()
         geom_qcng = input_data["initial_molecule"]
         comput = {**input_data["input_specification"], "molecule": geom_qcng}
-        program = input_data["keywords"].pop("program")
+        program = comput.pop("program")
         trajectory = []
         output_data = input_data.copy()
         try:


### PR DESCRIPTION
…erny optimizer

<!-- Thank you for your contribution! -->

## Description
Closes #302 

## Changelog description
Get qc program from QCInputSpecification keywords (contains keywords for the compute engine) instead of OptimizationInput keywords (keywords specific to the `berny` optimizer).

## Status
- [ x] Code base linted
- [ x] Ready to go
