### PR TITLE
Make QCEngine tolerant of `cpuinfo` failure to populate `brand_raw`, `brand`

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -24,6 +24,7 @@ v0.21.1 / 2022-01-06
 Bug Fixes
 +++++++++
 - (:pr:`338`) Correctly export version to tarballs created by git-archive. @mbanck, @loriab
+- (:pr:`339`) QCEngine now tolerant of `cpuinfo` failure to populate `brand_raw`, `brand`. @dotsdl, @loriab, @WardLT
 
 
 v0.21.0 / 2021-11-22

--- a/qcengine/config.py
+++ b/qcengine/config.py
@@ -53,12 +53,16 @@ def get_global(key: Optional[str] = None) -> Union[str, Dict[str, Any]]:
             _global_values["cpu_brand"] = _global_values["cpuinfo"]["brand_raw"]
         except KeyError:
             # Remove this if py-cpuinfo is pinned to >=6.0.0
-            _global_values["cpu_brand"] = _global_values["cpuinfo"]["brand"]
+            try:
+                _global_values["cpu_brand"] = _global_values["cpuinfo"]["brand"]
+            except KeyError:
+                pass
+
 
     if key is None:
         return _global_values.copy()
     else:
-        return _global_values[key]
+        return _global_values.get(key)
 
 
 class NodeDescriptor(pydantic.BaseModel):

--- a/qcengine/config.py
+++ b/qcengine/config.py
@@ -53,15 +53,12 @@ def get_global(key: Optional[str] = None) -> Union[str, Dict[str, Any]]:
             _global_values["cpu_brand"] = _global_values["cpuinfo"]["brand_raw"]
         except KeyError:
             # Remove this if py-cpuinfo is pinned to >=6.0.0
-            try:
-                _global_values["cpu_brand"] = _global_values["cpuinfo"]["brand"]
-            except KeyError:
-                pass
+            _global_values["cpu_brand"] = _global_values["cpuinfo"].get("brand", 'unknown')
 
     if key is None:
         return _global_values.copy()
     else:
-        return _global_values.get(key)
+        return _global_values[key]
 
 
 class NodeDescriptor(pydantic.BaseModel):

--- a/qcengine/config.py
+++ b/qcengine/config.py
@@ -53,7 +53,7 @@ def get_global(key: Optional[str] = None) -> Union[str, Dict[str, Any]]:
             _global_values["cpu_brand"] = _global_values["cpuinfo"]["brand_raw"]
         except KeyError:
             # Remove this if py-cpuinfo is pinned to >=6.0.0
-            _global_values["cpu_brand"] = _global_values["cpuinfo"].get("brand", "unknown")
+            _global_values["cpu_brand"] = _global_values["cpuinfo"].get("brand", "(unknown)")
 
     if key is None:
         return _global_values.copy()

--- a/qcengine/config.py
+++ b/qcengine/config.py
@@ -53,7 +53,7 @@ def get_global(key: Optional[str] = None) -> Union[str, Dict[str, Any]]:
             _global_values["cpu_brand"] = _global_values["cpuinfo"]["brand_raw"]
         except KeyError:
             # Remove this if py-cpuinfo is pinned to >=6.0.0
-            _global_values["cpu_brand"] = _global_values["cpuinfo"].get("brand", 'unknown')
+            _global_values["cpu_brand"] = _global_values["cpuinfo"].get("brand", "unknown")
 
     if key is None:
         return _global_values.copy()

--- a/qcengine/config.py
+++ b/qcengine/config.py
@@ -58,7 +58,6 @@ def get_global(key: Optional[str] = None) -> Union[str, Dict[str, Any]]:
             except KeyError:
                 pass
 
-
     if key is None:
         return _global_values.copy()
     else:


### PR DESCRIPTION

<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->

Currently, we observe frequent failure of `cpuinfo` to give brand information when used within Docker containers on Pacific Research Platform. It is unclear why, but making QCEngine tolerant of this information being missing would help in production usage.

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->
QCEngine calls now tolerant of missing `brand_raw` or `brand` info from py-cpuinfo.

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
