### PR TITLE
Hessian parsing fixes for Turbomole Harness

### DIFF
--- a/qcengine/programs/tests/test_turbomole.py
+++ b/qcengine/programs/tests/test_turbomole.py
@@ -202,4 +202,4 @@ def test_turbomole_parse_hessian(h2o_nprhessian):
     hessian = parse_hessian(h2o_nprhessian)
     assert hessian.shape == (9, 9)
     eigvals, _ = np.linalg.eigh(hessian)
-    assert eigvals[-1] == pytest.approx(1.12157030e+00)
+    assert eigvals[-1] == pytest.approx(1.12157030e00)

--- a/qcengine/programs/tests/test_turbomole.py
+++ b/qcengine/programs/tests/test_turbomole.py
@@ -4,6 +4,7 @@ import qcelemental
 from qcelemental.testing import compare_values
 
 import qcengine as qcng
+from qcengine.programs.turbomole.harvester import parse_hessian
 from qcengine.testing import using
 
 
@@ -170,3 +171,35 @@ def test_turbomole_num_hessian(method, keywords, ref_eigvals, h2o_ricc2_def2svp)
     assert res.success is True
     assert res.properties.return_energy
     assert_hessian(H, ref_eigvals, size)
+
+
+@pytest.fixture
+def h2o_nprhessian():
+    return """$nprhessian
+     1  1   0.6142699252  -0.0000000000   0.0000000000  -0.3071349626  -0.2479448514
+     1  2  -0.0000000000  -0.3071349626   0.2479448514  -0.0000000000
+     2  1  -0.0000000000   0.4365036678   0.0000000000  -0.1885017686  -0.2182518339
+     2  2  -0.0000000000   0.1885017686  -0.2182518339   0.0000000000
+     3  1   0.0000000000   0.0000000000  -0.0000524175  -0.0000000000  -0.0000000000
+     3  2   0.0000262088  -0.0000000000   0.0000000000   0.0000262088
+     4  1  -0.3071349626  -0.1885017686  -0.0000000000   0.3389423895   0.2182233100
+     4  2   0.0000000000  -0.0318074269  -0.0297215414  -0.0000000000
+     5  1  -0.2479448514  -0.2182518339  -0.0000000000   0.2182233100   0.2092172237
+     5  2   0.0000000000   0.0297215414   0.0090346102   0.0000000000
+     6  1  -0.0000000000  -0.0000000000   0.0000262088   0.0000000000   0.0000000000
+     6  2  -0.0000125560  -0.0000000000   0.0000000000  -0.0000136528
+     7  1  -0.3071349626   0.1885017686  -0.0000000000  -0.0318074269   0.0297215414
+     7  2  -0.0000000000   0.3389423895  -0.2182233100   0.0000000000
+     8  1   0.2479448514  -0.2182518339   0.0000000000  -0.0297215414   0.0090346102
+     8  2   0.0000000000  -0.2182233100   0.2092172237  -0.0000000000
+     9  1  -0.0000000000   0.0000000000   0.0000262088  -0.0000000000   0.0000000000
+     9  2  -0.0000136528   0.0000000000  -0.0000000000  -0.0000125560
+    $end"""
+
+
+def test_turbomole_parse_hessian(h2o_nprhessian):
+    """Test parsing of unproject Turbomole Hessian for water."""
+    hessian = parse_hessian(h2o_nprhessian)
+    assert hessian.shape == (9, 9)
+    eigvals, _ = np.linalg.eigh(hessian)
+    assert eigvals[-1] == pytest.approx(1.12157030e+00)

--- a/qcengine/programs/turbomole/harvester.py
+++ b/qcengine/programs/turbomole/harvester.py
@@ -113,9 +113,7 @@ def harvest(input_model, stdout, **outfiles):
         qcvars["N ATOMS"] = gradient.size // 3
 
     # Prefer unprojected 'nprhessian' over projected 'hessian'.
-    hessian_text = outfiles.get("nprhessian", None)
-    if hessian_text is None:
-        hessian_text = outfiles.get("hessian", None)
+    hessian_text = outfiles.get("nprhessian", outfiles.get("hessian", None))
 
     if hessian_text is not None:
         hessian = parse_hessian(hessian_text)

--- a/qcengine/programs/turbomole/harvester.py
+++ b/qcengine/programs/turbomole/harvester.py
@@ -92,7 +92,7 @@ def parse_hessian(hessian):
 
     hess_items = [item for item in split if is_float(item)]
     coord_num = int(sqrt(len(hess_items)))
-    assert coord_num ** 2 == len(hess_items)
+    assert coord_num**2 == len(hess_items)
     hessian = np.array(hess_items, dtype=float).reshape(-1, coord_num)
 
     return hessian
@@ -118,7 +118,7 @@ def harvest(input_model, stdout, **outfiles):
     if hessian_text is None:
         hessian_text = outfiles.get("hessian", None)
 
-    if hessian_text is not None: 
+    if hessian_text is not None:
         hessian = parse_hessian(hessian_text)
         qcvars["N ATOMS"] = hessian.shape[0] // 3
     else:

--- a/qcengine/programs/turbomole/harvester.py
+++ b/qcengine/programs/turbomole/harvester.py
@@ -1,4 +1,3 @@
-import itertools as it
 from math import sqrt
 import re
 from decimal import Decimal

