### PR TITLE
Error correction for NWChem computations that fail to converge

### DIFF
--- a/qcengine/programs/nwchem/errors.py
+++ b/qcengine/programs/nwchem/errors.py
@@ -4,6 +4,7 @@ from typing import Any, Dict
 from qcelemental.models import AtomicInput
 
 from qcengine.exceptions import SimpleKnownErrorException
+from qcengine.programs.nwchem.germinate import xc_functionals
 
 
 class GeomBinvrError(SimpleKnownErrorException):
@@ -20,5 +21,36 @@ class GeomBinvrError(SimpleKnownErrorException):
         return {"geometry__noautoz": True}
 
 
+class ConvergenceFailedError(SimpleKnownErrorException):
+    """Failed to converge on electronic steps. This will increase the limit by 2x"""
+
+    error_name = "convergence_failed"
+    description = "The computation failed to converge. We increased the number of steps by a factor of 2"
+
+    @classmethod
+    def _detect(cls, outputs: Dict[str, str]) -> bool:
+        return (
+            "This type of error is most commonly" in outputs["stdout"] and "convergence criteria" in outputs["stdout"]
+        )
+
+    def create_keyword_update(self, input_data: AtomicInput) -> Dict[str, Any]:
+        # Fit the correct keyword we are looking to update is different for different methods
+        method = input_data.model.method
+        if method == "dft" or method.split()[0] in xc_functionals:
+            if "dft__iterations" in input_data.keywords:
+                kwd = "dft__iterations"
+                cur_iter = input_data.keywords["dft__iterations"]
+            elif "dft__maxiter" in input_data.keywords:
+                kwd = "dft__maxiter"
+                cur_iter = input_data.keywords["dft__maxiter"]
+            else:
+                kwd = "dft__maxiter"
+                cur_iter = 20  # The NWChem default
+        else:
+            raise ValueError(f'Method "{method}" is not yet supported')
+
+        return {kwd: cur_iter * 2}
+
+
 # List of all the known errors
-all_errors = [GeomBinvrError]
+all_errors = [GeomBinvrError, ConvergenceFailedError]

--- a/qcengine/programs/nwchem/errors.py
+++ b/qcengine/programs/nwchem/errors.py
@@ -26,7 +26,7 @@ class GeomBinvrError(SimpleKnownErrorException):
 
 
 class ConvergenceFailedError(SimpleKnownErrorException):
-    """Failed to converge on electronic steps. This will increase the limit by 2x"""
+    """Failed to converge on electronic steps. This will increase the limit by 4x"""
 
     error_name = "convergence_failed"
     description = "The computation failed to converge."

--- a/qcengine/programs/nwchem/errors.py
+++ b/qcengine/programs/nwchem/errors.py
@@ -64,7 +64,7 @@ class ConvergenceFailedError(SimpleKnownErrorException):
         else:
             raise ValueError(f'Method "{method}" is not yet supported')
 
-        return {kwd: cur_iter * 2}
+        return {kwd: cur_iter * 4}
 
 
 # List of all the known errors

--- a/qcengine/programs/nwchem/germinate.py
+++ b/qcengine/programs/nwchem/germinate.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, Tuple
 from qcengine.exceptions import InputError
 
 # List of XC functionals known to NWChem
