### PR TITLE
Updated docstrings and function annotations for compute and compute_procedure

### DIFF
--- a/docs/source/environment.rst
+++ b/docs/source/environment.rst
@@ -24,11 +24,11 @@ The configuration file operated based on the current node descriptor and can be 
     >>> qcng.get_config()
     <JobConfig ncores=2 memory=2.506 scratch_directory=None>
 
-    >>> qcng.get_config(local_options={"scratch_directory": "/tmp"})
+    >>> qcng.get_config(task_config={"scratch_directory": "/tmp"})
     <JobConfig ncores=2 memory=2.506 scratch_directory='/tmp'>
 
     >>> os.environ["SCRATCH"] = "/my_scratch"
-    >>> qcng.get_config(local_options={"scratch_directory": "$SCRATCH"})
+    >>> qcng.get_config(task_config={"scratch_directory": "$SCRATCH"})
     <JobConfig ncores=2 memory=2.506 scratch_directory='/my_scratch'>
 
 Global Environment

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -106,11 +106,11 @@ Each of these options can be specified by the user as well.
     >>> qcng.get_config()
     <JobConfig ncores=2 memory=2.506 scratch_directory=None>
 
-    >>> qcng.get_config(local_options={"scratch_directory": "/tmp"})
+    >>> qcng.get_config(task_config={"scratch_directory": "/tmp"})
     <JobConfig ncores=2 memory=2.506 scratch_directory='/tmp'>
 
     >>> os.environ["SCRATCH"] = "/my_scratch"
-    >>> qcng.get_config(local_options={"scratch_directory": "$SCRATCH"})
+    >>> qcng.get_config(task_config={"scratch_directory": "$SCRATCH"})
     <JobConfig ncores=2 memory=2.506 scratch_directory='/my_scratch'>
 
 Program and Procedure Information

--- a/qcengine/config.py
+++ b/qcengine/config.py
@@ -267,28 +267,28 @@ def parse_environment(data: Dict[str, Any]) -> Dict[str, Any]:
     return ret
 
 
-def get_config(*, hostname: Optional[str] = None, local_options: Dict[str, Any] = None) -> TaskConfig:
+def get_config(*, hostname: Optional[str] = None, task_config: Dict[str, Any] = None) -> TaskConfig:
     """
     Returns the configuration key for qcengine.
     """
 
-    if local_options is None:
-        local_options = {}
+    if task_config is None:
+        task_config = {}
 
-    local_options = parse_environment(local_options)
+    task_config = parse_environment(task_config)
     config = {}
 
     # Node data
     node = get_node_descriptor(hostname)
     ncores = node.ncores or get_global("ncores")
-    config["scratch_directory"] = local_options.pop("scratch_directory", node.scratch_directory)
-    config["retries"] = local_options.pop("retries", node.retries)
+    config["scratch_directory"] = task_config.pop("scratch_directory", node.scratch_directory)
+    config["retries"] = task_config.pop("retries", node.retries)
 
     # Jobs per node
-    jobs_per_node = local_options.pop("jobs_per_node", None) or node.jobs_per_node
+    jobs_per_node = task_config.pop("jobs_per_node", None) or node.jobs_per_node
 
     # Handle memory
-    memory = local_options.pop("memory", None)
+    memory = task_config.pop("memory", None)
     if memory is None:
         memory = node.memory or get_global("memory")
         memory_coeff = 1 - node.memory_safety_factor / 100
