### PR TITLE
gradients with ghost atoms for cfour and nwchem

### DIFF
--- a/qcengine/programs/cfour/harvester.py
+++ b/qcengine/programs/cfour/harvester.py
@@ -1224,11 +1224,11 @@ def harvest(in_mol: Molecule, method: str, c4out, **largs):
         if in_mol.fix_com and in_mol.fix_orientation:
             # Impose input frame if important as signalled by fix_*=T
             return_mol = in_mol
-            _, data = out_mol.align(in_mol, atoms_map=False, mols_align=True, verbose=0)
+            _, data = out_mol.align(in_mol, atoms_map=False, mols_align=True, generic_ghosts=True, verbose=0)
             mill = data["mill"]
 
         else:
-            return_mol, _ = in_mol.align(out_mol, atoms_map=False, mols_align=True, verbose=0)
+            return_mol, _ = in_mol.align(out_mol, atoms_map=False, mols_align=True, generic_ghosts=True, verbose=0)
             mill = qcel.molutil.compute_scramble(
                 len(in_mol.symbols), do_resort=False, do_shift=False, do_rotate=False, do_mirror=False
             )  # identity AlignmentMill
@@ -1330,7 +1330,9 @@ def harvest_GRD(grd):
     grad = []
     for at in range(Nat):
         mline = grd[at + 1].split()
-        el = "GH" if int(float(mline[0])) == 0 else qcel.periodictable.to_E(int(float(mline[0])))
+
+        # "@Xe" is potentially dangerous bypass for ghosts
+        el = "@Xe" if int(float(mline[0])) == 0 else qcel.periodictable.to_E(int(float(mline[0])))
         molxyz += "%s %16s %16s %16s\n" % (el, mline[-3], mline[-2], mline[-1])
         lline = grd[at + 1 + Nat].split()
         grad.append([float(lline[-3]), float(lline[-2]), float(lline[-1])])

--- a/qcengine/programs/nwchem/harvester.py
+++ b/qcengine/programs/nwchem/harvester.py
@@ -1202,6 +1202,8 @@ def harvest(
         # If present, align the gradients and hessian with the original molecular coordinates
         #  NWChem rotates the coordinates of the input molecule. `calc_mol` contains the coordinates for the
         #  rotated molecule, which we can use to determine how to rotate the gradients/hessian
+        # Beware the loose symmetrizer that can noticably change the input geometry.
+        #  `geometry__autosym = 1d-4` tightens.
         return_mol = in_mol
         _, data = calc_mol.align(in_mol, atoms_map=True, verbose=0, mols_align=0.01)
         mill = data["mill"]

--- a/qcengine/programs/nwchem/runner.py
+++ b/qcengine/programs/nwchem/runner.py
@@ -179,7 +179,9 @@ class NWChemHarness(ErrorCorrectionProgramHarness):
 
         if opts.pop("geometry__noautoz", False):
             molcmd = re.sub(r"geometry ([^\n]*)", r"geometry \1 noautoz", molcmd)
-        if val := opts.pop("geometry__autosym", False):
+        # someday when minimum >=py38 `if val := opts.pop("geometry__autosym", False):`
+        if opts.get("geometry__autosym", False):
+            val = opts.pop("geometry__autosym")
             molcmd = re.sub(r"geometry ([^\n]*)", rf"geometry \1 autosym {val}", molcmd)
 
         # Handle calc type and quantum chemical method

--- a/qcengine/programs/nwchem/runner.py
+++ b/qcengine/programs/nwchem/runner.py
@@ -179,6 +179,8 @@ class NWChemHarness(ErrorCorrectionProgramHarness):
 
         if opts.pop("geometry__noautoz", False):
             molcmd = re.sub(r"geometry ([^\n]*)", r"geometry \1 noautoz", molcmd)
+        if val := opts.pop("geometry__autosym", False):
+            molcmd = re.sub(r"geometry ([^\n]*)", rf"geometry \1 autosym {val}", molcmd)
 
         # Handle calc type and quantum chemical method
         mdccmd, mdcopts = muster_modelchem(input_model.model.method, input_model.driver, opts.pop("qc_module", False))


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->

## Changelog description
- [x] Expand the Xenon hack so that Cfour can run and harvest gradient jobs when molecule has ghost atoms.
- [x] Allow `geometry__autosym` keyword for NWChem. NWChem has a loose symmetrizer that can change the working geometry slightly more than QCEngine expects. Now that can be dialed back.
- [x] Test gradients with ghosts for Cfour (newly works), NWChem (newly matches), GAMESS (already skipped even for energies), and Psi4 (already worked).

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
