### PR TITLE
Linted files and updated import ordering so linter passes again

### DIFF
--- a/qcengine/config.py
+++ b/qcengine/config.py
@@ -34,7 +34,7 @@ def get_global(key: Optional[str] = None) -> Union[str, Dict[str, Any]]:
     if _global_values is None:
         _global_values = {}
         _global_values["hostname"] = socket.gethostname()
-        _global_values["memory"] = round(psutil.virtual_memory().available / (1024 ** 3), 3)
+        _global_values["memory"] = round(psutil.virtual_memory().available / (1024**3), 3)
         _global_values["username"] = getpass.getuser()
 
         # Work through VMs and logical cores.

--- a/qcengine/programs/cfour/runner.py
+++ b/qcengine/programs/cfour/runner.py
@@ -90,7 +90,7 @@ class CFOURHarness(ProgramHarness):
 
         # Handle memory
         # for cfour, [GiB] --> [QW]
-        opts["memory_size"] = int(config.memory * (1024 ** 3) / 8)
+        opts["memory_size"] = int(config.memory * (1024**3) / 8)
         opts["mem_unit"] = "integerwords"
 
         # Handle molecule

--- a/qcengine/programs/gamess/runner.py
+++ b/qcengine/programs/gamess/runner.py
@@ -119,7 +119,7 @@ class GAMESSHarness(ProgramHarness):
         # * docs on mwords: "This is given in units of 1,000,000 words (as opposed to 1024*1024 words)"
         # * docs: "the memory required on each processor core for a run using p cores is therefore MEMDDI/p + MWORDS."
         # * int() rounds down
-        mwords_total = int(config.memory * (1024 ** 3) / 8e6)
+        mwords_total = int(config.memory * (1024**3) / 8e6)
 
         for mem_frac_replicated in (1, 0.5, 0.1, 0.75):
             mwords, memddi = self._partition(mwords_total, mem_frac_replicated, config.ncores)

--- a/qcengine/programs/molpro.py
+++ b/qcengine/programs/molpro.py
@@ -184,7 +184,7 @@ class MolproHarness(ProgramHarness):
                 unrestricted = True
 
             # Memory is in megawords per core for Molpro
-            memory_mw_core = int(config.memory * (1024 ** 3) / 8e6 / config.ncores)
+            memory_mw_core = int(config.memory * (1024**3) / 8e6 / config.ncores)
             input_file.append("memory,{},M".format(memory_mw_core))
             input_file.append("")
 

--- a/qcengine/programs/nwchem/runner.py
+++ b/qcengine/programs/nwchem/runner.py
@@ -2,10 +2,10 @@
 Calls the NWChem executable.
 """
 import copy
+import hashlib
 import logging
 import pprint
 import re
-import hashlib
 from decimal import Decimal
 from typing import Any, Dict, Optional, Tuple
 
@@ -168,7 +168,7 @@ class NWChemHarness(ErrorCorrectionProgramHarness):
         # * int() rounds down
         # * was [GiB] --> [B] c. v6.6 but fails in v7.0 probably b/c https://github.com/nwchemgit/nwchem/commit/fca382eab477c3e85548457bfceb1fc9be31b47c#diff-7baaf4807cc9b853af14d9127f63db47d706e12f697a98560bc98bb647ef8326
         #   * memory_size = int(config.memory * (1024 ** 3))
-        memory_size = int(config.memory * (1024 ** 3) / 8)
+        memory_size = int(config.memory * (1024**3) / 8)
         if config.use_mpiexec:  # It is the memory per MPI rank
             memory_size //= config.nnodes * config.ncores // config.cores_per_rank
         opts["memory"] = memory_size

--- a/qcengine/programs/turbomole/runner.py
+++ b/qcengine/programs/turbomole/runner.py
@@ -154,7 +154,7 @@ class TurbomoleHarness(ProgramHarness):
         control = turbomolerec["infiles"]["control"]
 
         # Calculate total available memory in MB
-        mem_mb = config.memory * (1024 ** 3) / 1e6
+        mem_mb = config.memory * (1024**3) / 1e6
         ri_fraction = 0.25
         # Total amount of memory allocated to ricore
         ricore = 0


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
local `make lint` and the GitHub workflow linting do not pass due to a few files not being correctly formatted or having imports incorrectly sorted. This PR simply lints/resorts imports so these checks pass again.

## Changelog description
Linted and ordered imports for a few `runner.py` files.

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [ x] Code base linted
- [ x] Ready to go
