### PR TITLE
fix CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,12 +18,12 @@ jobs:
       matrix:
         cfg:
           - conda-env: psi
-            python-version: 3.6
+            python-version: 3.7
             label: Psi4-release
             runs-on: ubuntu-latest
 
           - conda-env: psi-nightly
-            python-version: 3.9
+            python-version: 3.10
             label: Psi4-nightly
             runs-on: ubuntu-latest
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,7 +23,7 @@ jobs:
             runs-on: ubuntu-latest
 
           - conda-env: psi-nightly
-            python-version: 3.10
+            python-version: "3.10"
             label: Psi4-nightly
             runs-on: ubuntu-latest
 

--- a/devtools/conda-envs/docs-cf.yaml
+++ b/devtools/conda-envs/docs-cf.yaml
@@ -25,4 +25,4 @@ dependencies:
   - codecov
 
   - pip:
-     - git+git://github.com/MolSSI/qcarchive-sphinx-theme#egg=qcarchive_sphinx_theme
+     - git+https://github.com/MolSSI/qcarchive-sphinx-theme#egg=qcarchive_sphinx_theme

--- a/devtools/conda-envs/opt-disp.yaml
+++ b/devtools/conda-envs/opt-disp.yaml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - psi4=1.5*
+  - psi4
   - blas=*=mkl  # not needed but an example of disuading solver from openblas and old psi
   #- intel-openmp!=2019.5
   - rdkit

--- a/devtools/conda-envs/psi.yaml
+++ b/devtools/conda-envs/psi.yaml
@@ -3,7 +3,7 @@ channels:
   - psi4
   - conda-forge
 dependencies:
-  - psi4=1.4
+  - psi4=1.5
   - dftd3
   - geometric
   - intel-openmp!=2019.5


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
Latest psi4 is v1.5 . And mixing release psi4 and nightly deps is trouble in this age of shifting L2.

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