-_xc_functionals = [
+xc_functionals = [
     "acm",
     "b3lyp",
     "beckehandh",
@@ -168,7 +168,7 @@ def muster_modelchem(method: str, derint: int, use_tce: bool) -> Tuple[str, Dict
             f"Do not specify TCE as a method. Instead specify the desired method " f'as a keyword and "qc_module=True".'
         )
 
-    elif method.split()[0] in _xc_functionals:
+    elif method.split()[0] in xc_functionals:
         opts["dft__xc"] = method
         if use_tce:
             mdccmd = f"task tce {runtyp}\n\n"

--- a/qcengine/programs/nwchem/harvester.py
+++ b/qcengine/programs/nwchem/harvester.py
@@ -185,8 +185,7 @@ def harvest_outfile_pass(outtext):
             re.MULTILINE,
         )
         if mobj:
-            logger.debug("matched scs-mp2")
-            print("matched scs-mp2", mobj.groups())
+            logger.debug("matched scs-mp2", mobj.groups())
             psivar["MP2 SAME-SPIN CORRELATION ENERGY"] = mobj.group(1)
             psivar["MP2 OPPOSITE-SPIN CORRELATION ENERGY"] = mobj.group(3)
 
@@ -255,7 +254,6 @@ def harvest_outfile_pass(outtext):
             if mobj:
                 mbpt_plain = cc_name.replace("\\", "").replace("MBPT", "MP").replace("(", "").replace(")", "")
                 logger.debug(f"matched tce mbpt {mbpt_plain}", mobj.groups())
-                print(f"matched tce mbpt {mbpt_plain}", mobj.groups())
                 tce_cumm_corl += float(mobj.group(1))
 
                 if mbpt_plain == "MP2":
@@ -287,7 +285,7 @@ def harvest_outfile_pass(outtext):
 
             if mobj2:
                 mbpt_plain = cc_name.replace("\\", "").replace("MBPT", "MP").replace("(", "").replace(")", "")
-                print(f"matched tce {mbpt_plain} dipole moment")
+                logger.debug(f"matched tce {mbpt_plain} dipole moment")
                 # only pulling Debye
                 psivar[f"{mbpt_plain} DIPOLE"] = np.array([mobj2.group(1), mobj2.group(3), mobj2.group(5)])
 
@@ -337,7 +335,7 @@ def harvest_outfile_pass(outtext):
             if mobj2:
                 cc_plain = cc_name.replace("\\", "")
                 cc_corr = cc_plain.replace("CCSD", "")
-                print(f"matched tce {cc_plain} dipole moment")
+                logger.debug(f"matched tce {cc_plain} dipole moment")
 
                 # only pulling Debye
                 psivar[f"{cc_plain} DIPOLE"] = np.array([mobj2.group(1), mobj2.group(3), mobj2.group(5)])
@@ -367,9 +365,8 @@ def harvest_outfile_pass(outtext):
             )
 
             if mobj:
-                logger.debug(f"matched {cc_name}")
                 mobj3 = re.search(r"Wavefunction type : Restricted open-shell Hartree-Fock", outtext, re.MULTILINE)
-                print(f"matched {cc_name}", mobj.groups())
+                logger.debug(f"matched {cc_name}", mobj.groups())
                 if mobj3:
                     pass
                 else:
@@ -389,7 +386,7 @@ def harvest_outfile_pass(outtext):
                 re.MULTILINE,
             )
             if mobj2:
-                print(f"matched tce dipole moment")
+                logger.debug(f"matched tce dipole moment")
 
                 # only pulling Debye
                 psivar[f"CURRENT DIPOLE"] = np.array([mobj2.group(1), mobj2.group(3), mobj2.group(5)])
@@ -411,7 +408,6 @@ def harvest_outfile_pass(outtext):
 
         if mobj:
             logger.debug("matched ccsd")
-            print("matched ccsd")
             psivar["CCSD CORRELATION ENERGY"] = mobj.group(2)
             psivar["CCSD TOTAL ENERGY"] = mobj.group(3)
 
@@ -450,8 +446,7 @@ def harvest_outfile_pass(outtext):
         )
         # SCS-CCSD included
         if mobj:
-            logger.debug("matched scs-ccsd")
-            print("matched scs-ccsd", mobj.groups())
+            logger.debug("matched scs-ccsd", mobj.groups())
             psivar["CCSD SAME-SPIN CORRELATION ENERGY"] = mobj.group(1)
             psivar["CCSD OPPOSITE-SPIN CORRELATION ENERGY"] = mobj.group(3)
             # psivar['CCSD SAME-SPIN CORRELATION ENERGY'] = psivar['SCS-CCSD SAME-SPIN CORRELATION ENERGY'] = (
@@ -489,11 +484,11 @@ def harvest_outfile_pass(outtext):
         # mobj.group(4) = excitation energy (eV)
 
         if mobj:
-            print(mobj)
+            logger.debug(mobj)
             ext_energy = {}  # dic
 
             ext_energy_list = []
-            print(f"matched eom-{cc_name}")
+            logger.debug(f"matched eom-{cc_name}")
             for mobj_list in mobj:
                 logger.debug("matched EOM-%s - %s symmetry" % (cc_name, mobj_list[0]))  # cc_name, symmetry
                 logger.debug(mobj_list)
