### PR TITLE
Use micromamba for CI setup instead of miniconda

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -77,12 +77,12 @@ jobs:
         fetch-depth: 0
 
     - name: Create Environment
-      uses: conda-incubator/setup-miniconda@v2
+      uses: mamba-org/provision-with-micromamba@v11
       with:
-        activate-environment: test
+        environment-name: test
         environment-file: devtools/conda-envs/${{ matrix.cfg.conda-env }}.yaml
-        python-version: ${{ matrix.cfg.python-version }}
-        auto-activate-base: false
+        extra-specs: |
+          python=${{ matrix.cfg.python-version }}
 
     - name: Special Config - NWChem
       if: "(matrix.cfg.label == 'NWChem')"

--- a/devtools/conda-envs/adcc.yaml
+++ b/devtools/conda-envs/adcc.yaml
@@ -3,6 +3,7 @@ channels:
   - adcc
   - psi4/label/dev
   - conda-forge
+  - defaults
 dependencies:
   - adcc>=0.15.7
   - psi4

--- a/devtools/conda-envs/adcc.yaml
+++ b/devtools/conda-envs/adcc.yaml
@@ -2,8 +2,9 @@ name: test
 channels:
   - adcc
   - psi4/label/dev
-  - conda-forge
   - defaults
+  - conda-forge
+  - psi4/label/dev
 dependencies:
   - adcc>=0.15.7
   - psi4

--- a/devtools/conda-envs/opt-disp.yaml
+++ b/devtools/conda-envs/opt-disp.yaml
@@ -3,6 +3,7 @@ channels:
   - psi4/label/dev
   - conda-forge
   - defaults
+  - psi4/label/dev
 dependencies:
   - psi4=1.5*
   - blas=*=mkl  # not needed but an example of disuading solver from openblas and old psi

--- a/devtools/conda-envs/psi-nightly.yaml
+++ b/devtools/conda-envs/psi-nightly.yaml
@@ -3,6 +3,7 @@ channels:
   - psi4/label/dev
   - conda-forge
   - defaults
+  - psi4/label/dev
 dependencies:
   - psi4
   - blas=*=mkl  # not needed but an example of disuading solver from openblas and old psi

--- a/devtools/conda-envs/psi-nightly.yaml
+++ b/devtools/conda-envs/psi-nightly.yaml
@@ -2,6 +2,7 @@ name: test
 channels:
   - psi4/label/dev
   - conda-forge
+  - defaults
 dependencies:
   - psi4
   - blas=*=mkl  # not needed but an example of disuading solver from openblas and old psi

--- a/devtools/conda-envs/psi.yaml
+++ b/devtools/conda-envs/psi.yaml
@@ -1,8 +1,9 @@
 name: test
 channels:
   - psi4
-  - conda-forge
   - defaults
+  - conda-forge
+  - psi4
 dependencies:
   - psi4=1.4
   - dftd3

--- a/devtools/conda-envs/psi.yaml
+++ b/devtools/conda-envs/psi.yaml
@@ -2,6 +2,7 @@ name: test
 channels:
   - psi4
   - conda-forge
+  - defaults
 dependencies:
   - psi4=1.4
   - dftd3


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->

| env | miniconda | micromamba |
| --- | ---: | ---: |
| Psi4-release | 4m20s | failed |
| Psi4-nightly | 3m48s | failed |
| ANI | 2m9s | 1m18s |
| OpenMM | 4m22s | 2m43s |
| xTB | 1m20s | 41s |
| QCore | 2m57s | 1m4s |
| NWChem | 1m27s | 37s |
| MRChem | 1m32s | 35s |
| ADCC | 4m2s | failed |
| opt-disp | 4m11s | failed |

<details><summary>Psi4-release</summary>

```
   psi4/linux-64             
  psi4/noarch               
  pkgs/r/noarch             
  pkgs/main/noarch          
  pkgs/r/linux-64           
  pkgs/main/linux-64        
  conda-forge/noarch        
  conda-forge/linux-64      
  Encountered problems while solving:
    - package 'pydantic-1.8.2-py39h7f8727e_0' is excluded by strict repo priority
```
</details>

<details><summary>Psi4-nightly</summary>

```
   psi4/label/dev/noarch     
  psi4/label/dev/linux-64   
  pkgs/r/noarch             
  pkgs/main/noarch          
  pkgs/r/linux-64           
  pkgs/main/linux-64        
  conda-forge/noarch        
  conda-forge/linux-64      
  Encountered problems while solving:
    - package qcelemental-0.24.0-pyhd8ed1ab_0 requires pydantic >=1.8.2, but none of the providers can be installed
```
</details>

<details><summary>ADCC</summary>

```
  adcc/linux-64             
  adcc/noarch               
  psi4/label/dev/linux-64   
  psi4/label/dev/noarch     
  pkgs/r/noarch             
  pkgs/r/linux-64           
  pkgs/main/noarch          
  conda-forge/noarch        
  pkgs/main/linux-64        
  conda-forge/linux-64      
  Encountered problems while solving:
    - package qcelemental-0.24.0-pyhd8ed1ab_0 requires pydantic >=1.8.2, but none of the providers can be installed
```
</details>

<details><summary>opt-disp</summary>

```
  psi4/label/dev/noarch     
  psi4/label/dev/linux-64   
  pkgs/r/noarch             
  pkgs/r/linux-64           
  pkgs/main/noarch          
  pkgs/main/linux-64        
  conda-forge/noarch        
  conda-forge/linux-64      
  Encountered problems while solving:
    - package qcelemental-0.24.0-pyhd8ed1ab_0 requires pydantic >=1.8.2, but none of the providers can be installed
    - package dftd4-python-3.3.0-py310h6acc77f_0 requires dftd4 >=3.3.0,<3.4.0a0, but none of the providers can be installed
    - package psi4-1.5+e9f4d6d-py38hbf93d9d_0 requires chemps2 >=1.8.10,<1.8.11.0a0, but none of the providers can be installed
```
</details>

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [ ] Code base linted
- [ ] Ready to go
