### PR TITLE
bugfix: 'N Atoms' is now set in qcvars for grad/Hessian calcs

### DIFF
--- a/qcengine/programs/turbomole/runner.py
+++ b/qcengine/programs/turbomole/runner.py
@@ -7,12 +7,13 @@ from decimal import Decimal
 from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
 
-from qcelemental.models import AtomicResult, Provenance
+from qcelemental.models import AtomicResult, Provenance, BasisSet
 from qcelemental.util import safe_version, which
 
-from ...util import execute, temporary_directory
+from ...exceptions import InputError
 from ..model import ProgramHarness
 from ..qcvar_identities_resources import build_atomicproperties, build_out
+from ...util import execute, temporary_directory
 from .define import execute_define, prepare_stdin
 from .harvester import harvest
 from .methods import KEYWORDS, METHODS
@@ -81,6 +82,13 @@ class TurbomoleHarness(ProgramHarness):
     def build_input(
         self, input_model: "AtomicInput", config: "TaskConfig", template: Optional[str] = None
     ) -> Dict[str, Any]:
+
+        # The 'define' wrapper can only handle normal string basis set input. If
+        # a QCSchema basis set is given we break early, because this is not handled
+        # right now.
+        if isinstance(input_model.model.basis, BasisSet):
+            raise InputError("QCSchema BasisSet for model.basis not implemented. Use string basis name.")
+
         turbomolerec = {
             "infiles": {},
             "outfiles": {"control": "control"},

--- a/qcengine/tests/test_harness_canonical.py
+++ b/qcengine/tests/test_harness_canonical.py
@@ -46,7 +46,7 @@ _canonical_methods_qcsk_basis = [
     pytest.param("psi4", {"method": "hf", "basis": qcsk_bs}, {}, marks=using("psi4_mp2qcsk")),
     ("qchem", {"method": "hf", "basis": qcsk_bs}, {}),
     ("qcore", {"method": "pbe", "basis": qcsk_bs}, {}),
-    # ("turbomole", {"method": "pbe", "basis": qcsk_bs}, {}),
+    ("turbomole", {"method": "pbe", "basis": qcsk_bs}, {}),
 ]
 
 


### PR DESCRIPTION
## Description
The update to 0.20.0 broke the Turbomole harness, as 'N ATOMS' was missing in qcvars, when derivatives of the energy were calculated. This line led to an exception:

https://github.com/MolSSI/QCElemental/blob/36c5e0d3de3655fe02c42c4c1fe52eb4ba933c54/qcelemental/models/results.py#L279

## Changelog description
`qcvars['N ATOMS']` is now set for gradient and/or Hessian runs, so the AtomicProperties can be now be properly created.

## Status
- [ ] Code base linted
- [ ] Ready to go