@@ -551,7 +546,7 @@ def harvest_outfile_pass(outtext):
         if mobj:
             logger.debug("matched TDDFT with transition moments")
             for mobj_list in mobj:
-                print(mobj_list)
+                logger.debug(mobj_list)
                 # in eV
                 psivar[f"TDDFT ROOT {mobj_list[0]} EXCITATION ENERGY - {mobj_list[1]} SYMMETRY"] = mobj_list[2]
                 psivar[f"TDDFT ROOT {mobj_list[0]} EXCITED STATE ENERGY - {mobj_list[1]} SYMMETRY"] = psivar[
@@ -649,7 +644,6 @@ def harvest_outfile_pass(outtext):
         )
         if mobj:
             logger.debug("matched multiplicity via alpha and beta electrons 0")
-            print("matched multiplicity via alpha and beta electrons 0")
             out_mult = int(mobj.group(1)) - int(mobj.group(2)) + 1  # nopen + 1
             psivar["N ALPHA ELECTRONS"] = mobj.group(1)
             psivar["N BETA ELECTRONS"] = mobj.group(2)
@@ -669,8 +663,7 @@ def harvest_outfile_pass(outtext):
             re.MULTILINE | re.IGNORECASE,
         )
         if mobj:
-            logger.debug("matched alpha and beta electrons 1")
-            print("matched alpha and beta electrons 1", mobj.groups())
+            logger.debug("matched alpha and beta electrons 1", mobj.groups())
             calcinfo = True
             psivar["N BASIS FUNCTIONS"] = mobj.group("nbf")
             psivar["N MOLECULAR ORBITALS"] = mobj.group("nmo")
@@ -696,8 +689,7 @@ def harvest_outfile_pass(outtext):
             re.MULTILINE | re.IGNORECASE,
         )
         if mobj and not calcinfo:
-            logger.debug("matched alpha and beta electrons 2")
-            print("matched alpha and beta electrons 2", mobj.groups())
+            logger.debug("matched alpha and beta electrons 2", mobj.groups())
             calcinfo = True
             psivar["N BASIS FUNCTIONS"] = mobj.group("nbf")
             psivar["N MOLECULAR ORBITALS"] = (int(mobj.group("namo")) + int(mobj.group("nbmo"))) / 2
@@ -715,8 +707,7 @@ def harvest_outfile_pass(outtext):
             re.MULTILINE | re.IGNORECASE,
         )
         if mobj and not calcinfo:
-            logger.debug("matched alpha and beta electrons 3")
-            print("matched alpha and beta electrons 3", mobj.groups())
+            logger.debug("matched alpha and beta electrons 3", mobj.groups())
             calcinfo = True
             psivar["N BASIS FUNCTIONS"] = mobj.group("nbf")
             psivar["N MOLECULAR ORBITALS"] = mobj.group("nbf")
@@ -734,8 +725,7 @@ def harvest_outfile_pass(outtext):
             re.MULTILINE | re.IGNORECASE,
         )
         if mobj and not calcinfo:
-            logger.debug("matched alpha and beta electrons 4")
-            print("matched alpha and beta electrons 4", mobj.groups())
+            logger.debug("matched alpha and beta electrons 4", mobj.groups())
             calcinfo = True
             psivar["N BASIS FUNCTIONS"] = mobj.group("nbf")
             psivar["N MOLECULAR ORBITALS"] = mobj.group("nbf")  # BAD! TODO

--- a/qcengine/programs/nwchem/runner.py
+++ b/qcengine/programs/nwchem/runner.py
@@ -136,7 +136,7 @@ class NWChemHarness(ErrorCorrectionProgramHarness):
             # Check if any of the errors are known
             for error in all_errors:
                 error.detect_error(dexe)
