### PR TITLE
Multi-Molecule Torsiondrives

### DIFF
--- a/qcengine/procedures/torsiondrive.py
+++ b/qcengine/procedures/torsiondrive.py
@@ -49,8 +49,8 @@ class TorsionDriveProcedure(ProcedureHarness):
         state = torsiondrive.td_api.create_initial_state(
             dihedrals=dihedrals,
             grid_spacing=grid_spacing,
-            elements=input_model.initial_molecule.symbols,
-            init_coords=[input_model.initial_molecule.geometry.flatten().tolist()],
+            elements=input_model.initial_molecule[0].symbols,
+            init_coords=[molecule.geometry.flatten().tolist() for molecule in input_model.initial_molecule],
             dihedral_ranges=dihedral_ranges,
             energy_upper_limit=energy_upper_limit,
             energy_decrease_thresh=energy_decrease_thresh,
@@ -179,7 +179,7 @@ class TorsionDriveProcedure(ProcedureHarness):
 
         from qcengine import compute_procedure
 
-        input_molecule = input_model.initial_molecule.copy(deep=True).dict()
+        input_molecule = input_model.initial_molecule[0].copy(deep=True).dict()
         input_molecule["geometry"] = np.array(job).reshape(len(input_molecule["symbols"]), 3)
         input_molecule = Molecule.from_data(input_molecule)
 

--- a/qcengine/tests/test_procedures.py
+++ b/qcengine/tests/test_procedures.py
@@ -272,7 +272,7 @@ def test_torsiondrive_generic():
     input_data = TorsionDriveInput(
         keywords=TDKeywords(dihedrals=[(2, 0, 1, 5)], grid_spacing=[180]),
         input_specification=QCInputSpecification(driver=DriverEnum.gradient, model=Model(method="UFF", basis=None)),
-        initial_molecule=qcng.get_molecule("ethane"),
+        initial_molecule=[qcng.get_molecule("ethane")] * 2,
         optimization_spec=OptimizationSpecification(
             procedure="geomeTRIC",
             keywords={


### PR DESCRIPTION
## Description
This PR adds support for multi molecule inputs to torsion drives bringing the QCFractal and QCEngine behaviour in sync. 

## Changelog description
The torsiondrive procedure can use multiple molecules as input to torsiondrives.

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [ ] Ready to go
