### PR TITLE
Allowing torchani to use GPU 

### DIFF
--- a/qcengine/config.py
+++ b/qcengine/config.py
@@ -8,7 +8,6 @@ import logging
 import os
 import socket
 from typing import Any, Dict, Optional, Union
-from typing_extensions import Literal
 
 import pydantic
 
@@ -159,8 +158,7 @@ class TaskConfig(pydantic.BaseModel):
     scratch_messy: bool = pydantic.Field(
         False, description="Leave scratch directory and contents on disk after completion."
     )
-    device: Literal['cpu', 'cuda'] = 'cpu' # which device to perform calculation
-    
+        
     class Config:
         extra = "forbid"
 

--- a/qcengine/config.py
+++ b/qcengine/config.py
@@ -158,7 +158,7 @@ class TaskConfig(pydantic.BaseModel):
     scratch_messy: bool = pydantic.Field(
         False, description="Leave scratch directory and contents on disk after completion."
     )
-        
+
     class Config:
         extra = "forbid"
 

--- a/qcengine/config.py
+++ b/qcengine/config.py
@@ -8,6 +8,7 @@ import logging
 import os
 import socket
 from typing import Any, Dict, Optional, Union
+from typing_extensions import Literal
 
 import pydantic
 
@@ -158,7 +159,8 @@ class TaskConfig(pydantic.BaseModel):
     scratch_messy: bool = pydantic.Field(
         False, description="Leave scratch directory and contents on disk after completion."
     )
-
+    device: Literal['cpu', 'cuda'] = 'cpu' # which device to perform calculation
+    
     class Config:
         extra = "forbid"
 

--- a/qcengine/programs/torchani.py
+++ b/qcengine/programs/torchani.py
@@ -100,7 +100,7 @@ class TorchANIHarness(ProgramHarness):
         import torch
         import torchani
 
-        device = torch.device("cpu")
+        device = torch.device(config.device)
 
         # Failure flag
         ret_data = {"success": False}
@@ -126,7 +126,8 @@ class TorchANIHarness(ProgramHarness):
         # Build coord array
         geom_array = input_data.molecule.geometry.reshape(1, -1, 3) * ureg.conversion_factor("bohr", "angstrom")
         coordinates = torch.tensor(geom_array.tolist(), requires_grad=True, device=device)
-
+        model.to(device)
+        
         _, energy_array = model((species, coordinates))
         energy = energy_array.mean()
         ensemble_std = energy_array.std()
@@ -172,7 +173,7 @@ class TorchANIHarness(ProgramHarness):
         ret_data["extras"] = input_data.extras.copy()
         ret_data["extras"].update(
             {
-                "ensemble_energies": energy_array.detach().numpy(),
+                "ensemble_energies": energy_array.cpu().detach().numpy(),
                 "ensemble_energy_avg": energy.item(),
                 "ensemble_energy_std": ensemble_std.item(),
                 "ensemble_per_root_atom_disagreement": ensemble_scaled_std.item(),

--- a/qcengine/programs/torchani.py
+++ b/qcengine/programs/torchani.py
@@ -140,11 +140,11 @@ class TorchANIHarness(ProgramHarness):
         elif input_data.driver == "gradient":
             derivative = torch.autograd.grad(energy.sum(), coordinates)[0].squeeze()
             ret_data["return_result"] = (
-                np.asarray(derivative * ureg.conversion_factor("angstrom", "bohr")).ravel().tolist()
+                np.asarray(derivative.cpu() * ureg.conversion_factor("angstrom", "bohr")).ravel().tolist()
             )
         elif input_data.driver == "hessian":
             hessian = torchani.utils.hessian(coordinates, energies=energy)
-            ret_data["return_result"] = np.asarray(hessian)
+            ret_data["return_result"] = np.asarray(hessian.cpu())
         else:
             raise InputError(
                 f"TorchANI can only compute energy, gradient, and hessian driver methods. Found {input_data.driver}."

--- a/qcengine/programs/torchani.py
+++ b/qcengine/programs/torchani.py
@@ -100,7 +100,7 @@ class TorchANIHarness(ProgramHarness):
         import torch
         import torchani
 
-        device = torch.device(config.device)
+        device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 
         # Failure flag
         ret_data = {"success": False}

--- a/qcengine/programs/torchani.py
+++ b/qcengine/programs/torchani.py
@@ -100,7 +100,7 @@ class TorchANIHarness(ProgramHarness):
         import torch
         import torchani
 
-        device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
         # Failure flag
         ret_data = {"success": False}
@@ -127,7 +127,7 @@ class TorchANIHarness(ProgramHarness):
         geom_array = input_data.molecule.geometry.reshape(1, -1, 3) * ureg.conversion_factor("bohr", "angstrom")
         coordinates = torch.tensor(geom_array.tolist(), requires_grad=True, device=device)
         model.to(device)
-        
+
         _, energy_array = model((species, coordinates))
         energy = energy_array.mean()
         ensemble_std = energy_array.std()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
Added config for torchani to use GPU, related to this issue https://github.com/MolSSI/QCEngine/issues/326. 
Now we can use `local_options={'device':'cuda'}` to assign the device: 
```
import qcengine as qcng
import qcelemental as qcel

mol = qcel.models.Molecule.from_data("""
O  0.0  0.000  -0.129
H  0.0 -1.494  1.027
H  0.0  1.494  1.027
""")

inp = qcel.models.AtomicInput(
    molecule=mol,
    driver="energy",
    model={"method": "ani2x"}
    )

ret = qcng.compute(inp, "torchani", local_options={'device':'cuda'})
print(ret.return_result)
```

