### PR TITLE
Fix test after qcel v0.25

### DIFF
--- a/qcengine/programs/tests/test_canonical_fields.py
+++ b/qcengine/programs/tests/test_canonical_fields.py
@@ -2,6 +2,7 @@ import pprint
 import re
 
 import pytest
+import qcelemental as qcel
 from qcelemental.models import AtomicInput
 
 import qcengine as qcng
@@ -78,7 +79,10 @@ def test_protocol_native(program, model, keywords, native):
     #  <<  Test
 
     if native == "none":
-        assert ret.native_files is None
+        if qcel.util.parse_version(qcel.__version__) < qcel.util.parse_version("0.25.0"):
+            assert ret.native_files is None
+        else:
+            assert ret.native_files == {}
     elif native == "input":
         assert list(ret.native_files.keys()) == ["input"]
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
Since only tests are affected, retain compatibility with pre/post v0.25

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
