### PR TITLE
Add in restart capability to NWChem

### DIFF
--- a/qcengine/programs/nwchem/runner.py
+++ b/qcengine/programs/nwchem/runner.py
@@ -165,6 +165,7 @@ class NWChemHarness(ErrorCorrectionProgramHarness):
 
         # Shortcut: If the user allows restart and the restart directory is present
         allow_restart = opts.pop("allow_restarts", True)
+        scr_name = opts.pop("scratch_name", None)
 
         # Handle memory
         # * [GiB] --> [QW]
@@ -210,7 +211,8 @@ class NWChemHarness(ErrorCorrectionProgramHarness):
         if allow_restart:
             # use the input file as a source for a hash that is used to set the directory name
             input_hash = hashlib.sha256(nwchemrec["infiles"]["nwchem.nw"].encode()).hexdigest()[:12]
-            scr_name = "nwc_" + input_hash
+            if scr_name is None:
+                scr_name = "nwc_" + input_hash
             nwchemrec["scratch_name"] = scr_name
 
             # We call the "temporary_directory" to get the eventual name of the run directory

--- a/qcengine/programs/nwchem/runner.py
+++ b/qcengine/programs/nwchem/runner.py
@@ -7,6 +7,7 @@ import pprint
 import re
 import sys
 import traceback
+import hashlib
 from decimal import Decimal
 from typing import Any, Dict, Optional, Tuple
 
@@ -18,7 +19,7 @@ from qcengine.config import TaskConfig, get_config
 from qcengine.exceptions import UnknownError
 
 from ...exceptions import InputError
-from ...util import create_mpi_invocation, execute
+from ...util import create_mpi_invocation, execute, temporary_directory
 from ..model import ErrorCorrectionProgramHarness
 from ..qcvar_identities_resources import build_atomicproperties, build_out
 from ..util import error_stamp
@@ -144,14 +145,26 @@ class NWChemHarness(ErrorCorrectionProgramHarness):
     def build_input(
         self, input_model: AtomicInput, config: TaskConfig, template: Optional[str] = None
     ) -> Dict[str, Any]:
+        # Define the controller for th e
         nwchemrec = {
             "infiles": {},
             "scratch_directory": config.scratch_directory,
             "scratch_messy": config.scratch_messy,
         }
 
+        # Prepare to write out the options
         opts = copy.deepcopy(input_model.keywords)
         opts = {k.lower(): v for k, v in opts.items()}
+
+        # Determine the command to use to launch the code
+        if config.use_mpiexec:
+            nwchemrec["command"] = create_mpi_invocation(which("nwchem"), config)
+            logger.info(f"Launching with mpiexec: {' '.join(nwchemrec['command'])}")
+        else:
+            nwchemrec["command"] = [which("nwchem")]
+
+        # Shortcut: If the user allows restart and the restart directory is present
+        allow_restart = opts.pop("allow_restarts", True)
 
         # Handle memory
         # * [GiB] --> [QW]
@@ -193,6 +206,28 @@ class NWChemHarness(ErrorCorrectionProgramHarness):
         # Combine the molecule description, options and method command together
         nwchemrec["infiles"]["nwchem.nw"] = "echo\n" + molcmd + optcmd + mdccmd
 
+        # Now that we know the computation, check if we want a restart
+        if allow_restart:
+            # use the input file as a source for a hash that is used to set the directory name
+            input_hash = hashlib.sha256(nwchemrec["infiles"]["nwchem.nw"].encode()).hexdigest()[:12]
+            scr_name = "nwc_" + input_hash
+            nwchemrec["scratch_name"] = scr_name
+
+            # We call the "temporary_directory" to get the eventual name of the run directory
+            #  and then see if nwchem.db exists to determine whether
+            with temporary_directory(
+                parent=config.scratch_directory, child=scr_name, exist_ok=True, messy=True
+            ) as tmpdir:
+                restart = tmpdir.joinpath("nwchem.db").is_file()
+
+            # If computation is a restart, remove the input geometry
+            #  It is not needed for restarts and restarts geometry optimization
+            #   if you are using the NWChem Driver module
+
+            if restart:
+                logger.info(f"Restarting from {tmpdir}")
+                nwchemrec["infiles"]["nwchem.nw"] = "echo\n" + optcmd + mdccmd
+
         # For gradient methods, add a Python command to save the gradients in higher precision
         #  Note: The Hessian is already stored in high precision in a file named "*.hess"
         if input_model.driver == "gradient":
