### PR TITLE
Allow NWChem to restart single-point computations

### DIFF
--- a/qcengine/procedures/nwchem_opt/__init__.py
+++ b/qcengine/procedures/nwchem_opt/__init__.py
@@ -39,6 +39,10 @@ class NWChemDriverProcedure(ProcedureHarness):
         if keywords.get("program", "nwchem").lower() != "nwchem":
             raise InputError("NWChemDriver procedure only works with NWChem")
 
+        # Add a flag to the atomic input that tells the NWChemHarness we are calling it from driver
+        #  This is needed for the NWCHarness to make some changes to the input file
+        input_data.input_specification.extras["is_driver"] = True
+
         # Make an atomic input
         atomic_input = AtomicInput(
             molecule=input_data.initial_molecule,

--- a/qcengine/programs/nwchem/runner.py
+++ b/qcengine/programs/nwchem/runner.py
@@ -220,13 +220,14 @@ class NWChemHarness(ErrorCorrectionProgramHarness):
             ) as tmpdir:
                 restart = tmpdir.joinpath("nwchem.db").is_file()
 
-            # If computation is a restart, remove the input geometry
-            #  It is not needed for restarts and restarts geometry optimization
-            #   if you are using the NWChem Driver module
-
+            # If computation is a restart and you are calling from the NWChem Driver module, remove the input geometry
+            #  This will ensure the computation will pick up from the last geometry
             if restart:
                 logger.info(f"Restarting from {tmpdir}")
-                nwchemrec["infiles"]["nwchem.nw"] = "echo\n" + optcmd + mdccmd
+                if input_model.extras.get("is_driver", False):
+                    nwchemrec["infiles"]["nwchem.nw"] = "echo\n" + optcmd + mdccmd
+            else:
+                logger.warning(f"Existing files found in {tmpdir}. Your computation will restart")
 
         # For gradient methods, add a Python command to save the gradients in higher precision
         #  Note: The Hessian is already stored in high precision in a file named "*.hess"

--- a/qcengine/programs/tests/test_nwchem.py
+++ b/qcengine/programs/tests/test_nwchem.py
@@ -337,7 +337,7 @@ def test_conv_threshold(h20v2, method, keyword, init_iters, use_tce):
     assert result.extras["observed_errors"]["convergence_failed"]["keyword_updates"] == {keyword: init_iters * 4}
 
 
-@using('nwchem')
+@using("nwchem")
 def test_restart(nh2, tmpdir):
     resi = {
         "molecule": nh2,
@@ -345,18 +345,25 @@ def test_restart(nh2, tmpdir):
         "model": {"method": "b3lyp", "basis": "3-21g"},
         "keywords": {"dft__convergence__gradient": "1e-6", "dft__iterations": 4},
         "protocols": {"error_correction": {"default_policy": False}},
-        "extras": {"allow_restarts": True}
+        "extras": {"allow_restarts": True},
     }
 
     # Run once: It should fail to converge
-    result = qcng.compute(resi, "nwchem", local_options={'scratch_messy': True,
-                                                         'scratch_directory': '/home/lward/Work/ExaLearn/QCEngine/tmp'},
-                          raise_error=False)
+    local_options = {"scratch_messy": True, "scratch_directory": str(tmpdir)}
+    result = qcng.compute(
+        resi,
+        "nwchem",
+        local_options=local_options,
+        raise_error=False,
+    )
     assert not result.success
-    assert 'computation failed to converge' in str(result.error)
+    assert "computation failed to converge" in str(result.error)
 
     # Run again: It should converge
-    result = qcng.compute(resi, "nwchem", local_options={'scratch_messy': True,
-                                                         'scratch_directory': '/home/lward/Work/ExaLearn/QCEngine/tmp'},
-                          raise_error=False)
+    result = qcng.compute(
+        resi,
+        "nwchem",
+        local_options=local_options,
+        raise_error=False,
+    )
     assert result.success

--- a/qcengine/programs/tests/test_nwchem.py
+++ b/qcengine/programs/tests/test_nwchem.py
@@ -339,6 +339,8 @@ def test_conv_threshold(h20v2, method, keyword, init_iters, use_tce):
 
 @using("nwchem")
 def test_restart(nh2, tmpdir):
+    # Create a molecule that takes 5-8 steps for NWChem to relax it,
+    #  but only run the relaxation for 4 steps
     resi = {
         "molecule": nh2,
         "driver": "gradient",
@@ -359,7 +361,7 @@ def test_restart(nh2, tmpdir):
     assert not result.success
     assert "computation failed to converge" in str(result.error)
 
-    # Run again: It should converge
+    # Run again: It should converge only if we start from the last geometry
     result = qcng.compute(
         resi,
         "nwchem",

--- a/qcengine/programs/tests/test_nwchem.py
+++ b/qcengine/programs/tests/test_nwchem.py
@@ -335,3 +335,28 @@ def test_conv_threshold(h20v2, method, keyword, init_iters, use_tce):
     assert result.success
     assert "convergence_failed" in result.extras["observed_errors"]
     assert result.extras["observed_errors"]["convergence_failed"]["keyword_updates"] == {keyword: init_iters * 4}
+
+
+@using('nwchem')
+def test_restart(nh2, tmpdir):
+    resi = {
+        "molecule": nh2,
+        "driver": "gradient",
+        "model": {"method": "b3lyp", "basis": "3-21g"},
+        "keywords": {"dft__convergence__gradient": "1e-6", "dft__iterations": 4},
+        "protocols": {"error_correction": {"default_policy": False}},
+        "extras": {"allow_restarts": True}
+    }
+
+    # Run once: It should fail to converge
+    result = qcng.compute(resi, "nwchem", local_options={'scratch_messy': True,
+                                                         'scratch_directory': '/home/lward/Work/ExaLearn/QCEngine/tmp'},
+                          raise_error=False)
+    assert not result.success
+    assert 'computation failed to converge' in str(result.error)
+
+    # Run again: It should converge
+    result = qcng.compute(resi, "nwchem", local_options={'scratch_messy': True,
+                                                         'scratch_directory': '/home/lward/Work/ExaLearn/QCEngine/tmp'},
+                          raise_error=False)
+    assert result.success


### PR DESCRIPTION
## Description
Allows restarts to work for single-point NWChem computations, adds tests for that functionality.

As written, the NWCHarness does not write the geometry to the input
file for restart calculations. This is great for Driver computations
because it prevents the computation from restarting from the initial
geometry. However, the geometry is required for single point calculations
(esp Hessian, Gradient) because we use the geometry to determine
how NWChem rotates the coordinate system so that we can adjust
any direction-dependant quantities back to the initial coordinate system.

This change is simple: I add a flag that is set by the "driver" computation
to tell the NWCHarness not to write the geometry for restarts.
For clarity, the NWCOptimizerHarness calls the NWChemHardness
to make input files

## Changelog description
Allow NWChem to restart single-point calculations

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