--- a/qcengine/programs/turbomole/harvester.py
+++ b/qcengine/programs/turbomole/harvester.py
@@ -1,4 +1,5 @@
 import itertools as it
+from math import sqrt
 import re
 from decimal import Decimal
 
@@ -12,9 +13,6 @@ def parse_decimal(regex, text, method="search"):
     matches = getattr(with_float, method)(text)
 
     if method == "search":
-        # groups = matches.groups()
-        # if len(groups) == 1:
-        # groups = ("", groups[0])
         matches = [matches.groups()]
     return [(method, Decimal(energy)) for method, energy in matches]
 
@@ -83,35 +81,19 @@ def parse_gradient(gradient):
     return grad
 
 
-def parse_nprhessian(nprhessian):
-    lines = [l.strip() for l in nprhessian.strip().split("\n")]
-    assert lines[0] == "$nprhessian"
-    assert lines[-1] == "$end"
+def parse_hessian(hessian):
+    first_hessian = hessian.strip().split("$")[1]
+    split = first_hessian.split()
+    hess_type = split.pop(0)
+    assert hess_type in ("nprhessian", "hessian")
 
-    hess_lines = [line.split()[2:] for line in lines[1:-1]]
-    atom_num = int(lines[-2].split()[0])
-    hessian = np.array(list(it.chain(*hess_lines)), dtype=float)
-    hessian = hessian.reshape(atom_num, atom_num)
+    def is_float(str_):
+        return "." in str_
 
-    return hessian
-
-
-def parse_hessian(hessian, size):
-    lines = [l.strip() for l in hessian.strip().split("\n")]
-    assert lines[0] == "$hessian"
-    assert lines[-1] == "$end"
-
-    hess_lines = list()
-    for line in lines[1:-1]:
-        line = line.strip()
-        if line == "$hessian (projected)":
-            break
-        hess_lines.append(line.split()[2:])
-    else:
-        raise Exception("'$hessian (projected)' line was not encountered!")
-
-    hessian = np.array(list(it.chain(*hess_lines)), dtype=float)
-    hessian = hessian.reshape(size, size)
+    hess_items = [item for item in split if is_float(item)]
+    coord_num = int(sqrt(len(hess_items)))
+    assert coord_num ** 2 == len(hess_items)
+    hessian = np.array(hess_items, dtype=float).reshape(-1, coord_num)
 
     return hessian
 
@@ -131,13 +113,15 @@ def harvest(input_model, stdout, **outfiles):
         gradient = parse_gradient(outfiles["gradient"])
         qcvars["N ATOMS"] = gradient.size // 3
 
-    hessian = None
-    if "nprhessian" in outfiles:
-        hessian = parse_nprhessian(outfiles["nprhessian"])
-    if "hessian" in outfiles:
-        size = input_model.geometry.size
-        hessian = parse_hessian(outfiles["hessian"], size)
-    if hessian:
+    # Prefer unprojected 'nprhessian' over projected 'hessian'.
+    hessian_text = outfiles.get("nprhessian", None)
+    if hessian_text is None:
+        hessian_text = outfiles.get("hessian", None)
+
+    if hessian_text is not None: 
+        hessian = parse_hessian(hessian_text)
         qcvars["N ATOMS"] = hessian.shape[0] // 3
+    else:
+        hessian = None
 
     return qcvars, gradient, hessian

--- a/qcengine/programs/turbomole/runner.py
+++ b/qcengine/programs/turbomole/runner.py
@@ -210,7 +210,7 @@ class TurbomoleHarness(ProgramHarness):
         if input_model.driver.derivative_int() == 2:
             freq_command = "NumForce -level cc2" if ricc2_calculation else "aoforce"
             # NumForce seems to ignore the nprhessian command and will always
-            # write to hessian
+            # write to unprojected and projected Hessian to "hessian".
             hessian_outfile = "hessian" if ricc2_calculation else "nprhessian"
             commands.append(freq_command)
             # Add some keywords to the control file


### PR DESCRIPTION
## Description
Parsing Turbomole Hessian was faulty for bigger molecules. This was found [here](https://github.com/eljost/pysisyphus/issues/173). As the present code in QCEngine is derived from my own project [pysisyphus](https://github.com/eljost/pysisyphus) I want to provide my fix here.

I didn't add test for a big Hessian, but I have a 500 kb Hessian file at hand. If you tell me where I could put this file I could include a proper test. I refrained from including the file inline as a pytest.fixture ...

## Changelog description
Fixed Hessian-parsing for bigger molecules >= 60 atoms.

## Status
- [x] Code base linted
- [x] Ready to go

Regarding the linting ... i formatted the files I modified using Black, but there appear to be other "unlinted" files, which I did not modify here: 

```bash
make format
[...]
black qcengine
reformatted qcengine/config.py
reformatted qcengine/programs/cfour/runner.py
reformatted qcengine/programs/gamess/runner.py
reformatted qcengine/programs/nwchem/runner.py
reformatted qcengine/programs/molpro.py

All done! ✨ 🍰 ✨
5 files reformatted, 96 files left unchanged.
```
Locally, I ran all Turbomole tests and they passed.
