### PR TITLE
dir structure in execute and properties in Cfour

### DIFF
--- a/qcengine/programs/cfour/germinate.py
+++ b/qcengine/programs/cfour/germinate.py
@@ -3,23 +3,28 @@ from typing import Any, Dict
 from qcengine.exceptions import InputError
 
 
-def muster_modelchem(method: str, derint: int) -> Dict[str, Any]:
+def muster_modelchem(method: str, driver: "DriverEnum") -> Dict[str, Any]:
     """Converts the QC method into CFOUR keywords."""
 
     method = method.lower()
     opts = {}
 
-    if derint == 0:
-        if method == "cfour":
-            pass  # permit clean operation of sandwich mode
-        else:
-            opts["deriv_level"] = "zero"
+    if driver == "properties":
+        pass
+    else:
+        derint = driver.derivative_int()
 
-    elif derint == 1:
-        opts["deriv_level"] = "first"
+        if derint == 0:
+            if method == "cfour":
+                pass  # permit clean operation of sandwich mode
+            else:
+                opts["deriv_level"] = "zero"
 
-    elif derint == 2:
-        opts["vibration"] = "exact"
+        elif derint == 1:
+            opts["deriv_level"] = "first"
+
+        elif derint == 2:
+            opts["vibration"] = "exact"
 
     if method == "cfour":
         pass

--- a/qcengine/programs/cfour/runner.py
+++ b/qcengine/programs/cfour/runner.py
@@ -98,7 +98,7 @@ class CFOURHarness(ProgramHarness):
         opts.update(moldata["keywords"])
 
         # Handle calc type and quantum chemical method
-        mdcopts = muster_modelchem(input_model.model.method, input_model.driver.derivative_int())
+        mdcopts = muster_modelchem(input_model.model.method, input_model.driver)
         opts.update(mdcopts)
 
         # Handle basis set

--- a/qcengine/programs/tests/test_canonical_fields.py
+++ b/qcengine/programs/tests/test_canonical_fields.py
@@ -2,6 +2,7 @@ import pprint
 import re
 
 import pytest
+import qcelemental as qcel
 from qcelemental.models import AtomicInput
 
 import qcengine as qcng
@@ -78,7 +79,10 @@ def test_protocol_native(program, model, keywords, native):
     #  <<  Test
 
     if native == "none":
-        assert ret.native_files == {}
+        if qcel.__version__ >= "v0.25":
+            assert ret.native_files == {}
+        else:
+            assert ret.native_files is None
     elif native == "input":
         assert list(ret.native_files.keys()) == ["input"]
 

--- a/qcengine/programs/tests/test_canonical_fields.py
+++ b/qcengine/programs/tests/test_canonical_fields.py
@@ -78,7 +78,7 @@ def test_protocol_native(program, model, keywords, native):
     #  <<  Test
 
     if native == "none":
-        assert ret.native_files is None
+        assert ret.native_files == {}
     elif native == "input":
         assert list(ret.native_files.keys()) == ["input"]
 

--- a/qcengine/tests/test_procedures.py
+++ b/qcengine/tests/test_procedures.py
@@ -49,6 +49,7 @@ def test_geometric_psi4(input_data, optimizer):
     for single in ret.trajectory:
         assert "scf_properties" in single.keywords
         assert "WIBERG_LOWDIN_INDICES" in single.extras["qcvars"] or "WIBERG LOWDIN INDICES" in single.extras["qcvars"]
+        # TODO: old WIBERG qcvar used underscore; new one uses space. covering bases here but remove someday
 
 
 @using("psi4")

--- a/qcengine/util.py
+++ b/qcengine/util.py
@@ -596,7 +596,9 @@ def disk_files(
         for fl, content in infiles.items():
             omode = "wb" if fl in as_binary else "w"
             filename = lwd / fl
-            with open(filename, omode) as fp:
+            if filename.parent != lwd:
+                filename.parent.mkdir(parents=True, exist_ok=True)
+            with filename.open(omode) as fp:
                 fp.write(content)
                 LOGGER.info(f"... Writing ({omode}): {filename}")
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
One test fix and some miscellaneous little improvements. The change to `execute` is the only slightly daring one, I think.

## Changelog description
- [x] For Cfour harness, skip explicit `DERIV_LEVEL` setting when `driver = "properties"`. This is needed for DBOC, for example, where any user deriv level (at least 0 or 1) halts calc.
- [x] ~Fix `AtomicResult.native_files` empty test after qcel 0.25.~ Separated to #366 
- [x] Add Wiberg variable note David Dotson suggested in review.
- [x] In `qcengine.execute`, allow directory structure in files to be written to scratch/work directory. This is needed for some Psi4 tests where we copy in a plugin directory.

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