-            raise UnknownError(dexe["stdout"])
+            raise UnknownError(f"STDOUT:\n{dexe['stdout']}\nSTDERR:\n{dexe['stderr']}")
 
     def build_input(
         self, input_model: AtomicInput, config: TaskConfig, template: Optional[str] = None
@@ -238,10 +238,9 @@ task python
         stderr = outfiles.pop("stderr")
 
         # Read the NWChem stdout file and, if needed, the hess or grad files
-        try:
-            qcvars, nwhess, nwgrad, nwmol, version, errorTMP = harvest(input_model.molecule, stdout, **outfiles)
-        except Exception as e:
-            raise UnknownError(stdout)
+        # LW 7Jul21: I allow exceptions to be raised so that we can detect errors
+        #   in the parsing of output files
+        qcvars, nwhess, nwgrad, nwmol, version, errorTMP = harvest(input_model.molecule, stdout, **outfiles)
 
         if nwgrad is not None:
             qcvars[f"{input_model.model.method.upper()[4:]} TOTAL GRADIENT"] = nwgrad

--- a/qcengine/programs/qcvar_identities_resources.py
+++ b/qcengine/programs/qcvar_identities_resources.py
@@ -10,6 +10,7 @@ from .util import PreservingDict
 
 logger = logging.getLogger(__name__)
 
+
 def _difference(args):
     minuend, subtrahend = args
     return minuend - subtrahend

--- a/qcengine/programs/qcvar_identities_resources.py
+++ b/qcengine/programs/qcvar_identities_resources.py
@@ -1,11 +1,14 @@
 from decimal import Decimal as Dm
 from typing import Any, Dict, List
+import logging
 
 import numpy as np
 from qcelemental.models import AtomicResultProperties
 
 from .util import PreservingDict
 
+
+logger = logging.getLogger(__name__)
 
 def _difference(args):
     minuend, subtrahend = args
@@ -357,7 +360,7 @@ def build_out(rawvars: Dict[str, Any], verbose: int = 1) -> None:
                     data_rich_args.append(rawvars[pv])
                 else:
                     if verbose >= 2:
-                        print("""{}EMPTY, missing {}""".format(buildline, pv))
+                        logger.debug("""{}EMPTY, missing {}""".format(buildline, pv))
                     break
             else:
                 data_rich_args.append(pv)
@@ -367,7 +370,7 @@ def build_out(rawvars: Dict[str, Any], verbose: int = 1) -> None:
             # with data coming from file --> variable, looks more precise than it is. hack
             rawvars.__setitem__(pvar, result, 6)
             if verbose >= 1:
-                print("""{}SUCCESS""".format(buildline))
+                logger.debug("""{}SUCCESS""".format(buildline))
 
             if pvar == "CURRENT CORRELATION ENERGY" and abs(float(rawvars[pvar])) < 1.0e-16:
                 rawvars.pop(pvar)

--- a/qcengine/programs/tests/test_nwchem.py
+++ b/qcengine/programs/tests/test_nwchem.py
@@ -282,7 +282,7 @@ def test_autoz_error():
 
 
 @using("nwchem")
-def test_error_correction():
+def test_autoz_error_correction():
     """See if error correction for autoz works"""
 
     # Large molecule that leads to an AutoZ error
@@ -301,3 +301,28 @@ def test_error_correction():
     assert result.success
     assert "geom_binvr" in result.extras["observed_errors"]
     assert result.extras["observed_errors"]["geom_binvr"]["keyword_updates"] == {"geometry__noautoz": True}
+
+
+@pytest.mark.parametrize(
+    "method, keyword",
+    [
+        ["b3lyp", "dft__maxiter"],
+        ["b3lyp", "dft__iterations"],
+    ],
+)
+@using("nwchem")
+def test_conv_threshold(nh2, method, keyword):
+    result = qcng.compute(
+        {
+            "molecule": nh2,
+            "model": {"method": method, "basis": "sto-3g"},
+            "driver": "energy",
+            "keywords": {keyword: 4},
+        },
+        "nwchem",
+        raise_error=True,
+    )
+
+    assert result.success
+    assert "convergence_failed" in result.extras["observed_errors"]
+    assert result.extras["observed_errors"]["convergence_failed"]["keyword_updates"] == {keyword: 8}

--- a/qcengine/programs/tests/test_nwchem.py
+++ b/qcengine/programs/tests/test_nwchem.py
@@ -334,4 +334,4 @@ def test_conv_threshold(h20v2, method, keyword, init_iters, use_tce):
 
     assert result.success
     assert "convergence_failed" in result.extras["observed_errors"]
-    assert result.extras["observed_errors"]["convergence_failed"]["keyword_updates"] == {keyword: init_iters * 2}
+    assert result.extras["observed_errors"]["convergence_failed"]["keyword_updates"] == {keyword: init_iters * 4}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
Adds a simple error corrector for NWChem: Increase the number of iterations if it fails to converge

## Changelog description
Automatically increase the number of iterations when NWChem fails to converge

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