@@ -297,21 +297,21 @@ def get_config(*, hostname: Optional[str] = None, local_options: Dict[str, Any] 
     config["memory"] = memory
 
     # Get the number of cores available to each task
-    ncores = local_options.pop("ncores", int(ncores / jobs_per_node))
+    ncores = task_config.pop("ncores", int(ncores / jobs_per_node))
     if ncores < 1:
         raise KeyError("Number of jobs per node exceeds the number of available cores.")
 
     config["ncores"] = ncores
-    config["nnodes"] = local_options.pop("nnodes", 1)
+    config["nnodes"] = task_config.pop("nnodes", 1)
 
     # Add in the MPI launch command template
     config["mpiexec_command"] = node.mpiexec_command
     config["use_mpiexec"] = node.is_batch_node or config["nnodes"] > 1
-    config["cores_per_rank"] = local_options.get("cores_per_rank", 1)
+    config["cores_per_rank"] = task_config.get("cores_per_rank", 1)
 
     # Override any settings
-    if local_options is not None:
-        config.update(local_options)
+    if task_config is not None:
+        config.update(task_config)
 
     # Make sure mpirun command is defined if needed
     if config["use_mpiexec"] and config["mpiexec_command"] is None:

--- a/qcengine/programs/model.py
+++ b/qcengine/programs/model.py
@@ -1,9 +1,9 @@
 import abc
 import logging
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from pydantic import BaseModel
-from qcelemental.models import AtomicInput, AtomicResult
+from qcelemental.models import AtomicInput, AtomicResult, FailedOperation
 
 from qcengine.exceptions import KnownErrorException
 from qcengine.config import TaskConfig
@@ -30,7 +30,18 @@ class ProgramHarness(BaseModel, abc.ABC):
         super().__init__(**{**self._defaults, **kwargs})
 
     @abc.abstractmethod
-    def compute(self, input_data: AtomicInput, config: TaskConfig) -> AtomicResult:
+    def compute(self, input_data: AtomicInput, config: TaskConfig) -> Union[AtomicResult, FailedOperation]:
+        """Top-level compute method to be implemented for every ProgramHarness
+
+        Note:
+            This method behave in any of the following ways:
+                1. Return AtomicResult upon successful completion of a calculation
+                2. Return FailedOperation object if an operation was unsuccessful or raised an exception. This is most
+                    likely to occur if the underlying QC package has a QCSchema API that catches exceptions and
+                    returns them as FailedOperation objects to end users.
+                3. Raise an exception if a computation failed. The raised exception will be handled by the
+                    qcng.compute() method and either raised or packaged as a FailedOperation object.
+        """
         pass
 
     @staticmethod

--- a/qcengine/programs/tests/test_canonical_config.py
+++ b/qcengine/programs/tests/test_canonical_config.py
@@ -92,7 +92,7 @@ def test_local_options_memory_gib(program, model, keywords, memory_trickery, req
 
     config = qcng.config.get_config(
         hostname="something",
-        local_options={
+        task_config={
             "ncores": 1,
             "nnodes": 1,
             "memory": 1.555,
@@ -157,7 +157,7 @@ def test_local_options_scratch(program, model, keywords):
 
     config = qcng.config.get_config(
         hostname="something",
-        local_options={
+        task_config={
             "scratch_directory": scratch_directory,
             "scratch_messy": True,
         },
@@ -234,7 +234,7 @@ def test_local_options_ncores(program, model, keywords, ncores):
 
     config = qcng.config.get_config(
         hostname="something",
-        local_options={
+        task_config={
             "ncores": ncores,
             "nnodes": 1,
         },

--- a/qcengine/programs/tests/test_canonical_fields.py
+++ b/qcengine/programs/tests/test_canonical_fields.py
@@ -39,7 +39,7 @@ def test_protocol_native(program, model, keywords, native):
     }
     config = qcng.config.get_config(
         hostname="something",
-        local_options={
+        task_config={
             "ncores": 1,
             "nnodes": 1,
         },

--- a/qcengine/tests/test_config.py
+++ b/qcengine/tests/test_config.py
@@ -140,26 +140,26 @@ def test_config_default(opt_state_basic):
 
 
 def test_config_local_ncores(opt_state_basic):
-    config = qcng.config.get_config(hostname="something", local_options={"ncores": 10, "retries": 3})
+    config = qcng.config.get_config(hostname="something", task_config={"ncores": 10, "retries": 3})
     assert config.ncores == 10
     assert config.memory == 4
     assert config.retries == 3
 
 
 def test_config_local_njobs(opt_state_basic):
-    config = qcng.config.get_config(hostname="something", local_options={"jobs_per_node": 5})
+    config = qcng.config.get_config(hostname="something", task_config={"jobs_per_node": 5})
     assert config.ncores == 1
     assert pytest.approx(config.memory) == 0.8
 
 
 def test_config_local_njob_ncore(opt_state_basic):
-    config = qcng.config.get_config(hostname="something", local_options={"jobs_per_node": 3, "ncores": 1})
+    config = qcng.config.get_config(hostname="something", task_config={"jobs_per_node": 3, "ncores": 1})
     assert config.ncores == 1
     assert pytest.approx(config.memory, 0.1) == 1.33
 
 
 def test_config_local_njob_ncore_plus_memory(opt_state_basic):
-    config = qcng.config.get_config(hostname="something", local_options={"jobs_per_node": 3, "ncores": 1, "memory": 6})
+    config = qcng.config.get_config(hostname="something", task_config={"jobs_per_node": 3, "ncores": 1, "memory": 6})
     assert config.ncores == 1
     assert pytest.approx(config.memory, 0.1) == 6
 
@@ -167,7 +167,7 @@ def test_config_local_njob_ncore_plus_memory(opt_state_basic):
 def test_config_local_nnodes(opt_state_basic):
     # Give a warning that mentions that mpirun is needed if you define a multi-node task
     with pytest.raises(ValueError) as exc:
-        qcng.config.get_config(hostname="something", local_options={"nnodes": 10})
+        qcng.config.get_config(hostname="something", task_config={"nnodes": 10})
     assert "https://qcengine.readthedocs.io/en/stable/environment.html" in str(exc.value)
 
     # Test with an MPI run command
@@ -175,7 +175,7 @@ def test_config_local_nnodes(opt_state_basic):
         "nnodes": 4,
         "mpiexec_command": "mpirun -n {total_ranks} -N {ranks_per_node} --cpus-per-slot {cores_per_rank}",
     }
-    config = qcng.config.get_config(hostname="something", local_options=local_options)
+    config = qcng.config.get_config(hostname="something", task_config=local_options)
     assert config.use_mpiexec
     assert config.mpiexec_command.startswith("mpirun")
     assert create_mpi_invocation("hello_world", config) == [
@@ -191,7 +191,7 @@ def test_config_local_nnodes(opt_state_basic):
 
     # Change the number of cores per rank
     local_options["cores_per_rank"] = 2
-    config = qcng.config.get_config(hostname="something", local_options=local_options)
+    config = qcng.config.get_config(hostname="something", task_config=local_options)
     assert config.use_mpiexec
     assert config.mpiexec_command.startswith("mpirun")
     assert create_mpi_invocation("hello_world", config) == [
@@ -208,7 +208,7 @@ def test_config_local_nnodes(opt_state_basic):
 
 def test_config_validation(opt_state_basic):
     with pytest.raises(pydantic.ValidationError):
-        config = qcng.config.get_config(hostname="something", local_options={"bad": 10})
+        config = qcng.config.get_config(hostname="something", task_config={"bad": 10})
 
 
 def test_global_repr():
@@ -222,7 +222,7 @@ def test_batch_node(opt_state_basic):
     assert config.ncores == 24
     assert config.nnodes == 1
 
-    config = qcng.config.get_config(hostname="bn1", local_options={"nnodes": 2})
+    config = qcng.config.get_config(hostname="bn1", task_config={"nnodes": 2})
     assert config.use_mpiexec
     assert config.ncores == 24
     assert config.nnodes == 2

--- a/qcengine/util.py
+++ b/qcengine/util.py
@@ -19,7 +19,7 @@ from threading import Thread
 from typing import Any, BinaryIO, Dict, List, Optional, TextIO, Tuple, Union
 
 from pydantic import BaseModel, ValidationError
-from qcelemental.models import FailedOperation
+from qcelemental.models import AtomicResult, FailedOperation, OptimizationResult
 
 from qcengine.config import TaskConfig
 
@@ -142,17 +142,23 @@ def compute_wrapper(capture_output: bool = True, raise_error: bool = False) -> D
 
 
 def handle_output_metadata(
-    output_data: Union[Dict[str, Any], BaseModel],
+    output_data: Union[Dict[str, Any], "AtomicResult", "OptimizationResult", "FailedOperation"],
     metadata: Dict[str, Any],
     raise_error: bool = False,
     return_dict: bool = True,
-) -> Union[Dict[str, Any], BaseModel]:
+) -> Union[Dict[str, Any], "AtomicResult", "OptimizationResult", "FailedOperation"]:
     """
     Fuses general metadata and output together.
 
+    Parameters:
+        output_data: The original output object to be fused with metadata
+        metadata: Metadata produced by the compute_wrapper context manager
+        raise_error: Raise an exception if errors exist (True) or return FailedOperation (False)
+        return_dict: Return dictionary or object representation of data
+
     Returns
     -------
-    result : dict or pydantic.models.AtomicResult
+    result : AtomicResult, OptimizationResult, FailedOperation, or dict representation of any one.
         Output type depends on return_dict or a dict if an error was generated in model construction
     """
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
closes #348 

Still waiting on comment re: updating `local_config` -> `task_config` but wanted to provide these updates before I forgot.

## Changelog description
Updated docstrings and function annotations for compute and compute_procedure. Renamed kwarg `local_config` -> `task_config` to more clearly express that passed options become a `TaskConfig` argument.

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x ] Code base linted
- [ x] Ready to go