@@ -216,13 +251,6 @@ task python
             """
             nwchemrec["infiles"]["nwchem.nw"] += pycmd
 
-        # Determine the command
-        if config.use_mpiexec:
-            nwchemrec["command"] = create_mpi_invocation(which("nwchem"), config)
-            logger.info(f"Launching with mpiexec: {' '.join(nwchemrec['command'])}")
-        else:
-            nwchemrec["command"] = [which("nwchem")]
-
         return nwchemrec
 
     def execute(
@@ -235,6 +263,7 @@ task python
             ["nwchem.hess", "nwchem.grad"],
             scratch_messy=inputs["scratch_messy"],
             scratch_exist_ok=True,
+            scratch_name=inputs.get("scratch_name", None),
             scratch_directory=inputs["scratch_directory"],
         )
         return success, dexe

--- a/qcengine/programs/nwchem/runner.py
+++ b/qcengine/programs/nwchem/runner.py
@@ -163,10 +163,6 @@ class NWChemHarness(ErrorCorrectionProgramHarness):
         else:
             nwchemrec["command"] = [which("nwchem")]
 
-        # Shortcut: If the user allows restart and the restart directory is present
-        allow_restart = opts.pop("allow_restarts", True)
-        scr_name = opts.pop("scratch_name", None)
-
         # Handle memory
         # * [GiB] --> [QW]
         # * int() rounds down
@@ -208,9 +204,11 @@ class NWChemHarness(ErrorCorrectionProgramHarness):
         nwchemrec["infiles"]["nwchem.nw"] = "echo\n" + molcmd + optcmd + mdccmd
 
         # Now that we know the computation, check if we want a restart
-        if allow_restart:
+        #  TODO (wardlt): Store the restart information in the local_options configuration
+        if input_model.extras.get("allow_restarts", True):
             # use the input file as a source for a hash that is used to set the directory name
             input_hash = hashlib.sha256(nwchemrec["infiles"]["nwchem.nw"].encode()).hexdigest()[:12]
+            scr_name = input_model.extras.get("scratch_name")
             if scr_name is None:
                 scr_name = "nwc_" + input_hash
             nwchemrec["scratch_name"] = scr_name

--- a/qcengine/tests/test_procedures.py
+++ b/qcengine/tests/test_procedures.py
@@ -265,6 +265,28 @@ def test_nwchem_relax(linopt):
     assert pytest.approx(ret.final_molecule.measure([0, 1]), 1.0e-4) == 1.3459150737
 
 
+@using("nwchem")
+def test_nwchem_restart(tmpdir):
+    # Make the input file
+    input_data = {
+        "input_specification": {
+            "model": {"method": "HF", "basis": "sto-3g"},
+            "keywords": {"driver__maxiter": 2, "set__driver:linopt": 0},
+        },
+        "initial_molecule": qcng.get_molecule("hydrogen"),
+    }
+    input_data = OptimizationInput(**input_data)
+
+    # Run an initial step, which should not converge
+    local_opts = {"scratch_messy": True, "scratch_directory": str(tmpdir)}
+    ret = qcng.compute_procedure(input_data, "nwchemdriver", local_options=local_opts, raise_error=False)
+    assert not ret.success
+
+    # Run it again, which should converge
+    new_ret = qcng.compute_procedure(input_data, "nwchemdriver", local_options=local_opts, raise_error=True)
+    assert new_ret.success
+
+
 @using("rdkit")
 @using("torsiondrive")
 def test_torsiondrive_generic():


### PR DESCRIPTION
## Description
Adds the ability for NWChem computations to be restartable.

If NWChem terminates due to walltime it leaves the scratch directory. This commit gives each computation a repeatably-named output directory, so that the QCEngine will restart from that directory if it still exists.

## Changelog description
NWChem can restart if QCEngine is killed

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
