### PR TITLE
stdsuite testing remp2, oo, dfcc

### DIFF
--- a/qcengine/programs/tests/standard_suite_contracts.py
+++ b/qcengine/programs/tests/standard_suite_contracts.py
@@ -691,21 +691,41 @@ def contractual_lccd(
         expected = True
         if (
             (
-                (qc_module == "psi4-occ" and reference == "rhf" and corl_type in ["df", "cd"] and method == "lccd")
-                or (qc_module == "cfour-ncc" and reference in ["rhf"] and method == "lccd")
-                or (qc_module == "nwchem-tce" and reference in ["rhf", "uhf"] and method == "lccd")
-                or (qc_module == "gamess" and reference in ["rhf"] and method == "lccd")
+                (
+                    (qc_module == "psi4-occ" and reference == "rhf" and corl_type in ["df", "cd"] and method == "lccd")
+                    or (qc_module == "cfour-ncc" and reference in ["rhf"] and method == "lccd")
+                    or (qc_module == "nwchem-tce" and reference in ["rhf", "uhf"] and method == "lccd")
+                    or (qc_module == "gamess" and reference in ["rhf"] and method == "lccd")
+                )
+                and pv in ["LCCD SAME-SPIN CORRELATION ENERGY", "LCCD OPPOSITE-SPIN CORRELATION ENERGY"]
             )
-            and pv in ["LCCD SAME-SPIN CORRELATION ENERGY", "LCCD OPPOSITE-SPIN CORRELATION ENERGY"]
-        ) or (
-            (qc_module == "nwchem-tce" and reference in ["rohf"] and method in ["lccd"])
-            and pv
-            in [
-                "LCCD SAME-SPIN CORRELATION ENERGY",
-                "LCCD OPPOSITE-SPIN CORRELATION ENERGY",
-                "LCCD SINGLES ENERGY",
-                "LCCD DOUBLES ENERGY",
-            ]
+            or (
+                (qc_module == "nwchem-tce" and reference in ["rohf"] and method in ["lccd"])
+                and pv
+                in [
+                    "LCCD SAME-SPIN CORRELATION ENERGY",
+                    "LCCD OPPOSITE-SPIN CORRELATION ENERGY",
+                    "LCCD SINGLES ENERGY",
+                    "LCCD DOUBLES ENERGY",
+                ]
+            )
+            or (
+                (
+                    qc_module == "psi4-occ"
+                    and reference in ["rhf", "uhf", "rohf"]
+                    and corl_type in ["conv", "df", "cd"]
+                    and method == "olccd"
+                )
+                and pv
+                in [
+                    "LCCD CORRELATION ENERGY",
+                    "LCCD TOTAL ENERGY",
+                    "LCCD SAME-SPIN CORRELATION ENERGY",
+                    "LCCD SINGLES ENERGY",
+                    "LCCD DOUBLES ENERGY",
+                    "LCCD OPPOSITE-SPIN CORRELATION ENERGY",
+                ]
+            )
         ):
             expected = False
 

--- a/qcengine/programs/tests/standard_suite_contracts.py
+++ b/qcengine/programs/tests/standard_suite_contracts.py
@@ -1,6 +1,40 @@
 # This file consolidates the expectations of what properties/QCVariables
 #  a method should produce and what in practice a QC program does produce.
 
+__all__ = [
+    "contractual_current",
+    "contractual_hf",
+    "contractual_mp2",
+    "contractual_mp2p5",
+    "contractual_mp3",
+    "contractual_mp4_prsdq_pr",
+    "contractual_mp4",
+    "contractual_cisd",
+    "contractual_qcisd",
+    "contractual_qcisd_prt_pr",
+    "contractual_fci",
+    "contractual_lccd",
+    "contractual_lccsd",
+    "contractual_ccd",
+    "contractual_ccsd",
+    "contractual_ccsdpt_prccsd_pr",
+    "contractual_ccsd_prt_pr",
+    "contractual_accsd_prt_pr",
+    "contractual_ccsdt",
+    "contractual_ccsdt1a",
+    "contractual_ccsdt1b",
+    "contractual_ccsdt2",
+    "contractual_ccsdt3",
+    "contractual_ccsdt_prq_pr",
+    "contractual_ccsdtq",
+    "contractual_olccd",
+    "contractual_occd",
+    "contractual_dft_current",
+    "query_qcvar",
+    "query_has_qcvar",
+]
+
+
 from typing import Any, Tuple
 
 from qcengine.programs.qcvar_identities_resources import qcvars_to_atomicproperties
@@ -187,7 +221,7 @@ def contractual_mp2(
                         qc_module == "psi4-occ"
                         and reference == "rhf"
                         and corl_type in ["df", "cd"]
-                        and method in ["mp2", "mp2.5", "mp3", "lccd", "ccsd", "ccsd(t)"]
+                        and method in ["mp2", "mp2.5", "mp3", "lccd", "ccsd", "ccsd(t)", "a-ccsd(t)", "olccd", "occd"]
                     )
                 )
                 and pv in ["MP2 SAME-SPIN CORRELATION ENERGY", "MP2 OPPOSITE-SPIN CORRELATION ENERGY"]
@@ -690,9 +724,9 @@ def contractual_ccsd(
                     )
                     or (
                         qc_module == "psi4-occ"
-                        and reference == "rhf"
+                        and reference in ["rhf", "uhf"]
                         and corl_type in ["df", "cd"]
-                        and method in ["ccsd", "ccsd(t)"]
+                        and method in ["ccsd", "ccsd(t)", "a-ccsd(t)"]
                     )
                     or (qc_module in ["cfour-vcc"] and reference in ["rhf", "uhf"] and method in ["ccsd+t(ccsd)"])
                 )
@@ -1034,6 +1068,48 @@ def contractual_olccd(
 
     for pv in contractual_qcvars:
         expected = True
+        if (
+            (
+                (qc_module == "psi4-occ" and reference == "rhf" and corl_type in ["df", "cd"] and method == "olccd")
+            )
+            and pv in ["OLCCD SAME-SPIN CORRELATION ENERGY", "OLCCD OPPOSITE-SPIN CORRELATION ENERGY"]
+        ):
+            expected = False
+
+        yield (pv, pv, expected)
+
+
+def contractual_occd(
+    qc_module: str, driver: str, reference: str, method: str, corl_type: str, fcae: str
+) -> Tuple[str, str, bool]:
+    """Of the list of QCVariables an ideal OCCD should produce, returns whether or
+    not each is expected, given the calculation circumstances (like QC program).
+
+    {_contractual_docstring}
+    """
+    contractual_qcvars = [
+        "HF TOTAL ENERGY",
+        "OCCD CORRELATION ENERGY",
+        "OCCD TOTAL ENERGY",
+        "OCCD REFERENCE CORRECTION ENERGY",
+        "OCCD SAME-SPIN CORRELATION ENERGY",
+        "OCCD OPPOSITE-SPIN CORRELATION ENERGY",
+    ]
+    if driver == "gradient" and method == "occd":
+        contractual_qcvars.append("OCCD TOTAL GRADIENT")
+    elif driver == "hessian" and method == "occd":
+        # contractual_qcvars.append("OCCD TOTAL GRADIENT")
+        contractual_qcvars.append("OCCD TOTAL HESSIAN")
+
+    for pv in contractual_qcvars:
+        expected = True
+        if (
+            (
+                (qc_module == "psi4-occ" and reference in ["rhf", "uhf", "rohf"] and corl_type in ["df", "cd"] and method == "occd")
+            )
+            and pv in ["OCCD SAME-SPIN CORRELATION ENERGY", "OCCD OPPOSITE-SPIN CORRELATION ENERGY"]
+        ):
+            expected = False
 
         yield (pv, pv, expected)
 

--- a/qcengine/programs/tests/standard_suite_contracts.py
+++ b/qcengine/programs/tests/standard_suite_contracts.py
@@ -29,6 +29,8 @@ __all__ = [
     "contractual_ccsdtq",
     "contractual_olccd",
     "contractual_occd",
+    "contractual_occd_prt_pr",
+    "contractual_aoccd_prt_pr",
     "contractual_dft_current",
     "query_qcvar",
     "query_has_qcvar",
@@ -221,7 +223,7 @@ def contractual_mp2(
                         qc_module == "psi4-occ"
                         and reference == "rhf"
                         and corl_type in ["df", "cd"]
-                        and method in ["mp2", "mp2.5", "mp3", "lccd", "ccsd", "ccsd(t)", "a-ccsd(t)", "olccd", "occd"]
+                        and method in ["mp2", "mp2.5", "mp3", "lccd", "ccsd", "ccsd(t)", "a-ccsd(t)", "olccd", "occd", "occd(t)", "a-occd(t)"]
                     )
                 )
                 and pv in ["MP2 SAME-SPIN CORRELATION ENERGY", "MP2 OPPOSITE-SPIN CORRELATION ENERGY"]
@@ -1105,10 +1107,66 @@ def contractual_occd(
         expected = True
         if (
             (
-                (qc_module == "psi4-occ" and reference in ["rhf", "uhf", "rohf"] and corl_type in ["df", "cd"] and method == "occd")
+                (qc_module == "psi4-occ" and reference in ["rhf", "uhf", "rohf"] and corl_type in ["df", "cd"] and method in ["occd", "occd(t)", "a-occd(t)"])
             )
             and pv in ["OCCD SAME-SPIN CORRELATION ENERGY", "OCCD OPPOSITE-SPIN CORRELATION ENERGY"]
         ):
+            expected = False
+
+        yield (pv, pv, expected)
+
+
+def contractual_occd_prt_pr(
+    qc_module: str, driver: str, reference: str, method: str, corl_type: str, fcae: str
+) -> Tuple[str, str, bool]:
+    """Of the list of QCVariables an ideal OCCD(T) should produce, returns whether or
+    not each is expected, given the calculation circumstances (like QC program).
+
+    {_contractual_docstring}
+    """
+    contractual_qcvars = [
+        "HF TOTAL ENERGY",
+        "O(T) CORRECTION ENERGY",
+        "OCCD(T) CORRELATION ENERGY",
+        "OCCD(T) TOTAL ENERGY",
+    ]
+    if driver == "gradient" and method == "occd(t)":
+        contractual_qcvars.append("OCCD(T) TOTAL GRADIENT")
+    elif driver == "hessian" and method == "occd(t)":
+        # contractual_qcvars.append("OCCD(T) TOTAL GRADIENT")
+        contractual_qcvars.append("OCCD(T) TOTAL HESSIAN")
+
+    for pv in contractual_qcvars:
+        expected = True
+        if False:
+            expected = False
+
+        yield (pv, pv, expected)
+
+
+def contractual_aoccd_prt_pr(
+    qc_module: str, driver: str, reference: str, method: str, corl_type: str, fcae: str
+) -> Tuple[str, str, bool]:
+    """Of the list of QCVariables an ideal A-OCCD(T) (aka Lambda-OCCD(T), aka OCCD(aT) should produce, returns whether or
+    not each is expected, given the calculation circumstances (like QC program).
+
+    {_contractual_docstring}
+    """
+    contractual_qcvars = [
+        "HF TOTAL ENERGY",
+        "A-O(T) CORRECTION ENERGY",
+        "A-OCCD(T) CORRELATION ENERGY",
+        "A-OCCD(T) TOTAL ENERGY",
+    ]
+    if driver == "gradient" and method == "a-occd(t)":
+        contractual_qcvars.append("A-OCCD(T) TOTAL GRADIENT")
+    elif driver == "hessian" and method == "a-occd(t)":
+        # contractual_qcvars.append("A-OCCD(T) TOTAL GRADIENT")
+        contractual_qcvars.append("A-OCCD(T) TOTAL HESSIAN")
+
+    for pv in contractual_qcvars:
+        expected = True
+        if False:
             expected = False
 
         yield (pv, pv, expected)

--- a/qcengine/programs/tests/standard_suite_contracts.py
+++ b/qcengine/programs/tests/standard_suite_contracts.py
@@ -13,7 +13,7 @@ __all__ = [
     "contractual_qcisd",
     "contractual_qcisd_prt_pr",
     "contractual_fci",
-    "contractual_remp",
+    "contractual_remp2",
     "contractual_lccd",
     "contractual_lccsd",
     "contractual_ccd",
@@ -31,7 +31,7 @@ __all__ = [
     "contractual_omp2",
     "contractual_omp2p5",
     "contractual_omp3",
-    "contractual_oremp",
+    "contractual_oremp2",
     "contractual_olccd",
     "contractual_occd",
     "contractual_occd_prt_pr",
@@ -228,8 +228,8 @@ def contractual_mp2(
                         qc_module == "psi4-occ"
                         and reference == "rhf"
                         and corl_type in ["df", "cd"]
-                        and method in [ "mp2",  "mp2.5",  "mp3",  "remp",  "lccd", "ccsd", "ccsd(t)", "a-ccsd(t)",
-                                       "omp2", "omp2.5", "omp3", "oremp", "olccd", "occd", "occd(t)", "a-occd(t)"]
+                        and method in [ "mp2",  "mp2.5",  "mp3",  "remp2",  "lccd", "ccsd", "ccsd(t)", "a-ccsd(t)",
+                                       "omp2", "omp2.5", "omp3", "oremp2", "olccd", "occd", "occd(t)", "a-occd(t)"]
                     )
                 )
                 and pv in ["MP2 SAME-SPIN CORRELATION ENERGY", "MP2 OPPOSITE-SPIN CORRELATION ENERGY"]
@@ -250,7 +250,7 @@ def contractual_mp2(
                 ]
             )
             or (
-                ((qc_module == "psi4-occ" and reference == "rohf" and corl_type == "conv" and method in ["omp2", "omp2.5", "omp3", "oremp", "olccd"]))
+                ((qc_module == "psi4-occ" and reference == "rohf" and corl_type == "conv" and method in ["omp2", "omp2.5", "omp3", "oremp2", "olccd"]))
                 and pv
                 in [
                     "MP2 CORRELATION ENERGY",
@@ -572,46 +572,46 @@ def contractual_fci(
         yield (pv, pv, expected)
 
 
-def contractual_remp(
+def contractual_remp2(
     qc_module: str, driver: str, reference: str, method: str, corl_type: str, fcae: str
 ) -> Tuple[str, str, bool]:
-    f"""Of the list of QCVariables an ideal REMP should produce, returns whether or
+    f"""Of the list of QCVariables an ideal REMP2 should produce, returns whether or
     not each is expected, given the calculation circumstances (like QC program).
 
     {_contractual_docstring}
     """
     contractual_qcvars = [
         "HF TOTAL ENERGY",
-        "REMP CORRELATION ENERGY",
-        "REMP TOTAL ENERGY",
-        "REMP SAME-SPIN CORRELATION ENERGY",
-        "REMP SINGLES ENERGY",
-        "REMP DOUBLES ENERGY",
-        "REMP OPPOSITE-SPIN CORRELATION ENERGY",
+        "REMP2 CORRELATION ENERGY",
+        "REMP2 TOTAL ENERGY",
+        "REMP2 SAME-SPIN CORRELATION ENERGY",
+        "REMP2 SINGLES ENERGY",
+        "REMP2 DOUBLES ENERGY",
+        "REMP2 OPPOSITE-SPIN CORRELATION ENERGY",
     ]
-    if driver == "gradient" and method == "remp":
-        contractual_qcvars.append("REMP TOTAL GRADIENT")
-    elif driver == "hessian" and method == "remp":
-        # contractual_qcvars.append("REMP TOTAL GRADIENT")
-        contractual_qcvars.append("REMP TOTAL HESSIAN")
+    if driver == "gradient" and method == "remp2":
+        contractual_qcvars.append("REMP2 TOTAL GRADIENT")
+    elif driver == "hessian" and method == "remp2":
+        # contractual_qcvars.append("REMP2 TOTAL GRADIENT")
+        contractual_qcvars.append("REMP2 TOTAL HESSIAN")
 
     for pv in contractual_qcvars:
         expected = True
         if (
             (
-                (qc_module == "psi4-occ" and reference == "rhf" and corl_type in ["df", "cd"] and method == "remp")
+                (qc_module == "psi4-occ" and reference == "rhf" and corl_type in ["df", "cd"] and method == "remp2")
             )
-            and pv in ["REMP SAME-SPIN CORRELATION ENERGY", "REMP OPPOSITE-SPIN CORRELATION ENERGY"]
+            and pv in ["REMP2 SAME-SPIN CORRELATION ENERGY", "REMP2 OPPOSITE-SPIN CORRELATION ENERGY"]
         ) or (
-            (qc_module == "psi4-occ" and reference in ["rhf", "uhf", "rohf"] and corl_type in ["conv", "df", "cd"] and method == "oremp")
+            (qc_module == "psi4-occ" and reference in ["rhf", "uhf", "rohf"] and corl_type in ["conv", "df", "cd"] and method == "oremp2")
             and pv
             in [
-                "REMP CORRELATION ENERGY",
-                "REMP TOTAL ENERGY",
-                "REMP SAME-SPIN CORRELATION ENERGY",
-                "REMP SINGLES ENERGY",
-                "REMP DOUBLES ENERGY",
-                "REMP OPPOSITE-SPIN CORRELATION ENERGY",
+                "REMP2 CORRELATION ENERGY",
+                "REMP2 TOTAL ENERGY",
+                "REMP2 SAME-SPIN CORRELATION ENERGY",
+                "REMP2 SINGLES ENERGY",
+                "REMP2 DOUBLES ENERGY",
+                "REMP2 OPPOSITE-SPIN CORRELATION ENERGY",
             ]
         ):
             expected = False
@@ -1218,36 +1218,36 @@ def contractual_omp3(
         yield (pv, pv, expected)
 
 
-def contractual_oremp(
+def contractual_oremp2(
     qc_module: str, driver: str, reference: str, method: str, corl_type: str, fcae: str
 ) -> Tuple[str, str, bool]:
-    """Of the list of QCVariables an ideal OREMP should produce, returns whether or
+    """Of the list of QCVariables an ideal OREMP2 should produce, returns whether or
     not each is expected, given the calculation circumstances (like QC program).
 
     {_contractual_docstring}
     """
     contractual_qcvars = [
         "HF TOTAL ENERGY",
-        "OREMP CORRELATION ENERGY",
-        "OREMP TOTAL ENERGY",
-        "OREMP REFERENCE CORRECTION ENERGY",
-        "OREMP SAME-SPIN CORRELATION ENERGY",
-        "OREMP OPPOSITE-SPIN CORRELATION ENERGY",
+        "OREMP2 CORRELATION ENERGY",
+        "OREMP2 TOTAL ENERGY",
+        "OREMP2 REFERENCE CORRECTION ENERGY",
+        "OREMP2 SAME-SPIN CORRELATION ENERGY",
+        "OREMP2 OPPOSITE-SPIN CORRELATION ENERGY",
     ]
-    if driver == "gradient" and method == "oremp":
-        contractual_qcvars.append("OREMP TOTAL GRADIENT")
-    elif driver == "hessian" and method == "oremp":
-        # contractual_qcvars.append("OREMP TOTAL GRADIENT")
-        contractual_qcvars.append("OREMP TOTAL HESSIAN")
+    if driver == "gradient" and method == "oremp2":
+        contractual_qcvars.append("OREMP2 TOTAL GRADIENT")
+    elif driver == "hessian" and method == "oremp2":
+        # contractual_qcvars.append("OREMP2 TOTAL GRADIENT")
+        contractual_qcvars.append("OREMP2 TOTAL HESSIAN")
 
     for pv in contractual_qcvars:
         expected = True
         if (
             (
-                # usual for oo (qc_module == "psi4-occ" and reference == "rhf" and corl_type in ["df", "cd"] and method == "oremp")
-                (qc_module == "psi4-occ" and reference in ["rhf", "uhf", "rohf"] and corl_type in ["df", "cd"] and method == "oremp")
+                # usual for oo (qc_module == "psi4-occ" and reference == "rhf" and corl_type in ["df", "cd"] and method == "oremp2")
+                (qc_module == "psi4-occ" and reference in ["rhf", "uhf", "rohf"] and corl_type in ["df", "cd"] and method == "oremp2")
             )
-            and pv in ["OREMP SAME-SPIN CORRELATION ENERGY", "OREMP OPPOSITE-SPIN CORRELATION ENERGY"]
+            and pv in ["OREMP2 SAME-SPIN CORRELATION ENERGY", "OREMP2 OPPOSITE-SPIN CORRELATION ENERGY"]
         ):
             expected = False
 

--- a/qcengine/programs/tests/standard_suite_contracts.py
+++ b/qcengine/programs/tests/standard_suite_contracts.py
@@ -228,8 +228,25 @@ def contractual_mp2(
                         qc_module == "psi4-occ"
                         and reference == "rhf"
                         and corl_type in ["df", "cd"]
-                        and method in [ "mp2",  "mp2.5",  "mp3",  "remp2",  "lccd", "ccsd", "ccsd(t)", "a-ccsd(t)",
-                                       "omp2", "omp2.5", "omp3", "oremp2", "olccd", "occd", "occd(t)", "a-occd(t)"]
+                        and method
+                        in [
+                            "mp2",
+                            "mp2.5",
+                            "mp3",
+                            "remp2",
+                            "lccd",
+                            "ccsd",
+                            "ccsd(t)",
+                            "a-ccsd(t)",
+                            "omp2",
+                            "omp2.5",
+                            "omp3",
+                            "oremp2",
+                            "olccd",
+                            "occd",
+                            "occd(t)",
+                            "a-occd(t)",
+                        ]
                     )
                 )
                 and pv in ["MP2 SAME-SPIN CORRELATION ENERGY", "MP2 OPPOSITE-SPIN CORRELATION ENERGY"]
@@ -250,7 +267,14 @@ def contractual_mp2(
                 ]
             )
             or (
-                ((qc_module == "psi4-occ" and reference == "rohf" and corl_type == "conv" and method in ["omp2", "omp2.5", "omp3", "oremp2", "olccd"]))
+                (
+                    (
+                        qc_module == "psi4-occ"
+                        and reference == "rohf"
+                        and corl_type == "conv"
+                        and method in ["omp2", "omp2.5", "omp3", "oremp2", "olccd"]
+                    )
+                )
                 and pv
                 in [
                     "MP2 CORRELATION ENERGY",
@@ -330,9 +354,16 @@ def contractual_mp2p5(
             )
             and pv in ["MP2.5 SAME-SPIN CORRELATION ENERGY", "MP2.5 OPPOSITE-SPIN CORRELATION ENERGY"]
         ) or (
-            ((qc_module == "psi4-detci" and method in ["mp3"])
-            or (qc_module == "psi4-occ" and reference == "rohf" and corl_type in ["conv", "df", "cd"] and method in ["omp2.5", "omp3"]))
-                # Note SS/OS might be obtainable but no reference to verify
+            (
+                (qc_module == "psi4-detci" and method in ["mp3"])
+                or (
+                    qc_module == "psi4-occ"
+                    and reference == "rohf"
+                    and corl_type in ["conv", "df", "cd"]
+                    and method in ["omp2.5", "omp3"]
+                )
+            )
+            # Note SS/OS might be obtainable but no reference to verify
             and pv
             in [
                 "MP2.5 CORRELATION ENERGY",
@@ -375,37 +406,48 @@ def contractual_mp3(
         expected = True
         if (
             (
-                (qc_module.startswith("cfour") and method in ["mp3", "mp4(sdq)", "mp4"])
-                or (
-                    qc_module == "psi4-occ"
-                    and reference == "rhf"
-                    and corl_type in ["df", "cd"]
-                    and method in ["mp2.5", "mp3", "omp2.5", "omp3"]
+                (
+                    (qc_module.startswith("cfour") and method in ["mp3", "mp4(sdq)", "mp4"])
+                    or (
+                        qc_module == "psi4-occ"
+                        and reference == "rhf"
+                        and corl_type in ["df", "cd"]
+                        and method in ["mp2.5", "mp3", "omp2.5", "omp3"]
+                    )
+                    or (qc_module.startswith("nwchem") and method in ["mp3", "mp4"])
                 )
-                or (qc_module.startswith("nwchem") and method in ["mp3", "mp4"])
+                and pv in ["MP3 SAME-SPIN CORRELATION ENERGY", "MP3 OPPOSITE-SPIN CORRELATION ENERGY"]
             )
-            and pv in ["MP3 SAME-SPIN CORRELATION ENERGY", "MP3 OPPOSITE-SPIN CORRELATION ENERGY"]
-        ) or (
-            ((qc_module == "psi4-detci" and method == "mp3"))
-            and pv
-            in [
-                "MP3 SAME-SPIN CORRELATION ENERGY",
-                "MP3 OPPOSITE-SPIN CORRELATION ENERGY",
-                "MP3 SINGLES ENERGY",
-                "MP3 DOUBLES ENERGY",
-            ]
-        ) or (
-            ((qc_module == "psi4-occ" and reference == "rohf" and corl_type in ["conv", "df", "cd"] and method in ["omp2.5", "omp3"]))
-            # Note SS/OS might be obtainable but no reference to verify
-            and pv
-            in [
-                "MP3 CORRELATION ENERGY",
-                "MP3 TOTAL ENERGY",
-                "MP3 SAME-SPIN CORRELATION ENERGY",
-                "MP3 SINGLES ENERGY",
-                "MP3 DOUBLES ENERGY",
-                "MP3 OPPOSITE-SPIN CORRELATION ENERGY",
-            ]
+            or (
+                ((qc_module == "psi4-detci" and method == "mp3"))
+                and pv
+                in [
+                    "MP3 SAME-SPIN CORRELATION ENERGY",
+                    "MP3 OPPOSITE-SPIN CORRELATION ENERGY",
+                    "MP3 SINGLES ENERGY",
+                    "MP3 DOUBLES ENERGY",
+                ]
+            )
+            or (
+                (
+                    (
+                        qc_module == "psi4-occ"
+                        and reference == "rohf"
+                        and corl_type in ["conv", "df", "cd"]
+                        and method in ["omp2.5", "omp3"]
+                    )
+                )
+                # Note SS/OS might be obtainable but no reference to verify
+                and pv
+                in [
+                    "MP3 CORRELATION ENERGY",
+                    "MP3 TOTAL ENERGY",
+                    "MP3 SAME-SPIN CORRELATION ENERGY",
+                    "MP3 SINGLES ENERGY",
+                    "MP3 DOUBLES ENERGY",
+                    "MP3 OPPOSITE-SPIN CORRELATION ENERGY",
+                ]
+            )
         ):
             expected = False
 
@@ -598,12 +640,15 @@ def contractual_remp2(
     for pv in contractual_qcvars:
         expected = True
         if (
-            (
-                (qc_module == "psi4-occ" and reference == "rhf" and corl_type in ["df", "cd"] and method == "remp2")
-            )
+            ((qc_module == "psi4-occ" and reference == "rhf" and corl_type in ["df", "cd"] and method == "remp2"))
             and pv in ["REMP2 SAME-SPIN CORRELATION ENERGY", "REMP2 OPPOSITE-SPIN CORRELATION ENERGY"]
         ) or (
-            (qc_module == "psi4-occ" and reference in ["rhf", "uhf", "rohf"] and corl_type in ["conv", "df", "cd"] and method == "oremp2")
+            (
+                qc_module == "psi4-occ"
+                and reference in ["rhf", "uhf", "rohf"]
+                and corl_type in ["conv", "df", "cd"]
+                and method == "oremp2"
+            )
             and pv
             in [
                 "REMP2 CORRELATION ENERGY",
@@ -1138,11 +1183,8 @@ def contractual_omp2(
     for pv in contractual_qcvars:
         expected = True
         if (
-            (
-                (qc_module == "psi4-occ" and reference == "rhf" and corl_type in ["df", "cd"] and method == "omp2")
-            )
-            and pv in ["OMP2 SAME-SPIN CORRELATION ENERGY", "OMP2 OPPOSITE-SPIN CORRELATION ENERGY"]
-        ):
+            (qc_module == "psi4-occ" and reference == "rhf" and corl_type in ["df", "cd"] and method == "omp2")
+        ) and pv in ["OMP2 SAME-SPIN CORRELATION ENERGY", "OMP2 OPPOSITE-SPIN CORRELATION ENERGY"]:
             expected = False
 
         yield (pv, pv, expected)
@@ -1173,11 +1215,8 @@ def contractual_omp2p5(
     for pv in contractual_qcvars:
         expected = True
         if (
-            (
-                (qc_module == "psi4-occ" and reference == "rhf" and corl_type in ["df", "cd"] and method == "omp2.5")
-            )
-            and pv in ["OMP2.5 SAME-SPIN CORRELATION ENERGY", "OMP2.5 OPPOSITE-SPIN CORRELATION ENERGY"]
-        ):
+            (qc_module == "psi4-occ" and reference == "rhf" and corl_type in ["df", "cd"] and method == "omp2.5")
+        ) and pv in ["OMP2.5 SAME-SPIN CORRELATION ENERGY", "OMP2.5 OPPOSITE-SPIN CORRELATION ENERGY"]:
             expected = False
 
         yield (pv, pv, expected)
@@ -1208,11 +1247,8 @@ def contractual_omp3(
     for pv in contractual_qcvars:
         expected = True
         if (
-            (
-                (qc_module == "psi4-occ" and reference == "rhf" and corl_type in ["df", "cd"] and method == "omp3")
-            )
-            and pv in ["OMP3 SAME-SPIN CORRELATION ENERGY", "OMP3 OPPOSITE-SPIN CORRELATION ENERGY"]
-        ):
+            (qc_module == "psi4-occ" and reference == "rhf" and corl_type in ["df", "cd"] and method == "omp3")
+        ) and pv in ["OMP3 SAME-SPIN CORRELATION ENERGY", "OMP3 OPPOSITE-SPIN CORRELATION ENERGY"]:
             expected = False
 
         yield (pv, pv, expected)
@@ -1243,12 +1279,14 @@ def contractual_oremp2(
     for pv in contractual_qcvars:
         expected = True
         if (
+            # usual for oo (qc_module == "psi4-occ" and reference == "rhf" and corl_type in ["df", "cd"] and method == "oremp2")
             (
-                # usual for oo (qc_module == "psi4-occ" and reference == "rhf" and corl_type in ["df", "cd"] and method == "oremp2")
-                (qc_module == "psi4-occ" and reference in ["rhf", "uhf", "rohf"] and corl_type in ["df", "cd"] and method == "oremp2")
+                qc_module == "psi4-occ"
+                and reference in ["rhf", "uhf", "rohf"]
+                and corl_type in ["df", "cd"]
+                and method == "oremp2"
             )
-            and pv in ["OREMP2 SAME-SPIN CORRELATION ENERGY", "OREMP2 OPPOSITE-SPIN CORRELATION ENERGY"]
-        ):
+        ) and pv in ["OREMP2 SAME-SPIN CORRELATION ENERGY", "OREMP2 OPPOSITE-SPIN CORRELATION ENERGY"]:
             expected = False
 
         yield (pv, pv, expected)
@@ -1279,11 +1317,8 @@ def contractual_olccd(
     for pv in contractual_qcvars:
         expected = True
         if (
-            (
-                (qc_module == "psi4-occ" and reference == "rhf" and corl_type in ["df", "cd"] and method == "olccd")
-            )
-            and pv in ["OLCCD SAME-SPIN CORRELATION ENERGY", "OLCCD OPPOSITE-SPIN CORRELATION ENERGY"]
-        ):
+            (qc_module == "psi4-occ" and reference == "rhf" and corl_type in ["df", "cd"] and method == "olccd")
+        ) and pv in ["OLCCD SAME-SPIN CORRELATION ENERGY", "OLCCD OPPOSITE-SPIN CORRELATION ENERGY"]:
             expected = False
 
         yield (pv, pv, expected)
@@ -1315,10 +1350,12 @@ def contractual_occd(
         expected = True
         if (
             (
-                (qc_module == "psi4-occ" and reference in ["rhf", "uhf", "rohf"] and corl_type in ["df", "cd"] and method in ["occd", "occd(t)", "a-occd(t)"])
+                qc_module == "psi4-occ"
+                and reference in ["rhf", "uhf", "rohf"]
+                and corl_type in ["df", "cd"]
+                and method in ["occd", "occd(t)", "a-occd(t)"]
             )
-            and pv in ["OCCD SAME-SPIN CORRELATION ENERGY", "OCCD OPPOSITE-SPIN CORRELATION ENERGY"]
-        ):
+        ) and pv in ["OCCD SAME-SPIN CORRELATION ENERGY", "OCCD OPPOSITE-SPIN CORRELATION ENERGY"]:
             expected = False
 
         yield (pv, pv, expected)

--- a/qcengine/programs/tests/standard_suite_ref.py
+++ b/qcengine/programs/tests/standard_suite_ref.py
@@ -683,41 +683,36 @@ _std_suite = [
             "OMP2 CORRELATION ENERGY": -0.204465719970,  # occ, tight
             "OMP2 SAME-SPIN CORRELATION ENERGY": -0.054616313597,  # occ, tight
             "OMP2 TOTAL GRADIENT": np.array(  # occ, tight
-             [ 0., 0.,  0.004107528173,
-               0., 0., -0.004107528173]
+                [0.0, 0.0, 0.004107528173, 0.0, 0.0, -0.004107528173]
             ).reshape((-1, 3)),
             "OMP2.5 REFERENCE CORRECTION ENERGY": 0.000571728736,  # occ, tight
             "OMP2.5 CORRELATION ENERGY": -0.205686837008,  # occ, tight
             "OMP2.5 SAME-SPIN CORRELATION ENERGY": -0.052301161413,  # occ, tight
             "OMP2.5 TOTAL GRADIENT": np.array(  # occ, tight
-              [ 0.,   0.000000000000,     0.002017001118,
-                0.,   0.000000000000,    -0.002017001118]
+                [0.0, 0.000000000000, 0.002017001118, 0.0, 0.000000000000, -0.002017001118]
             ).reshape((-1, 3)),
             "OMP3 REFERENCE CORRECTION ENERGY": 0.000467222482,  # occ, tight
             "OMP3 CORRELATION ENERGY": -0.206935131375,  # occ, tight
             "OMP3 SAME-SPIN CORRELATION ENERGY": -0.050007707662,  # occ, tight
             "OMP3 TOTAL GRADIENT": np.array(  # occ, tight
-                [   0., 0., -0.000007413433,
-                    0., 0.,  0.000007413433]
+                [0.0, 0.0, -0.000007413433, 0.0, 0.0, 0.000007413433]
             ).reshape((-1, 3)),
             "OREMP2 REFERENCE CORRECTION ENERGY": 0.000553304064,  # occ, tight
             "OREMP2 CORRELATION ENERGY": -0.208942935871,  # occ, tight
             "OREMP2 SAME-SPIN CORRELATION ENERGY": -0.049683397802,  # occ, tight
             "OREMP2 TOTAL GRADIENT": np.array(  # occ, tight
-              [ 0.,  0.000000000000,     0.002830089047,
-                0.,  0.000000000000,    -0.002830089047]
+                [0.0, 0.000000000000, 0.002830089047, 0.0, 0.000000000000, -0.002830089047]
             ).reshape((-1, 3)),
             "OLCCD REFERENCE CORRECTION ENERGY": 0.0005522939,  # p4n
             "OLCCD CORRELATION ENERGY": -0.2104417743,  # p4n
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.0484443079,  # occ
-            "OLCCD TOTAL GRADIENT": np.array(  # occ
-                       [ 0.,             0.,             0.00339205449,
-                         0.,             0.,            -0.00339205449]
-            ).reshape((-1, 3)),
+            "OLCCD TOTAL GRADIENT": np.array([0.0, 0.0, 0.00339205449, 0.0, 0.0, -0.00339205449]).reshape(  # occ
+                (-1, 3)
+            ),
             "OCCD REFERENCE CORRECTION ENERGY": 0.000511277,  # qchem
             "OCCD CORRELATION ENERGY": -0.208649453,  # qchem
             "OCCD TOTAL GRADIENT": np.array(  # qchem, rearranged
-                [    0.00000000,    0.00000000, 0.00184797, 0, 0, -0.00184797]
+                [0.00000000, 0.00000000, 0.00184797, 0, 0, -0.00184797]
             ).reshape((-1, 3)),
             "O(T) CORRECTION ENERGY": _knownmissing,
             "A-O(T) CORRECTION ENERGY": _knownmissing,
@@ -1529,46 +1524,66 @@ _std_suite = [
             "OMP2 CORRELATION ENERGY": -0.224125328536,  # occ, tight
             "OMP2 SAME-SPIN CORRELATION ENERGY": -0.058141813805,  # occ, tight
             "OMP2 TOTAL GRADIENT": np.array(  # occ, tight
-                [ 0.,  0.,  0.012093662469,
-                  0.,  0.006798848063,   -0.006046831235,
-                  0., -0.006798848063,   -0.006046831235]
+                [0.0, 0.0, 0.012093662469, 0.0, 0.006798848063, -0.006046831235, 0.0, -0.006798848063, -0.006046831235]
             ).reshape((-1, 3)),
             "OMP2.5 REFERENCE CORRECTION ENERGY": 0.001534835679,  # occ, tight
             "OMP2.5 CORRELATION ENERGY": -0.225651726817,  # occ, tight
             "OMP2.5 SAME-SPIN CORRELATION ENERGY": -0.055105451161,  # occ, tight
             "OMP2.5 TOTAL GRADIENT": np.array(  # occ, tight
-              [ 0.,   0.000000000000,     0.008280964210,
-                0.,   0.004780030747,    -0.004140482105,
-                0.,  -0.004780030747,    -0.004140482105]
+                [
+                    0.0,
+                    0.000000000000,
+                    0.008280964210,
+                    0.0,
+                    0.004780030747,
+                    -0.004140482105,
+                    0.0,
+                    -0.004780030747,
+                    -0.004140482105,
+                ]
             ).reshape((-1, 3)),
             "OMP3 REFERENCE CORRECTION ENERGY": 0.000953570304,  # occ, tight
             "OMP3 CORRELATION ENERGY": -0.227372086899,  # occ, tight
             "OMP3 SAME-SPIN CORRELATION ENERGY": -0.052239106558,  # occ, tight
             "OMP3 TOTAL GRADIENT": np.array(  # occ, tight
-                [   0.,  0.000000000000,     0.004803850255,
-                    0.,  0.002953922342,    -0.002401925128,
-                    0., -0.002953922342,    -0.002401925128]
+                [
+                    0.0,
+                    0.000000000000,
+                    0.004803850255,
+                    0.0,
+                    0.002953922342,
+                    -0.002401925128,
+                    0.0,
+                    -0.002953922342,
+                    -0.002401925128,
+                ]
             ).reshape((-1, 3)),
             "OREMP2 REFERENCE CORRECTION ENERGY": 0.00128167136578,  # occ, tight
             "OREMP2 CORRELATION ENERGY": -0.23069139385821,  # occ, tight
             "OREMP2 SAME-SPIN CORRELATION ENERGY": -0.05189818473696,  # occ, tight
             "OREMP2 TOTAL GRADIENT": np.array(  # occ, tight
-               [    0., -0.000000000000,     0.009103029917,
-                    0.,  0.005405690204,    -0.004551514958,
-                    0., -0.005405690204,    -0.004551514958]
+                [
+                    0.0,
+                    -0.000000000000,
+                    0.009103029917,
+                    0.0,
+                    0.005405690204,
+                    -0.004551514958,
+                    0.0,
+                    -0.005405690204,
+                    -0.004551514958,
+                ]
             ).reshape((-1, 3)),
             "OLCCD REFERENCE CORRECTION ENERGY": 0.0011895155,  # p4n
             "OLCCD CORRELATION ENERGY": -0.2330452995,  # p4n
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.0503175223,  # occ
             "OLCCD TOTAL GRADIENT": np.array(  # occ
-                       [ 0.,              0.,              0.009755099696,
-                        -0.,              0.005854889163, -0.004877549848,
-                         0.,             -0.005854889163, -0.004877549848]
+                [0.0, 0.0, 0.009755099696, -0.0, 0.005854889163, -0.004877549848, 0.0, -0.005854889163, -0.004877549848]
             ).reshape((-1, 3)),
             "OCCD REFERENCE CORRECTION ENERGY": 0.001123344,  # qchem
             "OCCD CORRELATION ENERGY": -0.229118050,  # qchem
             "OCCD TOTAL GRADIENT": np.array(  # qchem, rearranged
-                [ 0., 0., 0.00727331, 0., 0.00447444, -0.00363665, 0., -0.00447444, -0.00363665]
+                [0.0, 0.0, 0.00727331, 0.0, 0.00447444, -0.00363665, 0.0, -0.00447444, -0.00363665]
             ).reshape((-1, 3)),
             "O(T) CORRECTION ENERGY": _knownmissing,
             "A-O(T) CORRECTION ENERGY": _knownmissing,
@@ -2564,41 +2579,71 @@ _std_suite = [
             "OMP2 CORRELATION ENERGY": -0.272599646070,  # occ, tight
             "OMP2 SAME-SPIN CORRELATION ENERGY": -0.066843168345,  # occ, tight
             "OMP2 TOTAL GRADIENT": np.array(  # occ, tight
-              [ 0.,  0.000000000000,     0.001853244534,
-                0.,  0.000249902550,    -0.000926622267,
-                0., -0.000249902550,    -0.000926622267]
+                [
+                    0.0,
+                    0.000000000000,
+                    0.001853244534,
+                    0.0,
+                    0.000249902550,
+                    -0.000926622267,
+                    0.0,
+                    -0.000249902550,
+                    -0.000926622267,
+                ]
             ).reshape((-1, 3)),
             "OMP2.5 REFERENCE CORRECTION ENERGY": 0.001691543451,  # occ, tight
             "OMP2.5 CORRELATION ENERGY": -0.273211228305,  # occ, tight
             "OMP2.5 SAME-SPIN CORRELATION ENERGY": -0.063331759367,  # occ, tight
             "OMP2.5 TOTAL GRADIENT": np.array(  # occ, tight
-              [ 0.,   0.000000000000,    -0.002291101232,
-                0.,  -0.001990147396,     0.001145550616,
-                0.,   0.001990147396,     0.001145550616]
+                [
+                    0.0,
+                    0.000000000000,
+                    -0.002291101232,
+                    0.0,
+                    -0.001990147396,
+                    0.001145550616,
+                    0.0,
+                    0.001990147396,
+                    0.001145550616,
+                ]
             ).reshape((-1, 3)),
             "OMP3 REFERENCE CORRECTION ENERGY": 0.001090059672,  # occ, tight
             "OMP3 CORRELATION ENERGY": -0.274015056808,  # occ, tight
             "OMP3 SAME-SPIN CORRELATION ENERGY": -0.059986220382,  # occ, tight
             "OMP3 TOTAL GRADIENT": np.array(  # occ, tight
-                [   0.,  0.000000000000,    -0.006148152213,
-                    0., -0.004066707268,     0.003074076107,
-                    0.,  0.004066707268,     0.003074076107]
+                [
+                    0.0,
+                    0.000000000000,
+                    -0.006148152213,
+                    0.0,
+                    -0.004066707268,
+                    0.003074076107,
+                    0.0,
+                    0.004066707268,
+                    0.003074076107,
+                ]
             ).reshape((-1, 3)),
             "OREMP2 REFERENCE CORRECTION ENERGY": 0.001444328268,  # occ, tight
             "OREMP2 CORRELATION ENERGY": -0.277848169449,  # occ, tight
             "OREMP2 SAME-SPIN CORRELATION ENERGY": -0.059932090515,  # occ, tight
             "OREMP2 TOTAL GRADIENT": np.array(  # occ, tight
-              [ 0.,  0.000000000000,    -0.001616411571,
-                0., -0.001508635375,     0.000808205786,
-                0.,  0.001508635375,     0.000808205786]
+                [
+                    0.0,
+                    0.000000000000,
+                    -0.001616411571,
+                    0.0,
+                    -0.001508635375,
+                    0.000808205786,
+                    0.0,
+                    0.001508635375,
+                    0.000808205786,
+                ]
             ).reshape((-1, 3)),
             "OLCCD REFERENCE CORRECTION ENERGY": 0.0013521561,  # p4n
             "OLCCD CORRELATION ENERGY": -0.2800053174,  # p4n
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.0582676514,  # occ
             "OLCCD TOTAL GRADIENT": np.array(  # occ
-                       [ 0.,              0.,             -0.001040099489,
-                         0.,             -0.001127979233,  0.000520049745,
-                        -0.,              0.001127979233,  0.000520049745]
+                [0.0, 0.0, -0.001040099489, 0.0, -0.001127979233, 0.000520049745, -0.0, 0.001127979233, 0.000520049745]
             ).reshape((-1, 3)),
             "OCCD REFERENCE CORRECTION ENERGY": 0.001279242,  # qchem
             "OCCD CORRELATION ENERGY": -0.275418269,  # qchem
@@ -3454,51 +3499,101 @@ _std_suite = [
             "OMP2 CORRELATION ENERGY": -0.059864579866,  # occ, tight
             "OMP2 SAME-SPIN CORRELATION ENERGY": -0.001971155898,  # occ, tight
             "OMP2 TOTAL GRADIENT": np.array(  # occ, tight
-                [   0.,  0.000000000000,     0.012017558262,
-                    0.,  0.000000000000,    -0.011623172725,
-                    0.,  0.010549443964,    -0.000197192768,
-                    0., -0.010549443964,    -0.000197192768]
+                [
+                    0.0,
+                    0.000000000000,
+                    0.012017558262,
+                    0.0,
+                    0.000000000000,
+                    -0.011623172725,
+                    0.0,
+                    0.010549443964,
+                    -0.000197192768,
+                    0.0,
+                    -0.010549443964,
+                    -0.000197192768,
+                ]
             ).reshape((-1, 3)),
             "OMP2.5 REFERENCE CORRECTION ENERGY": 0.000564671059,  # occ, tight
             "OMP2.5 CORRELATION ENERGY": -0.067680196985,  # occ, tight
             "OMP2.5 SAME-SPIN CORRELATION ENERGY": -0.002198682496,  # occ, tight
             "OMP2.5 TOTAL GRADIENT": np.array(  # occ, tight
-              [ 0.,   0.000000000000,     0.010260851431,
-                0.,   0.000000000000,    -0.009981279417,
-                0.,   0.011818192519,    -0.000139786007,
-                0.,  -0.011818192519,    -0.000139786007]
+                [
+                    0.0,
+                    0.000000000000,
+                    0.010260851431,
+                    0.0,
+                    0.000000000000,
+                    -0.009981279417,
+                    0.0,
+                    0.011818192519,
+                    -0.000139786007,
+                    0.0,
+                    -0.011818192519,
+                    -0.000139786007,
+                ]
             ).reshape((-1, 3)),
             "OMP3 REFERENCE CORRECTION ENERGY": 0.000777674538,  # occ, tight
             "OMP3 CORRELATION ENERGY": -0.075531256945,  # occ, tight
             "OMP3 SAME-SPIN CORRELATION ENERGY": -0.002426022161,  # occ, tight
             "OMP3 TOTAL GRADIENT": np.array(  # occ, tight
-                [   0.,  0.000000000000,     0.008456348171,
-                    0.,  0.000000000000,    -0.008291902042,
-                    0.,  0.013097750811,    -0.000082223065,
-                    0., -0.013097750811,    -0.000082223065]
+                [
+                    0.0,
+                    0.000000000000,
+                    0.008456348171,
+                    0.0,
+                    0.000000000000,
+                    -0.008291902042,
+                    0.0,
+                    0.013097750811,
+                    -0.000082223065,
+                    0.0,
+                    -0.013097750811,
+                    -0.000082223065,
+                ]
             ).reshape((-1, 3)),
             "OREMP2 REFERENCE CORRECTION ENERGY": 0.001061018532,  # occ, tight
             "OREMP2 CORRELATION ENERGY": -0.078996001732,  # occ, tight
             "OREMP2 SAME-SPIN CORRELATION ENERGY": -0.002398210306,  # occ, tight
             "OREMP2 TOTAL GRADIENT": np.array(  # occ, tight
-              [ 0.,  0.000000000000,     0.005898073051,
-                0.,  0.000000000000,    -0.005790147152,
-                0.,  0.014384641403,    -0.000053962950,
-                0., -0.014384641403,    -0.000053962950]
+                [
+                    0.0,
+                    0.000000000000,
+                    0.005898073051,
+                    0.0,
+                    0.000000000000,
+                    -0.005790147152,
+                    0.0,
+                    0.014384641403,
+                    -0.000053962950,
+                    0.0,
+                    -0.014384641403,
+                    -0.000053962950,
+                ]
             ).reshape((-1, 3)),
             "OLCCD REFERENCE CORRECTION ENERGY": 0.0014842084,  # p4n
             "OLCCD CORRELATION ENERGY": -0.0847413506,  # p4n
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.0024486744,  # occ
             "OLCCD TOTAL GRADIENT": np.array(  # occ
-                       [ 0.,              0.,              0.002952428656,
-                         0.,              0.,             -0.002937832654,
-                        -0.,              0.015746258127, -0.000007298001,
-                         0.,             -0.015746258127, -0.000007298001]
+                [
+                    0.0,
+                    0.0,
+                    0.002952428656,
+                    0.0,
+                    0.0,
+                    -0.002937832654,
+                    -0.0,
+                    0.015746258127,
+                    -0.000007298001,
+                    0.0,
+                    -0.015746258127,
+                    -0.000007298001,
+                ]
             ).reshape((-1, 3)),
             "OCCD REFERENCE CORRECTION ENERGY": 0.001165795,  # qchem
             "OCCD CORRELATION ENERGY": -0.082188930,  # qchem
             "OCCD TOTAL GRADIENT": np.array(  # qchem, rearranged
-              [0, 0, 0.00520110, 0, 0, -0.00505850, 0., 0.01487527, -0.00007130, 0., -0.01487527, -0.00007130]
+                [0, 0, 0.00520110, 0, 0, -0.00505850, 0.0, 0.01487527, -0.00007130, 0.0, -0.01487527, -0.00007130]
             ).reshape((-1, 3)),
             "O(T) CORRECTION ENERGY": _knownmissing,
             "A-O(T) CORRECTION ENERGY": _knownmissing,
@@ -3747,46 +3842,76 @@ _std_suite = [
             "OMP2 CORRELATION ENERGY": -0.156193539287,  # occ, tight
             "OMP2 SAME-SPIN CORRELATION ENERGY": -0.035974458829,  # occ, tight
             "OMP2 TOTAL GRADIENT": np.array(  # occ, tight
-              [ 0.,  0.000000000000,     0.026928654402,
-                0.,  0.014250914503,    -0.013464327201,
-                0., -0.014250914503,    -0.013464327201]
+                [
+                    0.0,
+                    0.000000000000,
+                    0.026928654402,
+                    0.0,
+                    0.014250914503,
+                    -0.013464327201,
+                    0.0,
+                    -0.014250914503,
+                    -0.013464327201,
+                ]
             ).reshape((-1, 3)),
             "OMP2.5 REFERENCE CORRECTION ENERGY": 0.001173901427,  # occ, tight
             "OMP2.5 CORRELATION ENERGY": -0.164044987798,  # occ, tight
             "OMP2.5 SAME-SPIN CORRELATION ENERGY": -0.035847752938,  # occ, tight
             "OMP2.5 TOTAL GRADIENT": np.array(  # occ, tight
-              [ 0.,   0.000000000000,     0.027494393497,
-                0.,   0.014585953475,    -0.013747196748,
-                0.,  -0.014585953475,    -0.013747196748]
+                [
+                    0.0,
+                    0.000000000000,
+                    0.027494393497,
+                    0.0,
+                    0.014585953475,
+                    -0.013747196748,
+                    0.0,
+                    -0.014585953475,
+                    -0.013747196748,
+                ]
             ).reshape((-1, 3)),
             "OMP3 REFERENCE CORRECTION ENERGY": 0.001024209316,  # occ, tight
             "OMP3 CORRELATION ENERGY": -0.171933638522,  # occ, tight
             "OMP3 SAME-SPIN CORRELATION ENERGY": -0.035747352644,  # occ, tight
             "OMP3 TOTAL GRADIENT": np.array(  # occ, tight
-                [   0.,  0.000000000000,     0.028120207496,
-                    0.,  0.014956911575,    -0.014060103748,
-                    0., -0.014956911575,    -0.014060103748]
+                [
+                    0.0,
+                    0.000000000000,
+                    0.028120207496,
+                    0.0,
+                    0.014956911575,
+                    -0.014060103748,
+                    0.0,
+                    -0.014956911575,
+                    -0.014060103748,
+                ]
             ).reshape((-1, 3)),
             "OREMP2 REFERENCE CORRECTION ENERGY": 0.00111233720168,  # occ, tight
             "OREMP2 CORRELATION ENERGY": -0.17359939909712,  # occ, tight
             "OREMP2 SAME-SPIN CORRELATION ENERGY": -0.03496212583967,  # occ, tight
             "OREMP2 TOTAL GRADIENT": np.array(  # occ, tight
-                [   0.,  0.000000000000,     0.030225286483,
-                    0.,  0.016238459426,    -0.015112643242,
-                    0., -0.016238459426,    -0.015112643242]
+                [
+                    0.0,
+                    0.000000000000,
+                    0.030225286483,
+                    0.0,
+                    0.016238459426,
+                    -0.015112643242,
+                    0.0,
+                    -0.016238459426,
+                    -0.015112643242,
+                ]
             ).reshape((-1, 3)),
             "OLCCD REFERENCE CORRECTION ENERGY": 0.0011118724,  # p4n
             "OLCCD CORRELATION ENERGY": -0.1781057943,  # p4n
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.0344689234,  # occ
             "OLCCD TOTAL GRADIENT": np.array(  # occ
-                       [ 0.,              0.,              0.031877236853,
-                        -0.,              0.017265501329, -0.015938618427,
-                         0.,             -0.017265501329, -0.015938618427]
+                [0.0, 0.0, 0.031877236853, -0.0, 0.017265501329, -0.015938618427, 0.0, -0.017265501329, -0.015938618427]
             ).reshape((-1, 3)),
             "OCCD REFERENCE CORRECTION ENERGY": 0.000987794,  # qchem
             "OCCD CORRELATION ENERGY": -0.173720242,  # qchem
-            "OCCD TOTAL GRADIENT":  np.array(  # qchem, rearranged
-                [0., 0., 0.02915872, 0., 0.01575094, -0.01457936, 0., -0.01575094, -0.01457936]
+            "OCCD TOTAL GRADIENT": np.array(  # qchem, rearranged
+                [0.0, 0.0, 0.02915872, 0.0, 0.01575094, -0.01457936, 0.0, -0.01575094, -0.01457936]
             ).reshape((-1, 3)),
             "O(T) CORRECTION ENERGY": _knownmissing,
             "A-O(T) CORRECTION ENERGY": _knownmissing,
@@ -4023,46 +4148,86 @@ _std_suite = [
             "OMP2 CORRELATION ENERGY": -0.197071770029,  # occ, tight
             "OMP2 SAME-SPIN CORRELATION ENERGY": -0.042459313035,  # occ, tight
             "OMP2 TOTAL GRADIENT": np.array(  # occ, tight
-                [   0.,  0.000000000000,     0.015314078302,
-                    0.,  0.006156840975,    -0.007657039151,
-                    0., -0.006156840975,    -0.007657039151]
+                [
+                    0.0,
+                    0.000000000000,
+                    0.015314078302,
+                    0.0,
+                    0.006156840975,
+                    -0.007657039151,
+                    0.0,
+                    -0.006156840975,
+                    -0.007657039151,
+                ]
             ).reshape((-1, 3)),
             "OMP2.5 REFERENCE CORRECTION ENERGY": 0.001350812375,  # occ, tight
             "OMP2.5 CORRELATION ENERGY": -0.204522615491,  # occ, tight
             "OMP2.5 SAME-SPIN CORRELATION ENERGY": -0.042086148458,  # occ, tight
             "OMP2.5 TOTAL GRADIENT": np.array(  # occ, tight
-              [ 0.,   0.000000000000,     0.015411835251,
-                0.,   0.006162364663,    -0.007705917626,
-                0.,  -0.006162364663,    -0.007705917626]
+                [
+                    0.0,
+                    0.000000000000,
+                    0.015411835251,
+                    0.0,
+                    0.006162364663,
+                    -0.007705917626,
+                    0.0,
+                    -0.006162364663,
+                    -0.007705917626,
+                ]
             ).reshape((-1, 3)),
             "OMP3 REFERENCE CORRECTION ENERGY": 0.001177767799,  # occ, tight
             "OMP3 CORRELATION ENERGY": -0.212015174087,  # occ, tight
             "OMP3 SAME-SPIN CORRELATION ENERGY": -0.041743491888,  # occ, tight
             "OMP3 TOTAL GRADIENT": np.array(  # occ, tight
-                [   0.,  0.000000000000,     0.015569868835,
-                    0.,  0.006203313670,    -0.007784934417,
-                    0., -0.006203313670,    -0.007784934417]
+                [
+                    0.0,
+                    0.000000000000,
+                    0.015569868835,
+                    0.0,
+                    0.006203313670,
+                    -0.007784934417,
+                    0.0,
+                    -0.006203313670,
+                    -0.007784934417,
+                ]
             ).reshape((-1, 3)),
             "OREMP2 REFERENCE CORRECTION ENERGY": 0.001287772670,  # occ, tight
             "OREMP2 CORRELATION ENERGY": -0.213723933328,  # occ, tight
             "OREMP2 SAME-SPIN CORRELATION ENERGY": -0.041063372010,  # occ, tight
             "OREMP2 TOTAL GRADIENT": np.array(  # occ, tight
-              [ 0.,  0.000000000000,     0.017901979677,
-                0.,  0.007592988824,    -0.008950989839,
-                0., -0.007592988824,    -0.008950989839]
+                [
+                    0.0,
+                    0.000000000000,
+                    0.017901979677,
+                    0.0,
+                    0.007592988824,
+                    -0.008950989839,
+                    0.0,
+                    -0.007592988824,
+                    -0.008950989839,
+                ]
             ).reshape((-1, 3)),
             "OLCCD REFERENCE CORRECTION ENERGY": 0.0012856903,  # p4n
             "OLCCD CORRELATION ENERGY": -0.2180560836,  # p4n
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.0405122800,  # occ
             "OLCCD TOTAL GRADIENT": np.array(  # occ
-                       [-0.,              0.,              0.019472272298,
-                        -0.,              0.008522161738, -0.009736136149,
-                         0.,             -0.008522161738, -0.009736136149]
+                [
+                    -0.0,
+                    0.0,
+                    0.019472272298,
+                    -0.0,
+                    0.008522161738,
+                    -0.009736136149,
+                    0.0,
+                    -0.008522161738,
+                    -0.009736136149,
+                ]
             ).reshape((-1, 3)),
             "OCCD REFERENCE CORRECTION ENERGY": 0.001155093,  # qchem
             "OCCD CORRELATION ENERGY": -0.213139955,  # qchem
             "OCCD TOTAL GRADIENT": np.array(  # qchem, rearranged
-                [0, 0, 0.01669862, 0,  0.00707632 , -0.00834931, 0, -0.00707632, -0.00834931],
+                [0, 0, 0.01669862, 0, 0.00707632, -0.00834931, 0, -0.00707632, -0.00834931],
             ).reshape((-1, 3)),
             "O(T) CORRECTION ENERGY": _knownmissing,
             "A-O(T) CORRECTION ENERGY": _knownmissing,
@@ -4350,54 +4515,114 @@ _std_suite = [
             "OMP2 CORRELATION ENERGY": -0.061388690115,  # occ, tight
             "OMP2 SAME-SPIN CORRELATION ENERGY": -0.001971155774,  # occ, tight
             "OMP2 TOTAL GRADIENT": np.array(  # occ, tight
-                [   0.,  0.000000000000,     0.012017560624,
-                    0.,  0.000000000000,    -0.011623175532,
-                    0.,  0.010549441086,    -0.000197192546,
-                    0., -0.010549441086,    -0.000197192546]
+                [
+                    0.0,
+                    0.000000000000,
+                    0.012017560624,
+                    0.0,
+                    0.000000000000,
+                    -0.011623175532,
+                    0.0,
+                    0.010549441086,
+                    -0.000197192546,
+                    0.0,
+                    -0.010549441086,
+                    -0.000197192546,
+                ]
             ).reshape((-1, 3)),
             "OMP2.5 REFERENCE CORRECTION ENERGY": -0.000959439798,  # occ, tight
             "OMP2.5 CORRELATION ENERGY": -0.069204306750,  # occ, tight
             "OMP2.5 SAME-SPIN CORRELATION ENERGY": -0.002198682531,  # occ, tight
             "OMP2.5 TOTAL GRADIENT": np.array(  # occ, tight
-              [ 0.,   0.000000000000,     0.010260857036,
-                0.,   0.000000000000,    -0.009981284641,
-                0.,   0.011818192175,    -0.000139786197,
-                0.,  -0.011818192175,    -0.000139786197]
+                [
+                    0.0,
+                    0.000000000000,
+                    0.010260857036,
+                    0.0,
+                    0.000000000000,
+                    -0.009981284641,
+                    0.0,
+                    0.011818192175,
+                    -0.000139786197,
+                    0.0,
+                    -0.011818192175,
+                    -0.000139786197,
+                ]
             ).reshape((-1, 3)),
             "OMP3 REFERENCE CORRECTION ENERGY": -0.000746435584,  # occ, tight
             "OMP3 CORRELATION ENERGY": -0.077055367311,  # occ, tight
             "OMP3 SAME-SPIN CORRELATION ENERGY": -0.002426022153,  # occ, tight
             "OMP3 TOTAL GRADIENT": np.array(  # occ, tight
-                [   0.,  0.000000000000,     0.008456347254,
-                    0.,  0.000000000000,    -0.008291901023,
-                    0.,  0.013097750617,    -0.000082223115,
-                    0., -0.013097750617,    -0.000082223115]
+                [
+                    0.0,
+                    0.000000000000,
+                    0.008456347254,
+                    0.0,
+                    0.000000000000,
+                    -0.008291901023,
+                    0.0,
+                    0.013097750617,
+                    -0.000082223115,
+                    0.0,
+                    -0.013097750617,
+                    -0.000082223115,
+                ]
             ).reshape((-1, 3)),
             "OREMP2 REFERENCE CORRECTION ENERGY": -0.000463092111,  # occ, tight
             "OREMP2 CORRELATION ENERGY": -0.080520111623,  # occ, tight
             "OREMP2 SAME-SPIN CORRELATION ENERGY": -0.002398210414,  # occ, tight
             "OREMP2 TOTAL GRADIENT": np.array(  # occ, tight
-              [ 0.,  0.000000000000,     0.005898074368,
-                0.,  0.000000000000,    -0.005790150595,
-                0.,  0.014384643442,    -0.000053961887,
-                0., -0.014384643442,    -0.000053961887]
+                [
+                    0.0,
+                    0.000000000000,
+                    0.005898074368,
+                    0.0,
+                    0.000000000000,
+                    -0.005790150595,
+                    0.0,
+                    0.014384643442,
+                    -0.000053961887,
+                    0.0,
+                    -0.014384643442,
+                    -0.000053961887,
+                ]
             ).reshape((-1, 3)),
             "OLCCD REFERENCE CORRECTION ENERGY": -0.0000399018,  # p4n
             "OLCCD CORRELATION ENERGY": -0.0862654609,  # p4n
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.0024486744,  # occ
             "OLCCD TOTAL GRADIENT": np.array(  # occ
-                       [-0.,              0.,              0.002952428137,
-                         0.,              0.,             -0.002937832352,
-                        -0.,              0.015746258328, -0.000007297893,
-                         0.,             -0.015746258328, -0.000007297893]
+                [
+                    -0.0,
+                    0.0,
+                    0.002952428137,
+                    0.0,
+                    0.0,
+                    -0.002937832352,
+                    -0.0,
+                    0.015746258328,
+                    -0.000007297893,
+                    0.0,
+                    -0.015746258328,
+                    -0.000007297893,
+                ]
             ).reshape((-1, 3)),
             "OCCD REFERENCE CORRECTION ENERGY": -0.000358562,  # qchem
             "OCCD CORRELATION ENERGY": -0.083713042,  # qchem
             "OCCD TOTAL GRADIENT": np.array(  # qchem 3-pt findif
-              [ 0.,  0.,    5.200665059079133e-03,
-                0.,  0.,   -5.057359056039087e-03,
-                0.,  1.487654179061328e-02,  -7.165259590676168e-05,
-                0., -1.487654176147304e-02,  -7.165259308673899e-05]
+                [
+                    0.0,
+                    0.0,
+                    5.200665059079133e-03,
+                    0.0,
+                    0.0,
+                    -5.057359056039087e-03,
+                    0.0,
+                    1.487654179061328e-02,
+                    -7.165259590676168e-05,
+                    0.0,
+                    -1.487654176147304e-02,
+                    -7.165259308673899e-05,
+                ]
             ).reshape((-1, 3)),
             "O(T) CORRECTION ENERGY": _knownmissing,
             "A-O(T) CORRECTION ENERGY": _knownmissing,
@@ -4520,48 +4745,96 @@ _std_suite = [
             "OMP2 CORRELATION ENERGY": -0.160607243189,  # occ, tight
             "OMP2 SAME-SPIN CORRELATION ENERGY": -0.035974454782,  # occ, tight
             "OMP2 TOTAL GRADIENT": np.array(  # occ, tight
-              [ 0.,  0.000000000000,     0.026928663612,
-                0.,  0.014250907985,    -0.013464331806,
-                0., -0.014250907985,    -0.013464331806]
+                [
+                    0.0,
+                    0.000000000000,
+                    0.026928663612,
+                    0.0,
+                    0.014250907985,
+                    -0.013464331806,
+                    0.0,
+                    -0.014250907985,
+                    -0.013464331806,
+                ]
             ).reshape((-1, 3)),
             "OMP2.5 REFERENCE CORRECTION ENERGY": -0.003239801580,  # occ, tight
             "OMP2.5 CORRELATION ENERGY": -0.168458692138,  # occ, tight
             "OMP2.5 SAME-SPIN CORRELATION ENERGY": -0.035847753329,  # occ, tight
             "OMP2.5 TOTAL GRADIENT": np.array(  # occ, tight
-              [ 0.,   0.000000000000,     0.027494386758,
-                0.,   0.014585950370,    -0.013747193379,
-                0.,  -0.014585950370,    -0.013747193379]
+                [
+                    0.0,
+                    0.000000000000,
+                    0.027494386758,
+                    0.0,
+                    0.014585950370,
+                    -0.013747193379,
+                    0.0,
+                    -0.014585950370,
+                    -0.013747193379,
+                ]
             ).reshape((-1, 3)),
             "OMP3 REFERENCE CORRECTION ENERGY": -0.003389494582,  # occ, tight
             "OMP3 CORRELATION ENERGY": -0.176347342433,  # occ, tight
             "OMP3 SAME-SPIN CORRELATION ENERGY": -0.035747352645,  # occ, tight
             "OMP3 TOTAL GRADIENT": np.array(  # occ, tight
-              [ 0.,  0.000000000000,     0.028120207297,
-                0.,  0.014956911348,    -0.014060103648,
-                0., -0.014956911348,    -0.014060103648]
+                [
+                    0.0,
+                    0.000000000000,
+                    0.028120207297,
+                    0.0,
+                    0.014956911348,
+                    -0.014060103648,
+                    0.0,
+                    -0.014956911348,
+                    -0.014060103648,
+                ]
             ).reshape((-1, 3)),
             "OREMP2 REFERENCE CORRECTION ENERGY": -0.003301366872,  # occ, tight
             "OREMP2 CORRELATION ENERGY": -0.178013102573,  # occ, tight
             "OREMP2 SAME-SPIN CORRELATION ENERGY": -0.034962125667,  # occ, tight
             "OREMP2 TOTAL GRADIENT": np.array(  # occ, tight
-              [ 0.,  0.000000000000,     0.030225286965,
-                0.,  0.016238460656,    -0.015112643483,
-                0., -0.016238460656,    -0.015112643483]
+                [
+                    0.0,
+                    0.000000000000,
+                    0.030225286965,
+                    0.0,
+                    0.016238460656,
+                    -0.015112643483,
+                    0.0,
+                    -0.016238460656,
+                    -0.015112643483,
+                ]
             ).reshape((-1, 3)),
             "OLCCD REFERENCE CORRECTION ENERGY": -0.0033018315,  # p4n
             "OLCCD CORRELATION ENERGY": -0.1825194982,  # p4n
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.0344689234,  # occ
             "OLCCD TOTAL GRADIENT": np.array(  # occ
-                       [-0.,              0.,              0.031877236593,
-                        -0.,              0.017265501452, -0.015938618296,
-                         0.,             -0.017265501452, -0.015938618296]
+                [
+                    -0.0,
+                    0.0,
+                    0.031877236593,
+                    -0.0,
+                    0.017265501452,
+                    -0.015938618296,
+                    0.0,
+                    -0.017265501452,
+                    -0.015938618296,
+                ]
             ).reshape((-1, 3)),
             "OCCD REFERENCE CORRECTION ENERGY": -0.003426081,  # qchem
             "OCCD CORRELATION ENERGY": -0.178133946,  # qchem
             "OCCD TOTAL GRADIENT": np.array(  # qchem 3-pt findif
-              [ 0.,    2.629008122312371e-10,   2.915992176610871e-02,
-                0.,    1.575113356366842e-02,  -1.457995768916476e-02,
-                0.,   -1.575113354590485e-02,  -1.457995755771435e-02]
+                [
+                    0.0,
+                    2.629008122312371e-10,
+                    2.915992176610871e-02,
+                    0.0,
+                    1.575113356366842e-02,
+                    -1.457995768916476e-02,
+                    0.0,
+                    -1.575113354590485e-02,
+                    -1.457995755771435e-02,
+                ]
             ).reshape((-1, 3)),
             "O(T) CORRECTION ENERGY": _knownmissing,
             "A-O(T) CORRECTION ENERGY": _knownmissing,
@@ -4681,48 +4954,86 @@ _std_suite = [
             "OMP2 CORRELATION ENERGY": -0.201681478150,  # occ, tight
             "OMP2 SAME-SPIN CORRELATION ENERGY": -0.042459312118,  # occ, tight
             "OMP2 TOTAL GRADIENT": np.array(  # occ, tight
-                [   0.,  0.000000000000,     0.015314087546,
-                    0.,  0.006156841239,    -0.007657043773,
-                    0., -0.006156841239,    -0.007657043773]
+                [
+                    0.0,
+                    0.000000000000,
+                    0.015314087546,
+                    0.0,
+                    0.006156841239,
+                    -0.007657043773,
+                    0.0,
+                    -0.006156841239,
+                    -0.007657043773,
+                ]
             ).reshape((-1, 3)),
             "OMP2.5 REFERENCE CORRECTION ENERGY": -0.003258895747,  # occ, tight
             "OMP2.5 CORRELATION ENERGY": -0.209132323529,  # occ, tight
             "OMP2.5 SAME-SPIN CORRELATION ENERGY": -0.042086148395,  # occ, tight
             "OMP2.5 TOTAL GRADIENT": np.array(  # occ, tight
-              [ 0.,   0.000000000000,     0.015411833442,
-                0.,   0.006162364110,    -0.007705916721,
-                0.,  -0.006162364110,    -0.007705916721]
+                [
+                    0.0,
+                    0.000000000000,
+                    0.015411833442,
+                    0.0,
+                    0.006162364110,
+                    -0.007705916721,
+                    0.0,
+                    -0.006162364110,
+                    -0.007705916721,
+                ]
             ).reshape((-1, 3)),
             "OMP3 REFERENCE CORRECTION ENERGY": -0.003431940343,  # occ, tight
             "OMP3 CORRELATION ENERGY": -0.216624882230,  # occ, tight
             "OMP3 SAME-SPIN CORRELATION ENERGY": -0.041743491868,  # occ, tight
             "OMP3 TOTAL GRADIENT": np.array(  # occ, tight
-                [   0.,  0.000000000000,     0.015569867435,
-                    0.,  0.006203313291,    -0.007784933717,
-                    0., -0.006203313291,    -0.007784933717]
+                [
+                    0.0,
+                    0.000000000000,
+                    0.015569867435,
+                    0.0,
+                    0.006203313291,
+                    -0.007784933717,
+                    0.0,
+                    -0.006203313291,
+                    -0.007784933717,
+                ]
             ).reshape((-1, 3)),
             "OREMP2 REFERENCE CORRECTION ENERGY": -0.003321935448,  # occ, tight
             "OREMP2 CORRELATION ENERGY": -0.218333639848,  # occ, tight
             "OREMP2 SAME-SPIN CORRELATION ENERGY": -0.041063372384,  # occ, tight
             "OREMP2 TOTAL GRADIENT": np.array(  # occ, tight
-              [ 0.,  0.000000000000,     0.017901994172,
-                0.,  0.007592995571,    -0.008950997086,
-                0., -0.007592995571,    -0.008950997086]
+                [
+                    0.0,
+                    0.000000000000,
+                    0.017901994172,
+                    0.0,
+                    0.007592995571,
+                    -0.008950997086,
+                    0.0,
+                    -0.007592995571,
+                    -0.008950997086,
+                ]
             ).reshape((-1, 3)),
             "OLCCD REFERENCE CORRECTION ENERGY": -0.0033240178,  # p4n
             "OLCCD CORRELATION ENERGY": -0.2226657917,  # p4n
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.0405122800,  # occ
             "OLCCD TOTAL GRADIENT": np.array(  # occ
-                       [ 0.,              0.,              0.019472272302,
-                        -0.,              0.008522161726, -0.009736136151,
-                         0.,             -0.008522161726, -0.009736136151]
+                [0.0, 0.0, 0.019472272302, -0.0, 0.008522161726, -0.009736136151, 0.0, -0.008522161726, -0.009736136151]
             ).reshape((-1, 3)),
             "OCCD REFERENCE CORRECTION ENERGY": -0.00345534,  # qchem
             "OCCD CORRELATION ENERGY": -0.217749658,  # qchem
             "OCCD TOTAL GRADIENT": np.array(  # qchem 3-pt findif
-              [ 0.,   2.948752353404416e-10,   1.669883480914791e-02,
-                0.,   7.076450128096212e-03,  -8.349414756025908e-03,
-                0.,  -7.076449627163584e-03,  -8.349414585495651e-03]
+                [
+                    0.0,
+                    2.948752353404416e-10,
+                    1.669883480914791e-02,
+                    0.0,
+                    7.076450128096212e-03,
+                    -8.349414756025908e-03,
+                    0.0,
+                    -7.076449627163584e-03,
+                    -8.349414585495651e-03,
+                ]
             ).reshape((-1, 3)),
             "O(T) CORRECTION ENERGY": _knownmissing,
             "A-O(T) CORRECTION ENERGY": _knownmissing,
@@ -4932,9 +5243,9 @@ _std_suite = [
             "OLCCD TOTAL GRADIENT": _knownmissing,
             "OCCD REFERENCE CORRECTION ENERGY": 0.000510311,  # qchem
             "OCCD CORRELATION ENERGY": -0.206722125,  # qchem
-            "OCCD TOTAL GRADIENT": np.array(  # qchem, rearranged
-                [0, 0, 0.00227059, 0, 0, -0.00227059]
-            ).reshape((-1, 3)),
+            "OCCD TOTAL GRADIENT": np.array([0, 0, 0.00227059, 0, 0, -0.00227059]).reshape(  # qchem, rearranged
+                (-1, 3)
+            ),
             "O(T) CORRECTION ENERGY": _knownmissing,
             "A-O(T) CORRECTION ENERGY": _knownmissing,
             # "XXX TOTAL GRADIENT": np.zeros(6).reshape((-1, 3)),
@@ -5451,7 +5762,7 @@ _std_suite = [
             "OCCD REFERENCE CORRECTION ENERGY": 0.001125755,  # qchem
             "OCCD CORRELATION ENERGY": -0.226880992,  # qchem
             "OCCD TOTAL GRADIENT": np.array(  # qchem, rearranged
-                [ 0, 0, 0.00797428, 0, 0.00488548, -0.00398714, 0, -0.00488548, -0.00398714]
+                [0, 0, 0.00797428, 0, 0.00488548, -0.00398714, 0, -0.00488548, -0.00398714]
             ).reshape((-1, 3)),
             "O(T) CORRECTION ENERGY": _knownmissing,
             "A-O(T) CORRECTION ENERGY": _knownmissing,
@@ -6205,7 +6516,7 @@ _std_suite = [
             "OCCD REFERENCE CORRECTION ENERGY": 0.001225751,  # qchem
             "OCCD CORRELATION ENERGY": -0.250044802,  # qchem
             "OCCD TOTAL GRADIENT": np.array(  # qchem, rearranged
-                [0, 0, -0.00269153 , 0, -0.00204152, 0.00134576, 0,  0.00204152, 0.00134576]
+                [0, 0, -0.00269153, 0, -0.00204152, 0.00134576, 0, 0.00204152, 0.00134576]
             ).reshape((-1, 3)),
             "O(T) CORRECTION ENERGY": _knownmissing,
             "A-O(T) CORRECTION ENERGY": _knownmissing,
@@ -6880,7 +7191,7 @@ _std_suite = [
             "OCCD REFERENCE CORRECTION ENERGY": 0.001154566,  # qchem
             "OCCD CORRELATION ENERGY": -0.081188108,  # qchem
             "OCCD TOTAL GRADIENT": np.array(  # qchem, rearranged
-                [0, 0, 0.00494989, 0, 0,  -0.00479521, 0, 0.01487079, -0.00007734, 0, -0.01487079, -0.00007734]
+                [0, 0, 0.00494989, 0, 0, -0.00479521, 0, 0.01487079, -0.00007734, 0, -0.01487079, -0.00007734]
             ).reshape((-1, 3)),
             "O(T) CORRECTION ENERGY": _knownmissing,
             "A-O(T) CORRECTION ENERGY": _knownmissing,
@@ -7357,7 +7668,7 @@ _std_suite = [
             "OCCD REFERENCE CORRECTION ENERGY": 0.001089195,  # qchem
             "OCCD CORRELATION ENERGY": -0.188164420,  # qchem
             "OCCD TOTAL GRADIENT": np.array(  # qchem, rearranged
-                [0, 0, 0.01780351, 0,  0.00760260, -0.00890176 , 0, -0.00760260, -0.00890176]
+                [0, 0, 0.01780351, 0, 0.00760260, -0.00890176, 0, -0.00760260, -0.00890176]
             ).reshape((-1, 3)),
             "O(T) CORRECTION ENERGY": _knownmissing,
             "A-O(T) CORRECTION ENERGY": _knownmissing,
@@ -7631,10 +7942,20 @@ _std_suite = [
             "OCCD REFERENCE CORRECTION ENERGY": -0.000362931,  # qchem
             "OCCD CORRELATION ENERGY": -0.082712571,  # qchem
             "OCCD TOTAL GRADIENT": np.array(  # qchem 3-pt findif
-              [  0.,    8.460068018933954e-12,   4.950754755080671e-03,
-                 0.,   -1.880015115318656e-12,  -4.795829218979597e-03,
-                 0.,    1.487359483495976e-02,  -7.746235397720769e-05,
-                 0.,   -1.487359480111949e-02,  -7.746237653738908e-05]
+                [
+                    0.0,
+                    8.460068018933954e-12,
+                    4.950754755080671e-03,
+                    0.0,
+                    -1.880015115318656e-12,
+                    -4.795829218979597e-03,
+                    0.0,
+                    1.487359483495976e-02,
+                    -7.746235397720769e-05,
+                    0.0,
+                    -1.487359480111949e-02,
+                    -7.746237653738908e-05,
+                ]
             ).reshape((-1, 3)),
             "O(T) CORRECTION ENERGY": _knownmissing,
             "A-O(T) CORRECTION ENERGY": _knownmissing,
@@ -7737,9 +8058,17 @@ _std_suite = [
             "OCCD REFERENCE CORRECTION ENERGY": -0.003402152,  # qchem
             "OCCD CORRELATION ENERGY": -0.175891240,  # qchem
             "OCCD TOTAL GRADIENT": np.array(  # qchem 3-pt findif
-             [ 0.,   -2.131628207280301e-11,   2.994042840143152e-02,
-               0.,    1.624512323772365e-02,  -1.497021096596995e-02,
-               0.,   -1.624512344378104e-02,  -1.497021098018081e-02]
+                [
+                    0.0,
+                    -2.131628207280301e-11,
+                    2.994042840143152e-02,
+                    0.0,
+                    1.624512323772365e-02,
+                    -1.497021096596995e-02,
+                    0.0,
+                    -1.624512344378104e-02,
+                    -1.497021098018081e-02,
+                ]
             ).reshape((-1, 3)),
             "O(T) CORRECTION ENERGY": _knownmissing,
             "A-O(T) CORRECTION ENERGY": _knownmissing,
@@ -7846,9 +8175,17 @@ _std_suite = [
             "OCCD REFERENCE CORRECTION ENERGY": -0.003478949,  # qchem
             "OCCD CORRELATION ENERGY": -0.192732814,  # qchem
             "OCCD TOTAL GRADIENT": np.array(  # qchem 3-pt findif
-              [  0.,   1.705302565824240e-10,   1.774538645804569e-02,
-                 0.,   7.588575865469238e-03,  -8.872690465011601e-03,
-                 0.,  -7.588575776651396e-03,  -8.872690337113909e-03]
+                [
+                    0.0,
+                    1.705302565824240e-10,
+                    1.774538645804569e-02,
+                    0.0,
+                    7.588575865469238e-03,
+                    -8.872690465011601e-03,
+                    0.0,
+                    -7.588575776651396e-03,
+                    -8.872690337113909e-03,
+                ]
             ).reshape((-1, 3)),
             "O(T) CORRECTION ENERGY": _knownmissing,
             "A-O(T) CORRECTION ENERGY": _knownmissing,
@@ -8828,7 +9165,7 @@ _std_suite = [
             "MP3 SINGLES ENERGY": 0.0,
             "MP3 TOTAL GRADIENT": np.array(
                 # dfocc findif-5
-                [ 0., 0., -0.000926981449, 0., 0., 0.000926981449]
+                [0.0, 0.0, -0.000926981449, 0.0, 0.0, 0.000926981449]
             ).reshape((-1, 3)),
             "REMP2 CORRELATION ENERGY": -0.208401248910,  # dfocc, tight
             "REMP2 SINGLES ENERGY": 0.0,
@@ -8836,7 +9173,7 @@ _std_suite = [
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD TOTAL GRADIENT": np.array(
                 # dfocc findif-5
-                [ 0., 0., 0.002193849073, 0., 0., -0.002193849073]
+                [0.0, 0.0, 0.002193849073, 0.0, 0.0, -0.002193849073]
             ).reshape((-1, 3)),
             "CCSD CORRELATION ENERGY": -0.20873986003026,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
@@ -9367,7 +9704,7 @@ _std_suite = [
             "MP3 SINGLES ENERGY": 0.0,
             "MP3 TOTAL GRADIENT": np.array(
                 # dfocc findif-5 fc cd+cd
-                [ 0., 0., -0.000588974421, 0., 0., 0.000588974421]
+                [0.0, 0.0, -0.000588974421, 0.0, 0.0, 0.000588974421]
             ).reshape((-1, 3)),
             "REMP2 CORRELATION ENERGY": -0.206423120122,  # dfocc, tight
             "REMP2 SINGLES ENERGY": 0.0,
@@ -9375,7 +9712,7 @@ _std_suite = [
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD TOTAL GRADIENT": np.array(
                 # dfocc findif-5 fc cd+cd
-                [ 0., 0., 0.002525704147, 0., 0., -0.002525704147]
+                [0.0, 0.0, 0.002525704147, 0.0, 0.0, -0.002525704147]
             ).reshape((-1, 3)),
             "CCSD CORRELATION ENERGY": -0.20681170792808,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
@@ -10419,45 +10756,38 @@ _std_suite = [
             ).reshape((-1, 3)),
             "(T) CORRECTION ENERGY": -0.00193801686266,  # dfocc, tight
             "CCSD(T) TOTAL GRADIENT": np.array(  # dfocc, tight
-                       [ 0.,              0.,              0.003068357914,
-                        -0.,             -0.,             -0.003068357914]
+                [0.0, 0.0, 0.003068357914, -0.0, -0.0, -0.003068357914]
             ).reshape((-1, 3)),
             "A-(T) CORRECTION ENERGY": -0.00196274645521,  # dfocc, tight
             "OMP2 REFERENCE CORRECTION ENERGY": 0.000705416559,  # dfocc, tight
             "OMP2 CORRELATION ENERGY": -0.204449284608,  # dfocc, tight
             "OMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
-                  [ 0.,  0.000000000000,     0.004079891926,
-                    0., -0.000000000000,    -0.004079891926]
+                [0.0, 0.000000000000, 0.004079891926, 0.0, -0.000000000000, -0.004079891926]
             ).reshape((-1, 3)),
             "OMP2.5 REFERENCE CORRECTION ENERGY": 0.000572277516,  # dfocc, tight
             "OMP2.5 CORRELATION ENERGY": -0.205719687105,  # dfocc, tight
             "OMP2.5 TOTAL GRADIENT": np.array(  # dfocc, tight
-                  [ 0.,  0.000000000000,     0.001995568826,
-                    0., -0.000000000000,    -0.001995568826]
+                [0.0, 0.000000000000, 0.001995568826, 0.0, -0.000000000000, -0.001995568826]
             ).reshape((-1, 3)),
             "OMP3 REFERENCE CORRECTION ENERGY": 0.000467850505,  # dfocc, tight
             "OMP3 CORRELATION ENERGY": -0.207017324163,  # dfocc, tight
             "OMP3 TOTAL GRADIENT": np.array(  # dfocc, tight
-                  [ 0.,  0.000000000000,    -0.000022521780,
-                    0., -0.000000000000,     0.000022521780]
+                [0.0, 0.000000000000, -0.000022521780, 0.0, -0.000000000000, 0.000022521780]
             ).reshape((-1, 3)),
             "OREMP2 REFERENCE CORRECTION ENERGY": 0.000553781427,  # dfocc, tight
             "OREMP2 CORRELATION ENERGY": -0.209041900252,  # dfocc, tight
             "OREMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
-                 [  0.,  0.000000000000,     0.002809444261,
-                    0., -0.000000000000,    -0.002809444261]
+                [0.0, 0.000000000000, 0.002809444261, 0.0, -0.000000000000, -0.002809444261]
             ).reshape((-1, 3)),
             "OLCCD REFERENCE CORRECTION ENERGY": 0.000552755815,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.210569944656,  # dfocc, tight
             "OLCCD TOTAL GRADIENT": np.array(  # dfocc, tight
-              [  0.000000000000,     0.000000000000,     0.003371636637,
-                -0.000000000000,    -0.000000000000,    -0.003371636637]
+                [0.000000000000, 0.000000000000, 0.003371636637, -0.000000000000, -0.000000000000, -0.003371636637]
             ).reshape((-1, 3)),
             "OCCD REFERENCE CORRECTION ENERGY": 0.00051171478318,  # dfocc, tight
             "OCCD CORRELATION ENERGY": -0.20877455867384,  # dfocc, tight
             "OCCD TOTAL GRADIENT": np.array(  # dfocc, tight
-              [ 0., 0.,    0.001829701353,
-                0., 0.,   -0.001829701353]
+                [0.0, 0.0, 0.001829701353, 0.0, 0.0, -0.001829701353]
             ).reshape((-1, 3)),
             "O(T) CORRECTION ENERGY": -0.002064008068,  # dfocc, tight
             "A-O(T) CORRECTION ENERGY": -0.002043954736,  # dfocc, tight
@@ -10524,52 +10854,98 @@ _std_suite = [
             ).reshape((-1, 3)),
             "(T) CORRECTION ENERGY": -0.00524345048605,  # dfocc, tight
             "CCSD(T) TOTAL GRADIENT": np.array(  # dfocc, tight
-                       [ 0.,              0.,              0.010200006450,
-                        -0.,              0.00604923838,  -0.005100003223,
-                        -0.,             -0.00604923838,  -0.005100003226]
+                [0.0, 0.0, 0.010200006450, -0.0, 0.00604923838, -0.005100003223, -0.0, -0.00604923838, -0.005100003226]
             ).reshape((-1, 3)),
             "A-(T) CORRECTION ENERGY": -0.00524100328791,  # dfocc, tight
             "OMP2 REFERENCE CORRECTION ENERGY": 0.002353213091,  # dfocc, tight
             "OMP2 CORRELATION ENERGY": -0.224108722336,  # dfocc, tight
             "OMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
-                  [ 0.,  0.000000000000,     0.012090520150,
-                    0.,  0.006792038487,    -0.006045260075,
-                    0., -0.006792038487,    -0.006045260075]
+                [
+                    0.0,
+                    0.000000000000,
+                    0.012090520150,
+                    0.0,
+                    0.006792038487,
+                    -0.006045260075,
+                    0.0,
+                    -0.006792038487,
+                    -0.006045260075,
+                ]
             ).reshape((-1, 3)),
             "OMP2.5 REFERENCE CORRECTION ENERGY": 0.001535554696,  # dfocc, tight
             "OMP2.5 CORRELATION ENERGY": -0.225687426127,  # dfocc, tight
             "OMP2.5 TOTAL GRADIENT": np.array(  # dfocc, tight
-                  [ 0.,  0.000000000000,     0.008284981234,
-                    0.,  0.004775627693,    -0.004142490617,
-                    0., -0.004775627693,    -0.004142490617]
+                [
+                    0.0,
+                    0.000000000000,
+                    0.008284981234,
+                    0.0,
+                    0.004775627693,
+                    -0.004142490617,
+                    0.0,
+                    -0.004775627693,
+                    -0.004142490617,
+                ]
             ).reshape((-1, 3)),
             "OMP3 REFERENCE CORRECTION ENERGY": 0.000954089054,  # dfocc, tight
             "OMP3 CORRELATION ENERGY": -0.227460339651,  # dfocc, tight
             "OMP3 TOTAL GRADIENT": np.array(  # dfocc, tight
-                  [ 0., -0.000000000000,     0.004815233651,
-                    0.,  0.002952173310,    -0.002407616826,
-                    0., -0.002952173310,    -0.002407616826]
+                [
+                    0.0,
+                    -0.000000000000,
+                    0.004815233651,
+                    0.0,
+                    0.002952173310,
+                    -0.002407616826,
+                    0.0,
+                    -0.002952173310,
+                    -0.002407616826,
+                ]
             ).reshape((-1, 3)),
             "OREMP2 REFERENCE CORRECTION ENERGY": 0.001281722402,  # dfocc, tight
             "OREMP2 CORRELATION ENERGY": -0.23079090375495,  # dfocc, tight
             "OREMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
-              [ 0.,  0.000000000000,     0.009108870642,
-                0.,  0.005403366342,    -0.004554435321,
-                0., -0.005403366342,    -0.004554435321]
+                [
+                    0.0,
+                    0.000000000000,
+                    0.009108870642,
+                    0.0,
+                    0.005403366342,
+                    -0.004554435321,
+                    0.0,
+                    -0.005403366342,
+                    -0.004554435321,
+                ]
             ).reshape((-1, 3)),
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001189314489,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.233173062606,  # dfocc, tight
             "OLCCD TOTAL GRADIENT": np.array(  # dfocc, tight
-                [        0.000000000000,    -0.000000000000,     0.009761700492,
-                        -0.000000000000,     0.005853403252,    -0.004880850246,
-                        -0.000000000000,    -0.005853403251,    -0.004880850246]
+                [
+                    0.000000000000,
+                    -0.000000000000,
+                    0.009761700492,
+                    -0.000000000000,
+                    0.005853403252,
+                    -0.004880850246,
+                    -0.000000000000,
+                    -0.005853403251,
+                    -0.004880850246,
+                ]
             ).reshape((-1, 3)),
             "OCCD REFERENCE CORRECTION ENERGY": 0.0011241002379,  # dfocc, tight
             "OCCD CORRELATION ENERGY": -0.22924045334096,  # dfocc, tight
             "OCCD TOTAL GRADIENT": np.array(  # dfocc, tight
-             [  0., -0.000000000000,     0.007259063497,
-               -0.,  0.004473960460,    -0.003629531749,
-               -0., -0.004473960460,    -0.003629531749]
+                [
+                    0.0,
+                    -0.000000000000,
+                    0.007259063497,
+                    -0.0,
+                    0.004473960460,
+                    -0.003629531749,
+                    -0.0,
+                    -0.004473960460,
+                    -0.003629531749,
+                ]
             ).reshape((-1, 3)),
             "O(T) CORRECTION ENERGY": -0.005578769043,  # dfocc, tight
             "A-O(T) CORRECTION ENERGY": -0.005480838164,  # dfocc, tight
@@ -10626,52 +11002,98 @@ _std_suite = [
             ).reshape((-1, 3)),
             "(T) CORRECTION ENERGY": -0.00726212675888,  # dfocc, tight
             "CCSD(T) TOTAL GRADIENT": np.array(  # dfocc, tight
-                       [ 0.,              0.,             -0.000217412659,
-                        -0.,             -0.000742939442,  0.000108706327,
-                         0.,              0.000742939441,  0.000108706333]
+                [0.0, 0.0, -0.000217412659, -0.0, -0.000742939442, 0.000108706327, 0.0, 0.000742939441, 0.000108706333]
             ).reshape((-1, 3)),
             "A-(T) CORRECTION ENERGY": -0.00718000875661,  # dfocc, tight
             "OMP2 REFERENCE CORRECTION ENERGY": 0.002514012770,  # dfocc, tight
             "OMP2 CORRELATION ENERGY": -0.272569214076,  # dfocc, tight
             "OMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
-                  [ 0., -0.000000000000,     0.001818176662,
-                    0.,  0.000241592175,    -0.000909088331,
-                    0., -0.000241592175,    -0.000909088331]
+                [
+                    0.0,
+                    -0.000000000000,
+                    0.001818176662,
+                    0.0,
+                    0.000241592175,
+                    -0.000909088331,
+                    0.0,
+                    -0.000241592175,
+                    -0.000909088331,
+                ]
             ).reshape((-1, 3)),
             "OMP2.5 REFERENCE CORRECTION ENERGY": 0.001691695489,  # dfocc, tight
             "OMP2.5 CORRELATION ENERGY": -0.273184743555,  # dfocc, tight
             "OMP2.5 TOTAL GRADIENT": np.array(  # dfocc, tight
-                  [ 0., -0.000000000000,    -0.002325903973,
-                    0., -0.001998665869,     0.001162951987,
-                    0.,  0.001998665869,     0.001162951987]
+                [
+                    0.0,
+                    -0.000000000000,
+                    -0.002325903973,
+                    0.0,
+                    -0.001998665869,
+                    0.001162951987,
+                    0.0,
+                    0.001998665869,
+                    0.001162951987,
+                ]
             ).reshape((-1, 3)),
             "OMP3 REFERENCE CORRECTION ENERGY": 0.001090223846,  # dfocc, tight
             "OMP3 CORRELATION ENERGY": -0.273992490969,  # dfocc, tight
             "OMP3 TOTAL GRADIENT": np.array(  # dfocc, tight
-                  [ 0.,  0.000000000000,    -0.006182600264,
-                    0., -0.004075383127,     0.003091300132,
-                    0.,  0.004075383127,     0.003091300132]
+                [
+                    0.0,
+                    0.000000000000,
+                    -0.006182600264,
+                    0.0,
+                    -0.004075383127,
+                    0.003091300132,
+                    0.0,
+                    0.004075383127,
+                    0.003091300132,
+                ]
             ).reshape((-1, 3)),
             "OREMP2 REFERENCE CORRECTION ENERGY": 0.001444459285,  # dfocc, tight
             "OREMP2 CORRELATION ENERGY": -0.277823416296,  # dfocc, tight
             "OREMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
-                 [  0., -0.000000000000,    -0.001651592566,
-                    0., -0.001517469318,     0.000825796283,
-                    0.,  0.001517469318,     0.000825796283]
+                [
+                    0.0,
+                    -0.000000000000,
+                    -0.001651592566,
+                    0.0,
+                    -0.001517469318,
+                    0.000825796283,
+                    0.0,
+                    0.001517469318,
+                    0.000825796283,
+                ]
             ).reshape((-1, 3)),
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001352291360,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.279981325469,  # dfocc, tight
             "OLCCD TOTAL GRADIENT": np.array(  # dfocc, tight
-             [  0.000000000000,    -0.000000000000,    -0.001075340549,
-               -0.000000000000,    -0.001136934323,     0.000537670274,
-                0.000000000000,     0.001136934323,     0.000537670274]
+                [
+                    0.000000000000,
+                    -0.000000000000,
+                    -0.001075340549,
+                    -0.000000000000,
+                    -0.001136934323,
+                    0.000537670274,
+                    0.000000000000,
+                    0.001136934323,
+                    0.000537670274,
+                ]
             ).reshape((-1, 3)),
             "OCCD REFERENCE CORRECTION ENERGY": 0.00127938819983,  # dfocc, tight
             "OCCD CORRELATION ENERGY": -0.27539517277894,  # dfocc, tight
             "OCCD TOTAL GRADIENT": np.array(  # dfocc, tight
-             [  0.,  0.000000000000,    -0.003670656144,
-               -0., -0.002477953103,     0.001835328072,
-                0.,  0.002477953103,     0.001835328072]
+                [
+                    0.0,
+                    0.000000000000,
+                    -0.003670656144,
+                    -0.0,
+                    -0.002477953103,
+                    0.001835328072,
+                    0.0,
+                    0.002477953103,
+                    0.001835328072,
+                ]
             ).reshape((-1, 3)),
             "O(T) CORRECTION ENERGY": -0.007571167323,  # dfocc, tight
             "A-O(T) CORRECTION ENERGY": -0.007455996809,  # dfocc, tight
@@ -10755,70 +11177,150 @@ _std_suite = [
             "CCSD CORRELATION ENERGY": -0.08223900985527,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD TOTAL GRADIENT": np.array(  # dfocc, tight
-                       [-0.,              0.,              0.005201169988,
-                         0.,             -0.,             -0.005060084065,
-                        -0.,              0.014882201275, -0.000070542962,
-                         0.,             -0.014882201275, -0.000070542961]
+                [
+                    -0.0,
+                    0.0,
+                    0.005201169988,
+                    0.0,
+                    -0.0,
+                    -0.005060084065,
+                    -0.0,
+                    0.014882201275,
+                    -0.000070542962,
+                    0.0,
+                    -0.014882201275,
+                    -0.000070542961,
+                ]
             ).reshape((-1, 3)),
             "(T) CORRECTION ENERGY": -0.00062655599464,  # dfocc, tight
             "CCSD(T) TOTAL GRADIENT": np.array(  # dfocc, tight
-                       [-0.,              0.,              0.004689654727,
-                         0.,             -0.,             -0.004631718438,
-                        -0.,              0.014962374742, -0.000028968145,
-                         0.,             -0.014962374742, -0.000028968144]
+                [
+                    -0.0,
+                    0.0,
+                    0.004689654727,
+                    0.0,
+                    -0.0,
+                    -0.004631718438,
+                    -0.0,
+                    0.014962374742,
+                    -0.000028968145,
+                    0.0,
+                    -0.014962374742,
+                    -0.000028968144,
+                ]
             ).reshape((-1, 3)),
             "A-(T) CORRECTION ENERGY": -0.00060971952519,  # dfocc, tight
             "OMP2 REFERENCE CORRECTION ENERGY": 0.000396459592,  # dfocc, tight
             "OMP2 CORRELATION ENERGY": -0.059832149673,  # dfocc, tight
             "OMP2 SAME-SPIN CORRELATION ENERGY": -0.001972801620,  # dfocc, tight
             "OMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
-                  [ 0.,  0.000000000000,     0.012031476427,
-                    0., -0.000000000000,    -0.011634888026,
-                    0.,  0.010540730273,    -0.000198294201,
-                    0., -0.010540730274,    -0.000198294201]
+                [
+                    0.0,
+                    0.000000000000,
+                    0.012031476427,
+                    0.0,
+                    -0.000000000000,
+                    -0.011634888026,
+                    0.0,
+                    0.010540730273,
+                    -0.000198294201,
+                    0.0,
+                    -0.010540730274,
+                    -0.000198294201,
+                ]
             ).reshape((-1, 3)),
             "OMP2.5 REFERENCE CORRECTION ENERGY": 0.000566397552,  # dfocc, tight
             "OMP2.5 CORRELATION ENERGY": -0.067689046439,  # dfocc, tight
             "OMP2.5 SAME-SPIN CORRELATION ENERGY": -0.002200309774,  # dfocc, tight
             "OMP2.5 TOTAL GRADIENT": np.array(  # dfocc, tight
-                  [ 0.,  0.000000000000,     0.010263706524,
-                    0., -0.000000000000,    -0.009982176653,
-                    0.,  0.011813660618,    -0.000140764936,
-                    0., -0.011813660618,    -0.000140764936]
+                [
+                    0.0,
+                    0.000000000000,
+                    0.010263706524,
+                    0.0,
+                    -0.000000000000,
+                    -0.009982176653,
+                    0.0,
+                    0.011813660618,
+                    -0.000140764936,
+                    0.0,
+                    -0.011813660618,
+                    -0.000140764936,
+                ]
             ).reshape((-1, 3)),
             "OMP3 REFERENCE CORRECTION ENERGY": 0.000780187024,  # dfocc, tight
             "OMP3 CORRELATION ENERGY": -0.075581499723,  # dfocc, tight
             "OMP3 SAME-SPIN CORRELATION ENERGY": -0.002427625806,  # dfocc, tight
             "OMP3 TOTAL GRADIENT": np.array(  # dfocc, tight
-                  [ 0.,  0.000000000000,     0.008448066470,
-                    0., -0.000000000000,    -0.008281866938,
-                    0.,  0.013097326629,    -0.000083099766,
-                    0., -0.013097326629,    -0.000083099766]
+                [
+                    0.0,
+                    0.000000000000,
+                    0.008448066470,
+                    0.0,
+                    -0.000000000000,
+                    -0.008281866938,
+                    0.0,
+                    0.013097326629,
+                    -0.000083099766,
+                    0.0,
+                    -0.013097326629,
+                    -0.000083099766,
+                ]
             ).reshape((-1, 3)),
             "OREMP2 REFERENCE CORRECTION ENERGY": 0.001063189693,  # dfocc, tight
             "OREMP2 CORRELATION ENERGY": -0.079048591655,  # dfocc, tight
             "OREMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
-                 [  0.,  0.000000000000,     0.005890513253,
-                    0., -0.000000000000,    -0.005780178036,
-                    0.,  0.014386023476,    -0.000055167609,
-                    0., -0.014386023476,    -0.000055167609]
+                [
+                    0.0,
+                    0.000000000000,
+                    0.005890513253,
+                    0.0,
+                    -0.000000000000,
+                    -0.005780178036,
+                    0.0,
+                    0.014386023476,
+                    -0.000055167609,
+                    0.0,
+                    -0.014386023476,
+                    -0.000055167609,
+                ]
             ).reshape((-1, 3)),
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001486131044,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.084811453110,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.002450103204,  # dfocc, tight
             "OLCCD TOTAL GRADIENT": np.array(  # dfocc, tight
-                [      -0.000000000000,     0.000000000000,     0.002942322545,
-                        0.000000000000,    -0.000000000000,    -0.002924986204,
-                       -0.000000000000,     0.015750409537,    -0.000008668171,
-                        0.000000000000,    -0.015750409537,    -0.000008668171]
+                [
+                    -0.000000000000,
+                    0.000000000000,
+                    0.002942322545,
+                    0.000000000000,
+                    -0.000000000000,
+                    -0.002924986204,
+                    -0.000000000000,
+                    0.015750409537,
+                    -0.000008668171,
+                    0.000000000000,
+                    -0.015750409537,
+                    -0.000008668171,
+                ]
             ).reshape((-1, 3)),
             "OCCD REFERENCE CORRECTION ENERGY": 0.00116757931849,  # dfocc, tight
             "OCCD CORRELATION ENERGY": -0.08225497590846,  # dfocc, tight
             "OCCD TOTAL GRADIENT": np.array(  # dfocc, tight
-                       [-0.,  0.,                0.005192742269,
-                         0., -0.,               -0.005046526613,
-                        -0.,  0.014877327584,   -0.000073107828,
-                         0., -0.014877327584,   -0.000073107828]
+                [
+                    -0.0,
+                    0.0,
+                    0.005192742269,
+                    0.0,
+                    -0.0,
+                    -0.005046526613,
+                    -0.0,
+                    0.014877327584,
+                    -0.000073107828,
+                    0.0,
+                    -0.014877327584,
+                    -0.000073107828,
+                ]
             ).reshape((-1, 3)),
             "O(T) CORRECTION ENERGY": -0.000628655467,  # dfocc, tight
             "A-O(T) CORRECTION ENERGY": -0.000606118093,  # dfocc, tight
@@ -10873,62 +11375,116 @@ _std_suite = [
             "CCSD CORRELATION ENERGY": -0.17395818499234,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD TOTAL GRADIENT": np.array(  # dfocc, tight
-                [-0.,             0.,              0.029266386707,
-                 0.,              0.015807793582, -0.014633193357,
-                -0.,             -0.015807793582, -0.014633193351]
+                [
+                    -0.0,
+                    0.0,
+                    0.029266386707,
+                    0.0,
+                    0.015807793582,
+                    -0.014633193357,
+                    -0.0,
+                    -0.015807793582,
+                    -0.014633193351,
+                ]
             ).reshape((-1, 3)),
             "(T) CORRECTION ENERGY": -0.00384810072338,  # dfocc, tight
             "CCSD(T) TOTAL GRADIENT": np.array(  # dfocc, tight
-                       [-0.,              0.,              0.031148775451,
-                         0.,              0.016805034066, -0.015574387726,
-                        -0.,             -0.016805034066, -0.015574387725]
+                [
+                    -0.0,
+                    0.0,
+                    0.031148775451,
+                    0.0,
+                    0.016805034066,
+                    -0.015574387726,
+                    -0.0,
+                    -0.016805034066,
+                    -0.015574387725,
+                ]
             ).reshape((-1, 3)),
             "A-(T) CORRECTION ENERGY": -0.00376812221828,  # dfocc, tight
             "OMP2 REFERENCE CORRECTION ENERGY": 0.001367832301,  # dfocc, tight
             "OMP2 CORRELATION ENERGY": -0.156173452626,  # dfocc, tight
             "OMP2 SAME-SPIN CORRELATION ENERGY": -0.036004901480,  # dfocc, tight
             "OMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
-                  [ 0., -0.000000000000,     0.026914388853,
-                    0.,  0.014240311996,    -0.013457194426,
-                    0., -0.014240311996,    -0.013457194426]
+                [
+                    0.0,
+                    -0.000000000000,
+                    0.026914388853,
+                    0.0,
+                    0.014240311996,
+                    -0.013457194426,
+                    0.0,
+                    -0.014240311996,
+                    -0.013457194426,
+                ]
             ).reshape((-1, 3)),
             "OMP2.5 REFERENCE CORRECTION ENERGY": 0.001174470264,  # dfocc, tight
             "OMP2.5 CORRELATION ENERGY": -0.164063461670,  # dfocc, tight
             "OMP2.5 SAME-SPIN CORRELATION ENERGY": -0.035847923992,  # dfocc, tight
             "OMP2.5 TOTAL GRADIENT": np.array(  # dfocc, tight
-                  [ 0., -0.000000000000,     0.027483211370,
-                    0.,  0.014576999156,    -0.013741605685,
-                    0., -0.014576999156,    -0.013741605685]
+                [
+                    0.0,
+                    -0.000000000000,
+                    0.027483211370,
+                    0.0,
+                    0.014576999156,
+                    -0.013741605685,
+                    0.0,
+                    -0.014576999156,
+                    -0.013741605685,
+                ]
             ).reshape((-1, 3)),
             "OMP3 REFERENCE CORRECTION ENERGY": 0.001024687110,  # dfocc, tight
             "OMP3 CORRELATION ENERGY": -0.171990731878,  # dfocc, tight
             "OMP3 SAME-SPIN CORRELATION ENERGY": -0.035717311998,  # dfocc, tight
             "OMP3 TOTAL GRADIENT": np.array(  # dfocc, tight
-                  [ 0., -0.000000000000,     0.028112148199,
-                    0.,  0.014949633980,    -0.014056074099,
-                    0., -0.014949633980,    -0.014056074099]
+                [
+                    0.0,
+                    -0.000000000000,
+                    0.028112148199,
+                    0.0,
+                    0.014949633980,
+                    -0.014056074099,
+                    0.0,
+                    -0.014949633980,
+                    -0.014056074099,
+                ]
             ).reshape((-1, 3)),
             "OREMP2 REFERENCE CORRECTION ENERGY": 0.0011125246764,  # dfocc, tight
             "OREMP2 CORRELATION ENERGY": -0.17366812020990,  # dfocc, tight
             "OREMP2 TOTAL GRADIENT": np.array(  # dfocc, tight)
-              [ 0., -0.000000000000,     0.030213597936,
-                0.,  0.016231443797,    -0.015106798968,
-                0., -0.016231443797,    -0.015106798968]
+                [
+                    0.0,
+                    -0.000000000000,
+                    0.030213597936,
+                    0.0,
+                    0.016231443797,
+                    -0.015106798968,
+                    0.0,
+                    -0.016231443797,
+                    -0.015106798968,
+                ]
             ).reshape((-1, 3)),
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001111851483,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.178196933112,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.034422402711,  # dfocc, tight
             "OLCCD TOTAL GRADIENT": np.array(  # dfocc, tight
-            [  -0.000000000000,    -0.000000000000,     0.031864432517,
-                0.000000000000,     0.017258987132,    -0.015932216258,
-               -0.000000000000,    -0.017258987132,    -0.015932216258]
+                [
+                    -0.000000000000,
+                    -0.000000000000,
+                    0.031864432517,
+                    0.000000000000,
+                    0.017258987132,
+                    -0.015932216258,
+                    -0.000000000000,
+                    -0.017258987132,
+                    -0.015932216258,
+                ]
             ).reshape((-1, 3)),
             "OCCD REFERENCE CORRECTION ENERGY": 0.00098766230788,  # dfocc, tight
             "OCCD CORRELATION ENERGY": -0.17380639841079,  # dfocc, tight
             "OCCD TOTAL GRADIENT": np.array(  # dfocc, tight
-                       [-0.,             -0.,              0.029147626743,
-                         0.,              0.01574493194,  -0.014573813372,
-                        -0.,             -0.01574493194,  -0.014573813372]
+                [-0.0, -0.0, 0.029147626743, 0.0, 0.01574493194, -0.014573813372, -0.0, -0.01574493194, -0.014573813372]
             ).reshape((-1, 3)),
             "O(T) CORRECTION ENERGY": -0.003993549226,  # dfocc, tight
             "A-O(T) CORRECTION ENERGY": -0.003893263740,  # dfocc, tight
@@ -10983,62 +11539,106 @@ _std_suite = [
             "CCSD CORRELATION ENERGY": -0.21328159274710,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD TOTAL GRADIENT": np.array(  # dfocc, tight
-                [ 0.,             -0.,              0.016818391166,
-                -0.,              0.0071380193,   -0.008409195584,
-                 0.,             -0.0071380193,   -0.008409195582]
+                [0.0, -0.0, 0.016818391166, -0.0, 0.0071380193, -0.008409195584, 0.0, -0.0071380193, -0.008409195582]
             ).reshape((-1, 3)),
             "(T) CORRECTION ENERGY": -0.00516563729772,  # dfocc, tight
             "CCSD(T) TOTAL GRADIENT": np.array(  # dfocc, tight
-                       [ 0.,             -0.,              0.019018581448,
-                        -0.,              0.008236968052, -0.009509290726,
-                         0.,             -0.008236968052, -0.009509290722]
+                [
+                    0.0,
+                    -0.0,
+                    0.019018581448,
+                    -0.0,
+                    0.008236968052,
+                    -0.009509290726,
+                    0.0,
+                    -0.008236968052,
+                    -0.009509290722,
+                ]
             ).reshape((-1, 3)),
             "A-(T) CORRECTION ENERGY": -0.00506341197521,  # dfocc, tight
             "OMP2 REFERENCE CORRECTION ENERGY": 0.001570633341,  # dfocc, tight
             "OMP2 CORRELATION ENERGY": -0.197048695120,  # dfocc, tight
             "OMP2 SAME-SPIN CORRELATION ENERGY": -0.042457672915,  # dfocc, tight
             "OMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
-                  [ 0.,  0.000000000000,     0.015291382216,
-                    0.,  0.006145115573,    -0.007645691108,
-                    0., -0.006145115573,    -0.007645691108]
+                [
+                    0.0,
+                    0.000000000000,
+                    0.015291382216,
+                    0.0,
+                    0.006145115573,
+                    -0.007645691108,
+                    0.0,
+                    -0.006145115573,
+                    -0.007645691108,
+                ]
             ).reshape((-1, 3)),
             "OMP2.5 REFERENCE CORRECTION ENERGY": 0.001350847967,  # dfocc, tight
             "OMP2.5 CORRELATION ENERGY": -0.204503012944,  # dfocc, tight
             "OMP2.5 SAME-SPIN CORRELATION ENERGY": -0.042084276114,  # dfocc, tight
             "OMP2.5 TOTAL GRADIENT": np.array(  # dfocc, tight
-                  [ 0., -0.000000000000,     0.015388626332,
-                    0.,  0.006150433332,    -0.007694313166,
-                    0., -0.006150433332,    -0.007694313166]
+                [
+                    0.0,
+                    -0.000000000000,
+                    0.015388626332,
+                    0.0,
+                    0.006150433332,
+                    -0.007694313166,
+                    0.0,
+                    -0.006150433332,
+                    -0.007694313166,
+                ]
             ).reshape((-1, 3)),
             "OMP3 REFERENCE CORRECTION ENERGY": 0.001177820960,  # dfocc, tight
             "OMP3 CORRELATION ENERGY": -0.211999043568,  # dfocc, tight
             "OMP3 SAME-SPIN CORRELATION ENERGY": -0.041741379825,  # dfocc, tight
             "OMP3 TOTAL GRADIENT": np.array(  # dfocc, tight
-                  [ 0.,  0.000000000000,     0.015546142750,
-                    0.,  0.006191167357,    -0.007773071375,
-                    0., -0.006191167357,    -0.007773071375]
+                [
+                    0.0,
+                    0.000000000000,
+                    0.015546142750,
+                    0.0,
+                    0.006191167357,
+                    -0.007773071375,
+                    0.0,
+                    -0.006191167357,
+                    -0.007773071375,
+                ]
             ).reshape((-1, 3)),
             "OREMP2 REFERENCE CORRECTION ENERGY": 0.001287786460,  # dfocc, tight
             "OREMP2 CORRELATION ENERGY": -0.213706080780,  # dfocc, tight
             "OREMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
-                 [  0., -0.000000000000,     0.017877890596,
-                    0.,  0.007580722221,    -0.008938945298,
-                    0., -0.007580722221,    -0.008938945298]
+                [
+                    0.0,
+                    -0.000000000000,
+                    0.017877890596,
+                    0.0,
+                    0.007580722221,
+                    -0.008938945298,
+                    0.0,
+                    -0.007580722221,
+                    -0.008938945298,
+                ]
             ).reshape((-1, 3)),
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001285702841,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.218038927594,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.040510034508,  # dfocc, tight
             "OLCCD TOTAL GRADIENT": np.array(  # dfocc, tight
-                [        0.000000000000,    -0.000000000000,     0.019448090911,
-                        -0.000000000000,     0.008509858260,    -0.009724045456,
-                         0.000000000000,    -0.008509858260,    -0.009724045456]
+                [
+                    0.000000000000,
+                    -0.000000000000,
+                    0.019448090911,
+                    -0.000000000000,
+                    0.008509858260,
+                    -0.009724045456,
+                    0.000000000000,
+                    -0.008509858260,
+                    -0.009724045456,
+                ]
             ).reshape((-1, 3)),
             "OCCD REFERENCE CORRECTION ENERGY": 0.00115506325268,  # dfocc, tight
             "OCCD CORRELATION ENERGY": -0.21312358096054,  # dfocc, tight
             "OCCD TOTAL GRADIENT": np.array(  # dfocc, tight
-             [  0.,  0.,                0.016675154934,
-               -0.,  0.007064234315,   -0.008337577467,
-                0., -0.007064234315,   -0.008337577467]
+                [0.0, 0.0, 0.016675154934, -0.0, 0.007064234315, -0.008337577467, 0.0, -0.007064234315, -0.008337577467]
             ).reshape((-1, 3)),
             "O(T) CORRECTION ENERGY": -0.005337854371,  # dfocc, tight
             "A-O(T) CORRECTION ENERGY": -0.005214252989,  # dfocc, tight
@@ -11084,53 +11684,113 @@ _std_suite = [
             "OMP2 CORRELATION ENERGY": -0.061356186762,  # dfocc, tight
             "OMP2 SAME-SPIN CORRELATION ENERGY": -0.001972801188,  # dfocc, tight
             "OMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
-                  [ 0.,  0.000000000000,     0.012031487574,
-                    0., -0.000000000000,    -0.011634881724,
-                    0.,  0.010540719393,    -0.000198302925,
-                    0., -0.010540719393,    -0.000198302925]
+                [
+                    0.0,
+                    0.000000000000,
+                    0.012031487574,
+                    0.0,
+                    -0.000000000000,
+                    -0.011634881724,
+                    0.0,
+                    0.010540719393,
+                    -0.000198302925,
+                    0.0,
+                    -0.010540719393,
+                    -0.000198302925,
+                ]
             ).reshape((-1, 3)),
             "OMP2.5 REFERENCE CORRECTION ENERGY": -0.000957639989,  # dfocc, tight
             "OMP2.5 CORRELATION ENERGY": -0.069213083529,  # dfocc, tight
             "OMP2.5 SAME-SPIN CORRELATION ENERGY": -0.002200309067,  # dfocc, tight
             "OMP2.5 TOTAL GRADIENT": np.array(  # dfocc, tight
-                  [ 0.,  0.000000000000,     0.010263733632,
-                    0., -0.000000000000,    -0.009982179290,
-                    0.,  0.011813639779,    -0.000140777171,
-                    0., -0.011813639779,    -0.000140777171]
+                [
+                    0.0,
+                    0.000000000000,
+                    0.010263733632,
+                    0.0,
+                    -0.000000000000,
+                    -0.009982179290,
+                    0.0,
+                    0.011813639779,
+                    -0.000140777171,
+                    0.0,
+                    -0.011813639779,
+                    -0.000140777171,
+                ]
             ).reshape((-1, 3)),
             "OMP3 REFERENCE CORRECTION ENERGY": -0.000743849641,  # dfocc, tight
             "OMP3 CORRELATION ENERGY": -0.077105536812,  # dfocc, tight
             "OMP3 SAME-SPIN CORRELATION ENERGY": -0.002427625679,  # dfocc, tight
             "OMP3 TOTAL GRADIENT": np.array(  # dfocc, tight
-                  [ 0.,  0.000000000000,     0.008448077204,
-                    0., -0.000000000000,    -0.008281875978,
-                    0.,  0.013097326563,    -0.000083100613,
-                    0., -0.013097326563,    -0.000083100613]
+                [
+                    0.0,
+                    0.000000000000,
+                    0.008448077204,
+                    0.0,
+                    -0.000000000000,
+                    -0.008281875978,
+                    0.0,
+                    0.013097326563,
+                    -0.000083100613,
+                    0.0,
+                    -0.013097326563,
+                    -0.000083100613,
+                ]
             ).reshape((-1, 3)),
             "OREMP2 REFERENCE CORRECTION ENERGY": -0.000460845361,  # dfocc, tight
             "OREMP2 CORRELATION ENERGY": -0.080572628744,  # dfocc, tight
             "OREMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
-                 [  0.,  0.000000000000,     0.005890487280,
-                    0., -0.000000000000,    -0.005780144920,
-                    0.,  0.014386015714,    -0.000055171180,
-                    0., -0.014386015714,    -0.000055171180]
+                [
+                    0.0,
+                    0.000000000000,
+                    0.005890487280,
+                    0.0,
+                    -0.000000000000,
+                    -0.005780144920,
+                    0.0,
+                    0.014386015714,
+                    -0.000055171180,
+                    0.0,
+                    -0.014386015714,
+                    -0.000055171180,
+                ]
             ).reshape((-1, 3)),
             "OLCCD REFERENCE CORRECTION ENERGY": -0.000037911160,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.086335490199,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.002450103939,  # dfocc, tight
             "OLCCD TOTAL GRADIENT": np.array(  # dfocc, tight
-                [       -0.000000000000,     0.000000000000,     0.002942353924,
-                         0.000000000000,    -0.000000000000,    -0.002925017923,
-                        -0.000000000000,     0.015750403382,    -0.000008668000,
-                         0.000000000000,    -0.015750403382,    -0.000008668000]
+                [
+                    -0.000000000000,
+                    0.000000000000,
+                    0.002942353924,
+                    0.000000000000,
+                    -0.000000000000,
+                    -0.002925017923,
+                    -0.000000000000,
+                    0.015750403382,
+                    -0.000008668000,
+                    0.000000000000,
+                    -0.015750403382,
+                    -0.000008668000,
+                ]
             ).reshape((-1, 3)),
             "OCCD REFERENCE CORRECTION ENERGY": -0.00035645775738,  # dfocc, tight
             "OCCD CORRELATION ENERGY": -0.08377901300913,  # dfocc, tight
             "OCCD TOTAL GRADIENT": np.array(  # dfocc, tight
-            [ -0.,  0.000000000000,     0.005192742183,
-               0., -0.000000000000,    -0.005046526527,
-              -0.,  0.014877327583,    -0.000073107828,
-               0., -0.014877327583,    -0.000073107828]
+                [
+                    -0.0,
+                    0.000000000000,
+                    0.005192742183,
+                    0.0,
+                    -0.000000000000,
+                    -0.005046526527,
+                    -0.0,
+                    0.014877327583,
+                    -0.000073107828,
+                    0.0,
+                    -0.014877327583,
+                    -0.000073107828,
+                ]
             ).reshape((-1, 3)),
             "O(T) CORRECTION ENERGY": -0.000628655467,  # dfocc, tight
             "A-O(T) CORRECTION ENERGY": -0.000606118094,  # dfocc, tight
@@ -11172,47 +11832,95 @@ _std_suite = [
             "OMP2 CORRELATION ENERGY": -0.160587412835,  # dfocc, tight
             "OMP2 SAME-SPIN CORRELATION ENERGY": -0.036004901152,  # dfocc, tight
             "OMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
-                  [ 0., -0.000000000000,     0.026914381459,
-                    0.,  0.014240313354,    -0.013457190729,
-                    0., -0.014240313354,    -0.013457190729]
+                [
+                    0.0,
+                    -0.000000000000,
+                    0.026914381459,
+                    0.0,
+                    0.014240313354,
+                    -0.013457190729,
+                    0.0,
+                    -0.014240313354,
+                    -0.013457190729,
+                ]
             ).reshape((-1, 3)),
             "OMP2.5 REFERENCE CORRECTION ENERGY": -0.003239492526,  # dfocc, tight
             "OMP2.5 CORRELATION ENERGY": -0.168477421879,  # dfocc, tight
             "OMP2.5 SAME-SPIN CORRELATION ENERGY": -0.035847923306,  # dfocc, tight
             "OMP2.5 TOTAL GRADIENT": np.array(  # dfocc, tight
-                  [ 0., -0.000000000000,     0.027483206969,
-                    0.,  0.014577000408,    -0.013741603485,
-                    0., -0.014577000408,    -0.013741603485]
+                [
+                    0.0,
+                    -0.000000000000,
+                    0.027483206969,
+                    0.0,
+                    0.014577000408,
+                    -0.013741603485,
+                    0.0,
+                    -0.014577000408,
+                    -0.013741603485,
+                ]
             ).reshape((-1, 3)),
             "OMP3 REFERENCE CORRECTION ENERGY": -0.003389275946,  # dfocc, tight
             "OMP3 CORRELATION ENERGY": -0.176404692086,  # dfocc, tight
             "OMP3 SAME-SPIN CORRELATION ENERGY": -0.035717311411,  # dfocc, tight
             "OMP3 TOTAL GRADIENT": np.array(  # dfocc, tight
-                  [ 0.,  0.000000000000,     0.028112143061,
-                    0.,  0.014949636932,    -0.014056071530,
-                    0., -0.014949636932,    -0.014056071530]
+                [
+                    0.0,
+                    0.000000000000,
+                    0.028112143061,
+                    0.0,
+                    0.014949636932,
+                    -0.014056071530,
+                    0.0,
+                    -0.014949636932,
+                    -0.014056071530,
+                ]
             ).reshape((-1, 3)),
             "OREMP2 REFERENCE CORRECTION ENERGY": -0.003301435451,  # dfocc, tight
             "OREMP2 CORRELATION ENERGY": -0.178082080418,  # dfocc, tight
             "OREMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
-                 [  0., -0.000000000000,     0.030213608364,
-                    0.,  0.016231443474,    -0.015106804182,
-                    0., -0.016231443474,    -0.015106804182]
+                [
+                    0.0,
+                    -0.000000000000,
+                    0.030213608364,
+                    0.0,
+                    0.016231443474,
+                    -0.015106804182,
+                    0.0,
+                    -0.016231443474,
+                    -0.015106804182,
+                ]
             ).reshape((-1, 3)),
             "OLCCD REFERENCE CORRECTION ENERGY": -0.003302111181,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.182610893321,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.034422399491,  # dfocc, tight
             "OLCCD TOTAL GRADIENT": np.array(  # dfocc, tight
-                [       -0.000000000000,    -0.000000000000,     0.031864462561,
-                         0.000000000000,     0.017259000991,    -0.015932231281,
-                        -0.000000000000,    -0.017259000990,    -0.015932231281]
+                [
+                    -0.000000000000,
+                    -0.000000000000,
+                    0.031864462561,
+                    0.000000000000,
+                    0.017259000991,
+                    -0.015932231281,
+                    -0.000000000000,
+                    -0.017259000990,
+                    -0.015932231281,
+                ]
             ).reshape((-1, 3)),
             "OCCD REFERENCE CORRECTION ENERGY": -0.00342629789193,  # dfocc, tight
             "OCCD CORRELATION ENERGY": -0.17822035862112,  # dfocc, tight
             "OCCD TOTAL GRADIENT": np.array(  # dfocc, tight
-             [-0., -0.000000000000,     0.029147627070,
-               0.,  0.015744932006,    -0.014573813535,
-              -0., -0.015744932006,    -0.014573813535]
+                [
+                    -0.0,
+                    -0.000000000000,
+                    0.029147627070,
+                    0.0,
+                    0.015744932006,
+                    -0.014573813535,
+                    -0.0,
+                    -0.015744932006,
+                    -0.014573813535,
+                ]
             ).reshape((-1, 3)),
             "O(T) CORRECTION ENERGY": -0.003993549230,  # dfocc, tight
             "A-O(T) CORRECTION ENERGY": -0.003893263743,  # dfocc, tight
@@ -11254,47 +11962,95 @@ _std_suite = [
             "OMP2 CORRELATION ENERGY": -0.201658737065,  # dfocc, tight
             "OMP2 SAME-SPIN CORRELATION ENERGY": -0.042457672983,  # dfocc, tight
             "OMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
-                  [ 0., -0.000000000000,     0.015291380391,
-                    0.,  0.006145126895,    -0.007645690196,
-                    0., -0.006145126895,    -0.007645690196]
+                [
+                    0.0,
+                    -0.000000000000,
+                    0.015291380391,
+                    0.0,
+                    0.006145126895,
+                    -0.007645690196,
+                    0.0,
+                    -0.006145126895,
+                    -0.007645690196,
+                ]
             ).reshape((-1, 3)),
             "OMP2.5 REFERENCE CORRECTION ENERGY": -0.003259197444,  # dfocc, tight
             "OMP2.5 CORRELATION ENERGY": -0.209113054889,  # dfocc, tight
             "OMP2.5 SAME-SPIN CORRELATION ENERGY": -0.042084275918,  # dfocc, tight
             "OMP2.5 TOTAL GRADIENT": np.array(  # dfocc, tight
-                  [ 0., -0.000000000000,     0.015388624199,
-                    0.,  0.006150440601,    -0.007694312099,
-                    0., -0.006150440601,    -0.007694312099]
+                [
+                    0.0,
+                    -0.000000000000,
+                    0.015388624199,
+                    0.0,
+                    0.006150440601,
+                    -0.007694312099,
+                    0.0,
+                    -0.006150440601,
+                    -0.007694312099,
+                ]
             ).reshape((-1, 3)),
             "OMP3 REFERENCE CORRECTION ENERGY": -0.003432224601,  # dfocc, tight
             "OMP3 CORRELATION ENERGY": -0.216609085513,  # dfocc, tight
             "OMP3 SAME-SPIN CORRELATION ENERGY": -0.041741379888,  # dfocc, tight
             "OMP3 TOTAL GRADIENT": np.array(  # dfocc, tight
-                  [ 0., -0.000000000000,     0.015546139127,
-                    0.,  0.006191172928,    -0.007773069564,
-                    0., -0.006191172928,    -0.007773069564]
+                [
+                    0.0,
+                    -0.000000000000,
+                    0.015546139127,
+                    0.0,
+                    0.006191172928,
+                    -0.007773069564,
+                    0.0,
+                    -0.006191172928,
+                    -0.007773069564,
+                ]
             ).reshape((-1, 3)),
             "OREMP2 REFERENCE CORRECTION ENERGY": -0.003322256873,  # dfocc, tight
             "OREMP2 CORRELATION ENERGY": -0.218316122726,  # dfocc, tight
             "OREMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
-                 [  0., -0.000000000000,     0.017877876813,
-                    0.,  0.007580722265,    -0.008938938407,
-                    0., -0.007580722265,    -0.008938938407]
+                [
+                    0.0,
+                    -0.000000000000,
+                    0.017877876813,
+                    0.0,
+                    0.007580722265,
+                    -0.008938938407,
+                    0.0,
+                    -0.007580722265,
+                    -0.008938938407,
+                ]
             ).reshape((-1, 3)),
             "OLCCD REFERENCE CORRECTION ENERGY": -0.003324348494,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.222648969545,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.040510044397,  # dfocc, tight
             "OLCCD TOTAL GRADIENT": np.array(  # dfocc, tight
-                [        0.000000000000,    -0.000000000000,     0.019447884570,
-                        -0.000000000000,     0.008509802850,    -0.009723942285,
-                         0.000000000000,    -0.008509802849,    -0.009723942285]
+                [
+                    0.000000000000,
+                    -0.000000000000,
+                    0.019447884570,
+                    -0.000000000000,
+                    0.008509802850,
+                    -0.009723942285,
+                    0.000000000000,
+                    -0.008509802849,
+                    -0.009723942285,
+                ]
             ).reshape((-1, 3)),
             "OCCD REFERENCE CORRECTION ENERGY": -0.00345497869314,  # dfocc, tight
             "OCCD CORRELATION ENERGY": -0.21773362291808,  # dfocc, tight
             "OCCD TOTAL GRADIENT": np.array(  # dfocc, tight
-            [  0., -0.000000000000,     0.016675155033,
-              -0.,  0.007064234369,    -0.008337577516,
-               0., -0.007064234369,    -0.008337577516]
+                [
+                    0.0,
+                    -0.000000000000,
+                    0.016675155033,
+                    -0.0,
+                    0.007064234369,
+                    -0.008337577516,
+                    0.0,
+                    -0.007064234369,
+                    -0.008337577516,
+                ]
             ).reshape((-1, 3)),
             "O(T) CORRECTION ENERGY": -0.005337854373,  # dfocc, tight
             "A-O(T) CORRECTION ENERGY": -0.005214252991,  # dfocc, tight
@@ -11352,45 +12108,38 @@ _std_suite = [
             ).reshape((-1, 3)),
             "(T) CORRECTION ENERGY": -0.00192209183545,  # dfocc, tight
             "CCSD(T) TOTAL GRADIENT": np.array(  # dfocc, tight
-                       [ 0.,              0.,              0.003412477814,
-                        -0.,             -0.,             -0.003412477814]
+                [0.0, 0.0, 0.003412477814, -0.0, -0.0, -0.003412477814]
             ).reshape((-1, 3)),
             "A-(T) CORRECTION ENERGY": -0.00194585245550,  # dfocc, tight
             "OMP2 REFERENCE CORRECTION ENERGY": 0.000703072086,  # dfocc, tight
             "OMP2 CORRELATION ENERGY": -0.202322737562,  # dfocc, tight
             "OMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
-                  [ 0.,  0.000000000000,     0.004462211239,
-                    0., -0.000000000000,    -0.004462211239]
+                [0.0, 0.000000000000, 0.004462211239, 0.0, -0.000000000000, -0.004462211239]
             ).reshape((-1, 3)),
             "OMP2.5 REFERENCE CORRECTION ENERGY": 0.000572012280,  # dfocc, tight
             "OMP2.5 CORRELATION ENERGY": -0.203736894925,  # dfocc, tight
             "OMP2.5 TOTAL GRADIENT": np.array(  # dfocc, tight
-                 [  0.,  0.000000000000,     0.002400349139,
-                    0., -0.000000000000,    -0.002400349139]
+                [0.0, 0.000000000000, 0.002400349139, 0.0, -0.000000000000, -0.002400349139]
             ).reshape((-1, 3)),
             "OMP3 REFERENCE CORRECTION ENERGY": 0.000469635507,  # dfocc, tight
             "OMP3 CORRELATION ENERGY": -0.205198445453,  # dfocc, tight
             "OMP3 TOTAL GRADIENT": np.array(  # dfocc, tight
-                  [ 0.,  0.000000000000,     0.000413292087,
-                    0., -0.000000000000,    -0.000413292087]
+                [0.0, 0.000000000000, 0.000413292087, 0.0, -0.000000000000, -0.000413292087]
             ).reshape((-1, 3)),
             "OREMP2 REFERENCE CORRECTION ENERGY": 0.000554531047,  # dfocc, tight
             "OREMP2 CORRELATION ENERGY": -0.207169559461,  # dfocc, tight
             "OREMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
-              [ 0.,  0.000000000000,     0.003224769580,
-                0., -0.000000000000,    -0.003224769580]
+                [0.0, 0.000000000000, 0.003224769580, 0.0, -0.000000000000, -0.003224769580]
             ).reshape((-1, 3)),
             "OLCCD REFERENCE CORRECTION ENERGY": 0.000553992712,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.208748872411,  # dfocc, tight
             "OLCCD TOTAL GRADIENT": np.array(  # dfocc, tight
-              [    0.000000000000,     0.000000000000,     0.003792898685,
-                  -0.000000000000,    -0.000000000000,    -0.003792898685]
+                [0.000000000000, 0.000000000000, 0.003792898685, -0.000000000000, -0.000000000000, -0.003792898685]
             ).reshape((-1, 3)),
             "OCCD REFERENCE CORRECTION ENERGY": 0.00051222526754,  # dfocc, tight
             "OCCD CORRELATION ENERGY": -0.20695630522582,  # dfocc, tight
             "OCCD TOTAL GRADIENT": np.array(  # dfocc, tight
-             [  0.,  0.,   0.002245645626,
-               -0., -0.,  -0.002245645626]
+                [0.0, 0.0, 0.002245645626, -0.0, -0.0, -0.002245645626]
             ).reshape((-1, 3)),
             "O(T) CORRECTION ENERGY": -0.002045023614,  # dfocc, tight
             "A-O(T) CORRECTION ENERGY": -0.002024842553,  # dfocc, tight
@@ -11457,52 +12206,108 @@ _std_suite = [
             ).reshape((-1, 3)),
             "(T) CORRECTION ENERGY": -0.00521721307613,  # dfocc, tight
             "CCSD(T) TOTAL GRADIENT": np.array(  # dfocc, tight
-                       [ 0.,              0.,              0.010801208563,
-                        -0.,              0.006421774051, -0.005400604280,
-                        -0.,             -0.006421774051, -0.005400604283]
+                [
+                    0.0,
+                    0.0,
+                    0.010801208563,
+                    -0.0,
+                    0.006421774051,
+                    -0.005400604280,
+                    -0.0,
+                    -0.006421774051,
+                    -0.005400604283,
+                ]
             ).reshape((-1, 3)),
             "A-(T) CORRECTION ENERGY": -0.00521446434812,  # dfocc, tight
             "OMP2 REFERENCE CORRECTION ENERGY": 0.002352666762,  # dfocc, tight
             "OMP2 CORRELATION ENERGY": -0.221650942141,  # dfocc, tight
             "OMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
-                  [ 0., -0.000000000000,     0.012771605048,
-                    0.,  0.007190306206,    -0.006385802524,
-                    0., -0.007190306205,    -0.006385802524]
+                [
+                    0.0,
+                    -0.000000000000,
+                    0.012771605048,
+                    0.0,
+                    0.007190306206,
+                    -0.006385802524,
+                    0.0,
+                    -0.007190306205,
+                    -0.006385802524,
+                ]
             ).reshape((-1, 3)),
             "OMP2.5 REFERENCE CORRECTION ENERGY": 0.001538577646,  # dfocc, tight
             "OMP2.5 CORRELATION ENERGY": -0.223375325491,  # dfocc, tight
             "OMP2.5 TOTAL GRADIENT": np.array(  # dfocc, tight
-                 [  0., -0.000000000000,     0.008996184043,
-                    0.,  0.005183828520,    -0.004498092021,
-                    0., -0.005183828519,    -0.004498092021]
+                [
+                    0.0,
+                    -0.000000000000,
+                    0.008996184043,
+                    0.0,
+                    0.005183828520,
+                    -0.004498092021,
+                    0.0,
+                    -0.005183828519,
+                    -0.004498092021,
+                ]
             ).reshape((-1, 3)),
             "OMP3 REFERENCE CORRECTION ENERGY": 0.000960712694,  # dfocc, tight
             "OMP3 CORRELATION ENERGY": -0.225313300040,  # dfocc, tight
             "OMP3 TOTAL GRADIENT": np.array(  # dfocc, tight
-                  [ 0., -0.000000000000,     0.005564092786,
-                    0.,  0.003375822885,    -0.002782046393,
-                    0., -0.003375822885,    -0.002782046393]
+                [
+                    0.0,
+                    -0.000000000000,
+                    0.005564092786,
+                    0.0,
+                    0.003375822885,
+                    -0.002782046393,
+                    0.0,
+                    -0.003375822885,
+                    -0.002782046393,
+                ]
             ).reshape((-1, 3)),
             "OREMP2 REFERENCE CORRECTION ENERGY": 0.001285806012,  # dfocc, tight
             "OREMP2 CORRELATION ENERGY": -0.228593144538,  # dfocc, tight
             "OREMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
-             [ 0.0,  0.000000000000,     0.009830485254,
-               0.0,  0.005814222254,    -0.004915242627,
-               0.0, -0.005814222254,    -0.004915242627]
+                [
+                    0.0,
+                    0.000000000000,
+                    0.009830485254,
+                    0.0,
+                    0.005814222254,
+                    -0.004915242627,
+                    0.0,
+                    -0.005814222254,
+                    -0.004915242627,
+                ]
             ).reshape((-1, 3)),
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001194079264,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.231028592985,  # dfocc, tight
             "OLCCD TOTAL GRADIENT": np.array(  # dfocc, tight
-       [        0.000000000000,     0.000000000000,     0.010488609074,
-               -0.000000000000,     0.006266448803,    -0.005244304537,
-               -0.000000000000,    -0.006266448803,    -0.005244304537]
+                [
+                    0.000000000000,
+                    0.000000000000,
+                    0.010488609074,
+                    -0.000000000000,
+                    0.006266448803,
+                    -0.005244304537,
+                    -0.000000000000,
+                    -0.006266448803,
+                    -0.005244304537,
+                ]
             ).reshape((-1, 3)),
             "OCCD REFERENCE CORRECTION ENERGY": 0.00112736114914,  # dfocc, tight
-            "OCCD CORRELATION ENERGY":  -0.22711013815896,  # dfocc, tight
+            "OCCD CORRELATION ENERGY": -0.22711013815896,  # dfocc, tight
             "OCCD TOTAL GRADIENT": np.array(  # dfocc, tight
-            [  0., -0.000000000000,     0.007977310114,
-              -0.,  0.004884098446,    -0.003988655057,
-              -0., -0.004884098446,    -0.003988655057]
+                [
+                    0.0,
+                    -0.000000000000,
+                    0.007977310114,
+                    -0.0,
+                    0.004884098446,
+                    -0.003988655057,
+                    -0.0,
+                    -0.004884098446,
+                    -0.003988655057,
+                ]
             ).reshape((-1, 3)),
             "O(T) CORRECTION ENERGY": -0.005548457534,  # dfocc, tight
             "A-O(T) CORRECTION ENERGY": -0.005450541943,  # dfocc, tight
@@ -11569,52 +12374,98 @@ _std_suite = [
             ).reshape((-1, 3)),
             "(T) CORRECTION ENERGY": -0.00709505459495,  # dfocc, tight
             "CCSD(T) TOTAL GRADIENT": np.array(  # dfocc, tight
-                       [ 0.,              0.,              0.000617506530,
-                        -0.,             -0.000361314051, -0.000308753267,
-                         0.,              0.000361314051, -0.000308753262]
+                [0.0, 0.0, 0.000617506530, -0.0, -0.000361314051, -0.000308753267, 0.0, 0.000361314051, -0.000308753262]
             ).reshape((-1, 3)),
             "A-(T) CORRECTION ENERGY": -0.00701650721029,  # dfocc, tight
             "OMP2 REFERENCE CORRECTION ENERGY": 0.002436225037,  # dfocc, tight
             "OMP2 CORRELATION ENERGY": -0.247501148905,  # dfocc, tight
             "OMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
-                  [ 0., -0.000000000000,     0.002625578291,
-                    0.,  0.000602919468,    -0.001312789146,
-                    0., -0.000602919468,    -0.001312789146]
+                [
+                    0.0,
+                    -0.000000000000,
+                    0.002625578291,
+                    0.0,
+                    0.000602919468,
+                    -0.001312789146,
+                    0.0,
+                    -0.000602919468,
+                    -0.001312789146,
+                ]
             ).reshape((-1, 3)),
             "OMP2.5 REFERENCE CORRECTION ENERGY": 0.001628506731,  # dfocc, tight
             "OMP2.5 CORRELATION ENERGY": -0.247890696918,  # dfocc, tight
             "OMP2.5 TOTAL GRADIENT": np.array(  # dfocc, tight
-                 [  0., -0.000000000000,    -0.001471303306,
-                    0., -0.001622363348,     0.000735651653,
-                    0.,  0.001622363348,     0.000735651653]
+                [
+                    0.0,
+                    -0.000000000000,
+                    -0.001471303306,
+                    0.0,
+                    -0.001622363348,
+                    0.000735651653,
+                    0.0,
+                    0.001622363348,
+                    0.000735651653,
+                ]
             ).reshape((-1, 3)),
             "OMP3 REFERENCE CORRECTION ENERGY": 0.001042188755,  # dfocc, tight
             "OMP3 CORRELATION ENERGY": -0.248510869843,  # dfocc, tight
             "OMP3 TOTAL GRADIENT": np.array(  # dfocc, tight
-                  [ 0., -0.000000000000,    -0.005274771244,
-                    0., -0.003679381392,     0.002637385622,
-                    0.,  0.003679381392,     0.002637385622]
+                [
+                    0.0,
+                    -0.000000000000,
+                    -0.005274771244,
+                    0.0,
+                    -0.003679381392,
+                    0.002637385622,
+                    0.0,
+                    0.003679381392,
+                    0.002637385622,
+                ]
             ).reshape((-1, 3)),
             "OREMP2 REFERENCE CORRECTION ENERGY": 0.001387432536,  # dfocc, tight
             "OREMP2 CORRELATION ENERGY": -0.252366737687,  # dfocc, tight
             "OREMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
-              [ 0.,  0.000000000000,    -0.000767533552,
-                0., -0.001128632785,     0.000383766776,
-                0.,  0.001128632785,     0.000383766776]
+                [
+                    0.0,
+                    0.000000000000,
+                    -0.000767533552,
+                    0.0,
+                    -0.001128632785,
+                    0.000383766776,
+                    0.0,
+                    0.001128632785,
+                    0.000383766776,
+                ]
             ).reshape((-1, 3)),
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001298398813,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.254465606264,  # dfocc, tight
             "OLCCD TOTAL GRADIENT": np.array(  # dfocc, tight
-                [        0.000000000000,    -0.000000000000,    -0.000178270779,
-                        -0.000000000000,    -0.000741462346,     0.000089135390,
-                         0.000000000000,     0.000741462346,     0.000089135390]
+                [
+                    0.000000000000,
+                    -0.000000000000,
+                    -0.000178270779,
+                    -0.000000000000,
+                    -0.000741462346,
+                    0.000089135390,
+                    0.000000000000,
+                    0.000741462346,
+                    0.000089135390,
+                ]
             ).reshape((-1, 3)),
             "OCCD REFERENCE CORRECTION ENERGY": 0.00122701106154,  # dfocc, tight
             "OCCD CORRELATION ENERGY": -0.25004962087804,  # dfocc, tight
             "OCCD TOTAL GRADIENT": np.array(  # dfocc, tight
-            [  0., -0.000000000000,    -0.002738846535,
-              -0., -0.002056141369,     0.001369423268,
-               0.,  0.002056141369,     0.001369423268]
+                [
+                    0.0,
+                    -0.000000000000,
+                    -0.002738846535,
+                    -0.0,
+                    -0.002056141369,
+                    0.001369423268,
+                    0.0,
+                    0.002056141369,
+                    0.001369423268,
+                ]
             ).reshape((-1, 3)),
             "O(T) CORRECTION ENERGY": -0.007400543965,  # dfocc, tight
             "A-O(T) CORRECTION ENERGY": -0.007287376322,  # dfocc, tight
@@ -11698,70 +12549,150 @@ _std_suite = [
             "CCSD CORRELATION ENERGY": -0.08123709133288,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD TOTAL GRADIENT": np.array(  # dfocc, tight
-                       [-0.,              0.,              0.004955877488,
-                         0.,             -0.,             -0.004802960939,
-                        -0.,              0.014879065297, -0.000076458275,
-                         0.,             -0.014879065297, -0.000076458275]
+                [
+                    -0.0,
+                    0.0,
+                    0.004955877488,
+                    0.0,
+                    -0.0,
+                    -0.004802960939,
+                    -0.0,
+                    0.014879065297,
+                    -0.000076458275,
+                    0.0,
+                    -0.014879065297,
+                    -0.000076458275,
+                ]
             ).reshape((-1, 3)),
             "(T) CORRECTION ENERGY": -0.00060440612636,  # dfocc, tight
             "CCSD(T) TOTAL GRADIENT": np.array(  # dfocc, tight
-                       [-0.,              0.,              0.004453849339,
-                         0.,             -0.,             -0.004383447765,
-                        -0.,              0.014958703713, -0.000035200787,
-                         0.,             -0.014958703713, -0.000035200787]
+                [
+                    -0.0,
+                    0.0,
+                    0.004453849339,
+                    0.0,
+                    -0.0,
+                    -0.004383447765,
+                    -0.0,
+                    0.014958703713,
+                    -0.000035200787,
+                    0.0,
+                    -0.014958703713,
+                    -0.000035200787,
+                ]
             ).reshape((-1, 3)),
             "A-(T) CORRECTION ENERGY": -0.00058824527447,  # dfocc, tight
             "OMP2 REFERENCE CORRECTION ENERGY": 0.000394385396,  # dfocc, tight
             "OMP2 CORRELATION ENERGY": -0.058935159355,  # dfocc, tight
             "OMP2 SAME-SPIN CORRELATION ENERGY": -0.001823537679,  # dfocc, tight
             "OMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
-                  [ 0., -0.000000000000,     0.011816043382,
-                    0., -0.000000000000,    -0.011405170159,
-                    0.,  0.010534044966,    -0.000205436611,
-                    0., -0.010534044966,    -0.000205436611]
+                [
+                    0.0,
+                    -0.000000000000,
+                    0.011816043382,
+                    0.0,
+                    -0.000000000000,
+                    -0.011405170159,
+                    0.0,
+                    0.010534044966,
+                    -0.000205436611,
+                    0.0,
+                    -0.010534044966,
+                    -0.000205436611,
+                ]
             ).reshape((-1, 3)),
             "OMP2.5 REFERENCE CORRECTION ENERGY": 0.000566186305,  # dfocc, tight
             "OMP2.5 CORRELATION ENERGY": -0.066806131554,  # dfocc, tight
             "OMP2.5 SAME-SPIN CORRELATION ENERGY": -0.002050540370,  # dfocc, tight
             "OMP2.5 TOTAL GRADIENT": np.array(  # dfocc, tight
-                 [  0.,  0.000000000000,     0.010039510728,
-                    0., -0.000000000000,    -0.009744203205,
-                    0.,  0.011807411335,    -0.000147653762,
-                    0., -0.011807411335,    -0.000147653762]
+                [
+                    0.0,
+                    0.000000000000,
+                    0.010039510728,
+                    0.0,
+                    -0.000000000000,
+                    -0.009744203205,
+                    0.0,
+                    0.011807411335,
+                    -0.000147653762,
+                    0.0,
+                    -0.011807411335,
+                    -0.000147653762,
+                ]
             ).reshape((-1, 3)),
             "OMP3 REFERENCE CORRECTION ENERGY": 0.000783155015,  # dfocc, tight
             "OMP3 CORRELATION ENERGY": -0.074716931449,  # dfocc, tight
             "OMP3 SAME-SPIN CORRELATION ENERGY": -0.002277314389,  # dfocc, tight
             "OMP3 TOTAL GRADIENT": np.array(  # dfocc, tight
-                  [ 0., -0.000000000000,     0.008212538414,
-                    0., -0.000000000000,    -0.008033077982,
-                    0.,  0.013091494156,    -0.000089730216,
-                    0., -0.013091494156,    -0.000089730216]
+                [
+                    0.0,
+                    -0.000000000000,
+                    0.008212538414,
+                    0.0,
+                    -0.000000000000,
+                    -0.008033077982,
+                    0.0,
+                    0.013091494156,
+                    -0.000089730216,
+                    0.0,
+                    -0.013091494156,
+                    -0.000089730216,
+                ]
             ).reshape((-1, 3)),
             "OREMP2 REFERENCE CORRECTION ENERGY": 0.001067566021,  # dfocc, tight
             "OREMP2 CORRELATION ENERGY": -0.078201861999,  # dfocc, tight
             "OREMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
-              [ 0.,  0.000000000000,     0.005652301943,
-                0., -0.000000000000,    -0.005529627660,
-                0.,  0.014380946092,    -0.000061337141,
-                0., -0.014380946092,    -0.000061337141]
+                [
+                    0.0,
+                    0.000000000000,
+                    0.005652301943,
+                    0.0,
+                    -0.000000000000,
+                    -0.005529627660,
+                    0.0,
+                    0.014380946092,
+                    -0.000061337141,
+                    0.0,
+                    -0.014380946092,
+                    -0.000061337141,
+                ]
             ).reshape((-1, 3)),
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001494223667,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.083986395282,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.002308873939,  # dfocc, tight
             "OLCCD TOTAL GRADIENT": np.array(  # dfocc, tight
-                [       -0.000000000000,     0.000000000000,     0.002693251383,
-                         0.000000000000,    -0.000000000000,    -0.002664270590,
-                        -0.000000000000,     0.015745905068,    -0.000014490396,
-                         0.000000000000,    -0.015745905068,    -0.000014490396]
+                [
+                    -0.000000000000,
+                    0.000000000000,
+                    0.002693251383,
+                    0.000000000000,
+                    -0.000000000000,
+                    -0.002664270590,
+                    -0.000000000000,
+                    0.015745905068,
+                    -0.000014490396,
+                    0.000000000000,
+                    -0.015745905068,
+                    -0.000014490396,
+                ]
             ).reshape((-1, 3)),
             "OCCD REFERENCE CORRECTION ENERGY": 0.00117513618887,  # dfocc, tight
             "OCCD CORRELATION ENERGY": -0.08143642271488,  # dfocc, tight
             "OCCD TOTAL GRADIENT": np.array(  # dfocc, tight
-            [ -0.,  0.000000000000,     0.004941329452,
-               0., -0.000000000000,    -0.004783766728,
-              -0.,  0.014873123435,    -0.000078781362,
-               0., -0.014873123435,    -0.000078781362]
+                [
+                    -0.0,
+                    0.000000000000,
+                    0.004941329452,
+                    0.0,
+                    -0.000000000000,
+                    -0.004783766728,
+                    -0.0,
+                    0.014873123435,
+                    -0.000078781362,
+                    0.0,
+                    -0.014873123435,
+                    -0.000078781362,
+                ]
             ).reshape((-1, 3)),
             "O(T) CORRECTION ENERGY": -0.000609013952,  # dfocc, tight
             "A-O(T) CORRECTION ENERGY": -0.000587107823,  # dfocc, tight
@@ -11816,62 +12747,126 @@ _std_suite = [
             "CCSD CORRELATION ENERGY": -0.17173557387375,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD TOTAL GRADIENT": np.array(  # dfocc, tight
-                       [-0.,              0.,              0.030043575132,
-                         0.,              0.016300990267, -0.015021787567,
-                        -0.,             -0.016300990267, -0.015021787565]
+                [
+                    -0.0,
+                    0.0,
+                    0.030043575132,
+                    0.0,
+                    0.016300990267,
+                    -0.015021787567,
+                    -0.0,
+                    -0.016300990267,
+                    -0.015021787565,
+                ]
             ).reshape((-1, 3)),
             "(T) CORRECTION ENERGY": -0.00381543842966,  # dfocc, tight
             "CCSD(T) TOTAL GRADIENT": np.array(  # dfocc, tight
-                       [-0.,              0.,              0.031923074308,
-                         0.,              0.017296807836, -0.015961537154,
-                        -0.,             -0.017296807836, -0.015961537154]
+                [
+                    -0.0,
+                    0.0,
+                    0.031923074308,
+                    0.0,
+                    0.017296807836,
+                    -0.015961537154,
+                    -0.0,
+                    -0.017296807836,
+                    -0.015961537154,
+                ]
             ).reshape((-1, 3)),
             "A-(T) CORRECTION ENERGY": -0.00373604126252,  # dfocc, tight
             "OMP2 REFERENCE CORRECTION ENERGY": 0.001361296352,  # dfocc, tight
             "OMP2 CORRELATION ENERGY": -0.153806958505,  # dfocc, tight
             "OMP2 SAME-SPIN CORRELATION ENERGY": -0.035220509485,  # dfocc, tight
             "OMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
-                  [ 0., -0.000000000000,     0.027773187697,
-                    0.,  0.014760469702,    -0.013886593849,
-                    0., -0.014760469702,    -0.013886593849]
+                [
+                    0.0,
+                    -0.000000000000,
+                    0.027773187697,
+                    0.0,
+                    0.014760469702,
+                    -0.013886593849,
+                    0.0,
+                    -0.014760469702,
+                    -0.013886593849,
+                ]
             ).reshape((-1, 3)),
             "OMP2.5 REFERENCE CORRECTION ENERGY": 0.001172388039,  # dfocc, tight
             "OMP2.5 CORRELATION ENERGY": -0.161802412521,  # dfocc, tight
             "OMP2.5 SAME-SPIN CORRELATION ENERGY": -0.035084385482,  # dfocc, tight
             "OMP2.5 TOTAL GRADIENT": np.array(  # dfocc, tight
-                 [  0., -0.000000000000,     0.028357272969,
-                    0.,  0.015100442421,    -0.014178636485,
-                    0., -0.015100442421,    -0.014178636485]
+                [
+                    0.0,
+                    -0.000000000000,
+                    0.028357272969,
+                    0.0,
+                    0.015100442421,
+                    -0.014178636485,
+                    0.0,
+                    -0.015100442421,
+                    -0.014178636485,
+                ]
             ).reshape((-1, 3)),
             "OMP3 REFERENCE CORRECTION ENERGY": 0.001026896343,  # dfocc, tight
             "OMP3 CORRELATION ENERGY": -0.169839459643,  # dfocc, tight
             "OMP3 SAME-SPIN CORRELATION ENERGY": -0.034978089725,  # dfocc, tight
             "OMP3 TOTAL GRADIENT": np.array(  # dfocc, tight
-                  [ 0., -0.000000000000,     0.029002023504,
-                    0.,  0.015477270320,    -0.014501011752,
-                    0., -0.015477270319,    -0.014501011752]
+                [
+                    0.0,
+                    -0.000000000000,
+                    0.029002023504,
+                    0.0,
+                    0.015477270320,
+                    -0.014501011752,
+                    0.0,
+                    -0.015477270319,
+                    -0.014501011752,
+                ]
             ).reshape((-1, 3)),
             "OREMP2 REFERENCE CORRECTION ENERGY": 0.001113332083,  # dfocc, tight
             "OREMP2 CORRELATION ENERGY": -0.171513122196,  # dfocc, tight
             "OREMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
-              [ 0., -0.000000000000,     0.031096217899,
-                0.,  0.016756071833,    -0.015548108949,
-                0., -0.016756071832,    -0.015548108949]
+                [
+                    0.0,
+                    -0.000000000000,
+                    0.031096217899,
+                    0.0,
+                    0.016756071833,
+                    -0.015548108949,
+                    0.0,
+                    -0.016756071832,
+                    -0.015548108949,
+                ]
             ).reshape((-1, 3)),
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001113749802,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.176088417240,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.033693410677,  # dfocc, tight
             "OLCCD TOTAL GRADIENT": np.array(  # dfocc, tight
-                [       -0.000000000000,    -0.000000000000,     0.032749728621,
-                         0.000000000000,     0.017783947932,    -0.016374864311,
-                        -0.000000000000,    -0.017783947932,    -0.016374864310]
+                [
+                    -0.000000000000,
+                    -0.000000000000,
+                    0.032749728621,
+                    0.000000000000,
+                    0.017783947932,
+                    -0.016374864311,
+                    -0.000000000000,
+                    -0.017783947932,
+                    -0.016374864310,
+                ]
             ).reshape((-1, 3)),
             "OCCD REFERENCE CORRECTION ENERGY": 0.00098853594635,  # dfocc, tight
             "OCCD CORRELATION ENERGY": -0.17171797869288,  # dfocc, tight
             "OCCD TOTAL GRADIENT": np.array(  # dfocc, tight
-            [ -0., -0.000000000000,     0.030027361324,
-               0.,  0.016268352543,    -0.015013680662,
-              -0., -0.016268352543,    -0.015013680662]
+                [
+                    -0.0,
+                    -0.000000000000,
+                    0.030027361324,
+                    0.0,
+                    0.016268352543,
+                    -0.015013680662,
+                    -0.0,
+                    -0.016268352543,
+                    -0.015013680662,
+                ]
             ).reshape((-1, 3)),
             "O(T) CORRECTION ENERGY": -0.003958389693,  # dfocc, tight
             "A-O(T) CORRECTION ENERGY": -0.003858590576,  # dfocc, tight
@@ -11926,62 +12921,126 @@ _std_suite = [
             "CCSD CORRELATION ENERGY": -0.18830636267506,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD TOTAL GRADIENT": np.array(  # dfocc, tight
-                       [ 0.,             -0.,              0.017859476803,
-                        -0.,              0.007647663282, -0.008929738402,
-                         0.,             -0.007647663282, -0.008929738401]
+                [
+                    0.0,
+                    -0.0,
+                    0.017859476803,
+                    -0.0,
+                    0.007647663282,
+                    -0.008929738402,
+                    0.0,
+                    -0.007647663282,
+                    -0.008929738401,
+                ]
             ).reshape((-1, 3)),
             "(T) CORRECTION ENERGY": -0.00498171470106,  # dfocc, tight
             "CCSD(T) TOTAL GRADIENT": np.array(  # dfocc, tight
-                       [ 0.,             -0.,              0.020007178737,
-                        -0.,              0.008716203188, -0.010003589371,
-                         0.,             -0.008716203188, -0.010003589367]
+                [
+                    0.0,
+                    -0.0,
+                    0.020007178737,
+                    -0.0,
+                    0.008716203188,
+                    -0.010003589371,
+                    0.0,
+                    -0.008716203188,
+                    -0.010003589367,
+                ]
             ).reshape((-1, 3)),
             "A-(T) CORRECTION ENERGY": -0.00488153123480,  # dfocc, tight
             "OMP2 REFERENCE CORRECTION ENERGY": 0.001480332224,  # dfocc, tight
             "OMP2 CORRELATION ENERGY": -0.172665177005,  # dfocc, tight
             "OMP2 SAME-SPIN CORRELATION ENERGY": -0.039018138633,  # dfocc, tight
             "OMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
-                  [ 0.,  0.000000000000,     0.016299386418,
-                    0.,  0.006629699700,    -0.008149693209,
-                    0., -0.006629699700,    -0.008149693209]
+                [
+                    0.0,
+                    0.000000000000,
+                    0.016299386418,
+                    0.0,
+                    0.006629699700,
+                    -0.008149693209,
+                    0.0,
+                    -0.006629699700,
+                    -0.008149693209,
+                ]
             ).reshape((-1, 3)),
             "OMP2.5 REFERENCE CORRECTION ENERGY": 0.001272971815,  # dfocc, tight
             "OMP2.5 CORRELATION ENERGY": -0.179766145094,  # dfocc, tight
             "OMP2.5 SAME-SPIN CORRELATION ENERGY": -0.038623138099,  # dfocc, tight
             "OMP2.5 TOTAL GRADIENT": np.array(  # dfocc, tight
-                 [  0., -0.000000000000,     0.016424137432,
-                    0.,  0.006638678143,    -0.008212068716,
-                    0., -0.006638678143,    -0.008212068716]
+                [
+                    0.0,
+                    -0.000000000000,
+                    0.016424137432,
+                    0.0,
+                    0.006638678143,
+                    -0.008212068716,
+                    0.0,
+                    -0.006638678143,
+                    -0.008212068716,
+                ]
             ).reshape((-1, 3)),
             "OMP3 REFERENCE CORRECTION ENERGY": 0.001112851260,  # dfocc, tight
             "OMP3 CORRELATION ENERGY": -0.186923452541,  # dfocc, tight
             "OMP3 SAME-SPIN CORRELATION ENERGY": -0.038268824767,  # dfocc, tight
             "OMP3 TOTAL GRADIENT": np.array(  # dfocc, tight
-                  [ 0.,  0.000000000000,     0.016608938328,
-                    0.,  0.006684117862,    -0.008304469164,
-                    0., -0.006684117862,    -0.008304469164]
+                [
+                    0.0,
+                    0.000000000000,
+                    0.016608938328,
+                    0.0,
+                    0.006684117862,
+                    -0.008304469164,
+                    0.0,
+                    -0.006684117862,
+                    -0.008304469164,
+                ]
             ).reshape((-1, 3)),
             "OREMP2 REFERENCE CORRECTION ENERGY": 0.001217776401,  # dfocc, tight
             "OREMP2 CORRELATION ENERGY": -0.188735219689,  # dfocc, tight
             "OREMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
-              [ 0.,  0.000000000000,     0.018940660731,
-                0.,  0.008076822926,    -0.009470330365,
-                0., -0.008076822926,    -0.009470330365]
+                [
+                    0.0,
+                    0.000000000000,
+                    0.018940660731,
+                    0.0,
+                    0.008076822926,
+                    -0.009470330365,
+                    0.0,
+                    -0.008076822926,
+                    -0.009470330365,
+                ]
             ).reshape((-1, 3)),
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001218640112,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.192974799277,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.037040961442,  # dfocc, tight
             "OLCCD TOTAL GRADIENT": np.array(  # dfocc, tight
-                [        0.000000000000,     0.000000000000,     0.020520978467,
-                        -0.000000000000,     0.009009472752,    -0.010260489234,
-                         0.000000000000,    -0.009009472752,    -0.010260489234]
+                [
+                    0.000000000000,
+                    0.000000000000,
+                    0.020520978467,
+                    -0.000000000000,
+                    0.009009472752,
+                    -0.010260489234,
+                    0.000000000000,
+                    -0.009009472752,
+                    -0.010260489234,
+                ]
             ).reshape((-1, 3)),
             "OCCD REFERENCE CORRECTION ENERGY": 0.0010910673835,  # dfocc, tight
             "OCCD CORRELATION ENERGY": -0.18822673037030,  # dfocc, tight
             "OCCD TOTAL GRADIENT": np.array(  # dfocc, tight
-            [  0.,  0.000000000000,     0.017781686076,
-              -0.,  0.007590501254,    -0.008890843038,
-               0., -0.007590501254,    -0.008890843038]
+                [
+                    0.0,
+                    0.000000000000,
+                    0.017781686076,
+                    -0.0,
+                    0.007590501254,
+                    -0.008890843038,
+                    0.0,
+                    -0.007590501254,
+                    -0.008890843038,
+                ]
             ).reshape((-1, 3)),
             "O(T) CORRECTION ENERGY": -0.005145029771,  # dfocc, tight
             "A-O(T) CORRECTION ENERGY": -0.005024912480,  # dfocc, tight
@@ -12026,53 +13085,113 @@ _std_suite = [
             "OMP2 CORRELATION ENERGY": -0.060459196444,  # dfocc, tight
             "OMP2 SAME-SPIN CORRELATION ENERGY": -0.001823537706,  # dfocc, tight
             "OMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
-                  [ 0.,  0.000000000000,     0.011816050823,
-                    0., -0.000000000000,    -0.011405176978,
-                    0.,  0.010534044979,    -0.000205436923,
-                    0., -0.010534044979,    -0.000205436923]
+                [
+                    0.0,
+                    0.000000000000,
+                    0.011816050823,
+                    0.0,
+                    -0.000000000000,
+                    -0.011405176978,
+                    0.0,
+                    0.010534044979,
+                    -0.000205436923,
+                    0.0,
+                    -0.010534044979,
+                    -0.000205436923,
+                ]
             ).reshape((-1, 3)),
             "OMP2.5 REFERENCE CORRECTION ENERGY": -0.000957847537,  # dfocc, tight
             "OMP2.5 CORRELATION ENERGY": -0.068330168643,  # dfocc, tight
             "OMP2.5 SAME-SPIN CORRELATION ENERGY": -0.002050540345,  # dfocc, tight
             "OMP2.5 TOTAL GRADIENT": np.array(  # dfocc, tight
-                 [  0.,  0.000000000000,     0.010039462838,
-                    0., -0.000000000000,    -0.009744167884,
-                    0.,  0.011807418804,    -0.000147647477,
-                    0., -0.011807418804,    -0.000147647477]
+                [
+                    0.0,
+                    0.000000000000,
+                    0.010039462838,
+                    0.0,
+                    -0.000000000000,
+                    -0.009744167884,
+                    0.0,
+                    0.011807418804,
+                    -0.000147647477,
+                    0.0,
+                    -0.011807418804,
+                    -0.000147647477,
+                ]
             ).reshape((-1, 3)),
             "OMP3 REFERENCE CORRECTION ENERGY": -0.000740878651,  # dfocc, tight
             "OMP3 CORRELATION ENERGY": -0.076240968538,  # dfocc, tight
             "OMP3 SAME-SPIN CORRELATION ENERGY": -0.002277314395,  # dfocc, tight
             "OMP3 TOTAL GRADIENT": np.array(  # dfocc, tight
-                  [ 0.,  0.000000000000,     0.008212498711,
-                    0., -0.000000000000,    -0.008033043130,
-                    0.,  0.013091495437,    -0.000089727790,
-                    0., -0.013091495437,    -0.000089727790]
+                [
+                    0.0,
+                    0.000000000000,
+                    0.008212498711,
+                    0.0,
+                    -0.000000000000,
+                    -0.008033043130,
+                    0.0,
+                    0.013091495437,
+                    -0.000089727790,
+                    0.0,
+                    -0.013091495437,
+                    -0.000089727790,
+                ]
             ).reshape((-1, 3)),
             "OREMP2 REFERENCE CORRECTION ENERGY": -0.000456469124,  # dfocc, tight
             "OREMP2 CORRELATION ENERGY": -0.079725899088,  # dfocc, tight
             "OREMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
-              [ 0.,  0.000000000000,     0.005652293263,
-                0., -0.000000000000,    -0.005529605660,
-                0.,  0.014380930007,    -0.000061343802,
-                0., -0.014380930007,    -0.000061343802]
+                [
+                    0.0,
+                    0.000000000000,
+                    0.005652293263,
+                    0.0,
+                    -0.000000000000,
+                    -0.005529605660,
+                    0.0,
+                    0.014380930007,
+                    -0.000061343802,
+                    0.0,
+                    -0.014380930007,
+                    -0.000061343802,
+                ]
             ).reshape((-1, 3)),
             "OLCCD REFERENCE CORRECTION ENERGY": -0.000029817721,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.085510432371,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.002308874960,  # dfocc, tight
             "OLCCD TOTAL GRADIENT": np.array(  # dfocc, tight
-                [       -0.000000000000,     0.000000000000,     0.002693270150,
-                         0.000000000000,    -0.000000000000,    -0.002664286871,
-                        -0.000000000000,     0.015745889183,    -0.000014491640,
-                         0.000000000000,    -0.015745889183,    -0.000014491640]
+                [
+                    -0.000000000000,
+                    0.000000000000,
+                    0.002693270150,
+                    0.000000000000,
+                    -0.000000000000,
+                    -0.002664286871,
+                    -0.000000000000,
+                    0.015745889183,
+                    -0.000014491640,
+                    0.000000000000,
+                    -0.015745889183,
+                    -0.000014491640,
+                ]
             ).reshape((-1, 3)),
             "OCCD REFERENCE CORRECTION ENERGY": -0.00034890091894,  # dfocc, tight
             "OCCD CORRELATION ENERGY": -0.08296045969717,  # dfocc, tight
             "OCCD TOTAL GRADIENT": np.array(  # dfocc, tight
-            [ -0.,  0.000000000000,     0.004941329268,
-               0., -0.000000000000,    -0.004783766592,
-              -0.,  0.014873123401,    -0.000078781338,
-               0., -0.014873123401,    -0.000078781338]
+                [
+                    -0.0,
+                    0.000000000000,
+                    0.004941329268,
+                    0.0,
+                    -0.000000000000,
+                    -0.004783766592,
+                    -0.0,
+                    0.014873123401,
+                    -0.000078781338,
+                    0.0,
+                    -0.014873123401,
+                    -0.000078781338,
+                ]
             ).reshape((-1, 3)),
             "O(T) CORRECTION ENERGY": -0.000609013944,  # dfocc, tight
             "A-O(T) CORRECTION ENERGY": -0.000587107816,  # dfocc, tight
@@ -12114,47 +13233,95 @@ _std_suite = [
             "OMP2 CORRELATION ENERGY": -0.158220918714,  # dfocc, tight
             "OMP2 SAME-SPIN CORRELATION ENERGY": -0.035220509402,  # dfocc, tight
             "OMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
-                  [ 0., -0.000000000000,     0.027773186774,
-                    0.,  0.014760475104,    -0.013886593387,
-                    0., -0.014760475103,    -0.013886593387]
+                [
+                    0.0,
+                    -0.000000000000,
+                    0.027773186774,
+                    0.0,
+                    0.014760475104,
+                    -0.013886593387,
+                    0.0,
+                    -0.014760475103,
+                    -0.013886593387,
+                ]
             ).reshape((-1, 3)),
             "OMP2.5 REFERENCE CORRECTION ENERGY": -0.003241577707,  # dfocc, tight
             "OMP2.5 CORRELATION ENERGY": -0.166216372729,  # dfocc, tight
             "OMP2.5 SAME-SPIN CORRELATION ENERGY": -0.035084385218,  # dfocc, tight
             "OMP2.5 TOTAL GRADIENT": np.array(  # dfocc, tight
-                 [  0., -0.000000000000,     0.028357346855,
-                    0.,  0.015100453507,    -0.014178673427,
-                    0., -0.015100453507,    -0.014178673427]
+                [
+                    0.0,
+                    -0.000000000000,
+                    0.028357346855,
+                    0.0,
+                    0.015100453507,
+                    -0.014178673427,
+                    0.0,
+                    -0.015100453507,
+                    -0.014178673427,
+                ]
             ).reshape((-1, 3)),
             "OMP3 REFERENCE CORRECTION ENERGY": -0.003387066455,  # dfocc, tight
             "OMP3 CORRELATION ENERGY": -0.174253419851,  # dfocc, tight
             "OMP3 SAME-SPIN CORRELATION ENERGY": -0.034978090484,  # dfocc, tight
             "OMP3 TOTAL GRADIENT": np.array(  # dfocc, tight
-                  [ 0., -0.000000000000,     0.029002032180,
-                    0.,  0.015477263061,    -0.014501016090,
-                    0., -0.015477263061,    -0.014501016090]
+                [
+                    0.0,
+                    -0.000000000000,
+                    0.029002032180,
+                    0.0,
+                    0.015477263061,
+                    -0.014501016090,
+                    0.0,
+                    -0.015477263061,
+                    -0.014501016090,
+                ]
             ).reshape((-1, 3)),
             "OREMP2 REFERENCE CORRECTION ENERGY": -0.003300628093,  # dfocc, tight
             "OREMP2 CORRELATION ENERGY": -0.175927082404,  # dfocc, tight
             "OREMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
-              [ 0., -0.000000000000,     0.031096218276,
-                0.,  0.016756071943,    -0.015548109138,
-                0., -0.016756071943,    -0.015548109138]
+                [
+                    0.0,
+                    -0.000000000000,
+                    0.031096218276,
+                    0.0,
+                    0.016756071943,
+                    -0.015548109138,
+                    0.0,
+                    -0.016756071943,
+                    -0.015548109138,
+                ]
             ).reshape((-1, 3)),
             "OLCCD REFERENCE CORRECTION ENERGY": -0.003300211378,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.180502377447,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.033693402688,  # dfocc, tight
             "OLCCD TOTAL GRADIENT": np.array(  # dfocc, tight
-                [       -0.000000000000,    -0.000000000000,     0.032749671199,
-                         0.000000000000,     0.017783936393,    -0.016374835600,
-                        -0.000000000000,    -0.017783936393,    -0.016374835600]
+                [
+                    -0.000000000000,
+                    -0.000000000000,
+                    0.032749671199,
+                    0.000000000000,
+                    0.017783936393,
+                    -0.016374835600,
+                    -0.000000000000,
+                    -0.017783936393,
+                    -0.016374835600,
+                ]
             ).reshape((-1, 3)),
             "OCCD REFERENCE CORRECTION ENERGY": -0.00342542420012,  # dfocc, tight
             "OCCD CORRELATION ENERGY": -0.17613193885178,  # dfocc, tight
             "OCCD TOTAL GRADIENT": np.array(  # dfocc, tight
-            [ -0., -0.000000000000,     0.030027364470,
-               0.,  0.016268353265,    -0.015013682235,
-              -0., -0.016268353265,    -0.015013682235]
+                [
+                    -0.0,
+                    -0.000000000000,
+                    0.030027364470,
+                    0.0,
+                    0.016268353265,
+                    -0.015013682235,
+                    -0.0,
+                    -0.016268353265,
+                    -0.015013682235,
+                ]
             ).reshape((-1, 3)),
             "O(T) CORRECTION ENERGY": -0.003958389711,  # dfocc, tight
             "A-O(T) CORRECTION ENERGY": -0.003858590593,  # dfocc, tight
@@ -12196,47 +13363,95 @@ _std_suite = [
             "OMP2 CORRELATION ENERGY": -0.177275218950,  # dfocc, tight
             "OMP2 SAME-SPIN CORRELATION ENERGY": -0.039018136779,  # dfocc, tight
             "OMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
-                  [ 0., -0.000000000000,     0.016299403030,
-                    0.,  0.006629703904,    -0.008149701515,
-                    0., -0.006629703904,    -0.008149701515]
+                [
+                    0.0,
+                    -0.000000000000,
+                    0.016299403030,
+                    0.0,
+                    0.006629703904,
+                    -0.008149701515,
+                    0.0,
+                    -0.006629703904,
+                    -0.008149701515,
+                ]
             ).reshape((-1, 3)),
             "OMP2.5 REFERENCE CORRECTION ENERGY": -0.003337076220,  # dfocc, tight
             "OMP2.5 CORRELATION ENERGY": -0.184376187039,  # dfocc, tight
             "OMP2.5 SAME-SPIN CORRELATION ENERGY": -0.038623138676,  # dfocc, tight
             "OMP2.5 TOTAL GRADIENT": np.array(  # dfocc, tight
-                 [  0., -0.000000000000,     0.016424136331,
-                    0.,  0.006638670952,    -0.008212068165,
-                    0., -0.006638670952,    -0.008212068165]
+                [
+                    0.0,
+                    -0.000000000000,
+                    0.016424136331,
+                    0.0,
+                    0.006638670952,
+                    -0.008212068165,
+                    0.0,
+                    -0.006638670952,
+                    -0.008212068165,
+                ]
             ).reshape((-1, 3)),
             "OMP3 REFERENCE CORRECTION ENERGY": -0.003497196377,  # dfocc, tight
             "OMP3 CORRELATION ENERGY": -0.191533494486,  # dfocc, tight
             "OMP3 SAME-SPIN CORRELATION ENERGY": -0.038268825438,  # dfocc, tight
             "OMP3 TOTAL GRADIENT": np.array(  # dfocc, tight
-                  [ 0.,  0.000000000000,     0.016608946514,
-                    0.,  0.006684114421,    -0.008304473257,
-                    0., -0.006684114421,    -0.008304473257]
+                [
+                    0.0,
+                    0.000000000000,
+                    0.016608946514,
+                    0.0,
+                    0.006684114421,
+                    -0.008304473257,
+                    0.0,
+                    -0.006684114421,
+                    -0.008304473257,
+                ]
             ).reshape((-1, 3)),
             "OREMP2 REFERENCE CORRECTION ENERGY": -0.003392270931,  # dfocc, tight
             "OREMP2 CORRELATION ENERGY": -0.193345261634,  # dfocc, tight
             "OREMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
-              [ 0.,  0.000000000000,     0.018940651737,
-                0.,  0.008076829692,    -0.009470325868,
-                0., -0.008076829692,    -0.009470325868]
+                [
+                    0.0,
+                    0.000000000000,
+                    0.018940651737,
+                    0.0,
+                    0.008076829692,
+                    -0.009470325868,
+                    0.0,
+                    -0.008076829692,
+                    -0.009470325868,
+                ]
             ).reshape((-1, 3)),
             "OLCCD REFERENCE CORRECTION ENERGY": -0.003391400191,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.197584841222,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.037040959020,  # dfocc, tight
             "OLCCD TOTAL GRADIENT": np.array(  # dfocc, tight
-                [        0.000000000000,     0.000000000000,     0.020521012807,
-                        -0.000000000000,     0.009009479704,    -0.010260506404,
-                         0.000000000000,    -0.009009479704,    -0.010260506404]
+                [
+                    0.000000000000,
+                    0.000000000000,
+                    0.020521012807,
+                    -0.000000000000,
+                    0.009009479704,
+                    -0.010260506404,
+                    0.000000000000,
+                    -0.009009479704,
+                    -0.010260506404,
+                ]
             ).reshape((-1, 3)),
             "OCCD REFERENCE CORRECTION ENERGY": -0.00351897455648,  # dfocc, tight
             "OCCD CORRELATION ENERGY": -0.19283677235185,  # dfocc, tight
             "OCCD TOTAL GRADIENT": np.array(  # dfocc, tight
-            [  0.,  0.000000000000,     0.017781687051,
-              -0.,  0.007590501825,    -0.008890843526,
-               0., -0.007590501825,    -0.008890843526]
+                [
+                    0.0,
+                    0.000000000000,
+                    0.017781687051,
+                    -0.0,
+                    0.007590501825,
+                    -0.008890843526,
+                    0.0,
+                    -0.007590501825,
+                    -0.008890843526,
+                ]
             ).reshape((-1, 3)),
             "O(T) CORRECTION ENERGY": -0.005145029773,  # dfocc, tight
             "A-O(T) CORRECTION ENERGY": -0.005024912482,  # dfocc, tight
@@ -12542,369 +13757,377 @@ _std_suite = [
 
 
 def compute_derived_qcvars(std_suite_list):
-  for calc in std_suite_list:
-    if calc["data"]:
-        if "MP2 CORRELATION ENERGY" in calc["data"]:
-            calc["data"]["MP2 TOTAL ENERGY"] = calc["data"]["MP2 CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
-            if "MP2 SINGLES ENERGY" in calc["data"]:
-                calc["data"]["MP2 DOUBLES ENERGY"] = (
-                    calc["data"]["MP2 CORRELATION ENERGY"] - calc["data"]["MP2 SINGLES ENERGY"]
-                )
-                if "MP2 SAME-SPIN CORRELATION ENERGY" in calc["data"]:
-                    calc["data"]["MP2 OPPOSITE-SPIN CORRELATION ENERGY"] = (
-                        calc["data"]["MP2 CORRELATION ENERGY"]
-                        - calc["data"]["MP2 SAME-SPIN CORRELATION ENERGY"]
-                        - calc["data"]["MP2 SINGLES ENERGY"]
-                    )
-                    calc["data"]["SCS-MP2 CORRELATION ENERGY"] = (
-                        (1 / 3) * calc["data"]["MP2 SAME-SPIN CORRELATION ENERGY"]
-                        + (6 / 5) * calc["data"]["MP2 OPPOSITE-SPIN CORRELATION ENERGY"]
-                        + calc["data"]["MP2 SINGLES ENERGY"]
-                    )
-                    calc["data"]["SCS-MP2 TOTAL ENERGY"] = (
-                        calc["data"]["SCS-MP2 CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
-                    )
-
-        if "MP3 CORRELATION ENERGY" in calc["data"]:
-            calc["data"]["MP3 TOTAL ENERGY"] = calc["data"]["MP3 CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
+    for calc in std_suite_list:
+        if calc["data"]:
             if "MP2 CORRELATION ENERGY" in calc["data"]:
-                calc["data"]["MP2.5 CORRELATION ENERGY"] = 0.5 * (
-                    calc["data"]["MP3 CORRELATION ENERGY"] + calc["data"]["MP2 CORRELATION ENERGY"]
-                )
-                calc["data"]["MP2.5 TOTAL ENERGY"] = (
-                    calc["data"]["MP2.5 CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
-                )
-
-            if "MP3 SINGLES ENERGY" in calc["data"]:
-                calc["data"]["MP3 DOUBLES ENERGY"] = (
-                    calc["data"]["MP3 CORRELATION ENERGY"] - calc["data"]["MP3 SINGLES ENERGY"]
+                calc["data"]["MP2 TOTAL ENERGY"] = (
+                    calc["data"]["MP2 CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
                 )
                 if "MP2 SINGLES ENERGY" in calc["data"]:
-                    calc["data"]["MP2.5 SINGLES ENERGY"] = 0.5 * (
-                        calc["data"]["MP3 SINGLES ENERGY"] + calc["data"]["MP2 SINGLES ENERGY"]
-                    )
-                    calc["data"]["MP2.5 DOUBLES ENERGY"] = (
-                        calc["data"]["MP2.5 CORRELATION ENERGY"] - calc["data"]["MP2.5 SINGLES ENERGY"]
-                    )
-                if "MP3 SAME-SPIN CORRELATION ENERGY" in calc["data"]:
-                    calc["data"]["MP3 OPPOSITE-SPIN CORRELATION ENERGY"] = (
-                        calc["data"]["MP3 CORRELATION ENERGY"]
-                        - calc["data"]["MP3 SAME-SPIN CORRELATION ENERGY"]
-                        - calc["data"]["MP3 SINGLES ENERGY"]
+                    calc["data"]["MP2 DOUBLES ENERGY"] = (
+                        calc["data"]["MP2 CORRELATION ENERGY"] - calc["data"]["MP2 SINGLES ENERGY"]
                     )
                     if "MP2 SAME-SPIN CORRELATION ENERGY" in calc["data"]:
-                        calc["data"]["MP2.5 SAME-SPIN CORRELATION ENERGY"] = 0.5 * (
-                            calc["data"]["MP3 SAME-SPIN CORRELATION ENERGY"]
-                            + calc["data"]["MP2 SAME-SPIN CORRELATION ENERGY"]
+                        calc["data"]["MP2 OPPOSITE-SPIN CORRELATION ENERGY"] = (
+                            calc["data"]["MP2 CORRELATION ENERGY"]
+                            - calc["data"]["MP2 SAME-SPIN CORRELATION ENERGY"]
+                            - calc["data"]["MP2 SINGLES ENERGY"]
                         )
-                        calc["data"]["MP2.5 OPPOSITE-SPIN CORRELATION ENERGY"] = (
-                            calc["data"]["MP2.5 CORRELATION ENERGY"]
-                            - calc["data"]["MP2.5 SAME-SPIN CORRELATION ENERGY"]
-                            - calc["data"]["MP2.5 SINGLES ENERGY"]
+                        calc["data"]["SCS-MP2 CORRELATION ENERGY"] = (
+                            (1 / 3) * calc["data"]["MP2 SAME-SPIN CORRELATION ENERGY"]
+                            + (6 / 5) * calc["data"]["MP2 OPPOSITE-SPIN CORRELATION ENERGY"]
+                            + calc["data"]["MP2 SINGLES ENERGY"]
                         )
-
-        if (
-            "MP3 TOTAL GRADIENT" in calc["data"]
-            and "MP2 TOTAL GRADIENT" in calc["data"]
-            and "HF TOTAL GRADIENT" in calc["data"]
-        ):
-            calc["data"]["MP2.5 TOTAL GRADIENT"] = 0.5 * (
-                calc["data"]["MP3 TOTAL GRADIENT"] + calc["data"]["MP2 TOTAL GRADIENT"]
-            )
-
-        if "MP4(SDQ) CORRELATION ENERGY" in calc["data"]:
-            calc["data"]["MP4(SDQ) TOTAL ENERGY"] = (
-                calc["data"]["MP4(SDQ) CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
-            )
-            if "MP4(T) CORRECTION ENERGY" in calc["data"]:
-                calc["data"]["MP4 CORRELATION ENERGY"] = (
-                    calc["data"]["MP4(SDQ) CORRELATION ENERGY"] + calc["data"]["MP4(T) CORRECTION ENERGY"]
-                )
-                calc["data"]["MP4 TOTAL ENERGY"] = (
-                    calc["data"]["MP4 CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
-                )
-                if "MP3 CORRELATION ENERGY" in calc["data"]:
-                    calc["data"]["MP4 CORRECTION ENERGY"] = (
-                        calc["data"]["MP4 CORRELATION ENERGY"] - calc["data"]["MP3 CORRELATION ENERGY"]
-                    )
-
-        if "CISD CORRELATION ENERGY" in calc["data"]:
-            calc["data"]["CISD TOTAL ENERGY"] = (
-                calc["data"]["CISD CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
-            )
-
-        if "QCISD CORRELATION ENERGY" in calc["data"]:
-            calc["data"]["QCISD TOTAL ENERGY"] = (
-                calc["data"]["QCISD CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
-            )
-            if "QCISD(T) CORRECTION ENERGY" in calc["data"]:
-                calc["data"]["QCISD(T) CORRELATION ENERGY"] = (
-                    calc["data"]["QCISD CORRELATION ENERGY"] + calc["data"]["QCISD(T) CORRECTION ENERGY"]
-                )
-                calc["data"]["QCISD(T) TOTAL ENERGY"] = (
-                    calc["data"]["QCISD(T) CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
-                )
-
-        if "FCI CORRELATION ENERGY" in calc["data"]:
-            calc["data"]["FCI TOTAL ENERGY"] = calc["data"]["FCI CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
-
-        if "REMP2 CORRELATION ENERGY" in calc["data"]:
-            calc["data"]["REMP2 TOTAL ENERGY"] = (
-                calc["data"]["REMP2 CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
-            )
-            if "REMP2 SINGLES ENERGY" in calc["data"]:
-                calc["data"]["REMP2 DOUBLES ENERGY"] = (
-                    calc["data"]["REMP2 CORRELATION ENERGY"] - calc["data"]["REMP2 SINGLES ENERGY"]
-                )
-                if "REMP2 SAME-SPIN CORRELATION ENERGY" in calc["data"]:
-                    calc["data"]["REMP2 OPPOSITE-SPIN CORRELATION ENERGY"] = (
-                        calc["data"]["REMP2 CORRELATION ENERGY"]
-                        - calc["data"]["REMP2 SAME-SPIN CORRELATION ENERGY"]
-                        - calc["data"]["REMP2 SINGLES ENERGY"]
-                    )
-
-        if "LCCD CORRELATION ENERGY" in calc["data"]:
-            calc["data"]["LCCD TOTAL ENERGY"] = (
-                calc["data"]["LCCD CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
-            )
-            if "LCCD SINGLES ENERGY" in calc["data"]:
-                calc["data"]["LCCD DOUBLES ENERGY"] = (
-                    calc["data"]["LCCD CORRELATION ENERGY"] - calc["data"]["LCCD SINGLES ENERGY"]
-                )
-                if "LCCD SAME-SPIN CORRELATION ENERGY" in calc["data"]:
-                    calc["data"]["LCCD OPPOSITE-SPIN CORRELATION ENERGY"] = (
-                        calc["data"]["LCCD CORRELATION ENERGY"]
-                        - calc["data"]["LCCD SAME-SPIN CORRELATION ENERGY"]
-                        - calc["data"]["LCCD SINGLES ENERGY"]
-                    )
-
-        if "LCCSD CORRELATION ENERGY" in calc["data"]:
-            calc["data"]["LCCSD TOTAL ENERGY"] = (
-                calc["data"]["LCCSD CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
-            )
-            if "LCCSD SINGLES ENERGY" in calc["data"]:
-                calc["data"]["LCCSD DOUBLES ENERGY"] = (
-                    calc["data"]["LCCSD CORRELATION ENERGY"] - calc["data"]["LCCSD SINGLES ENERGY"]
-                )
-                if "LCCSD SAME-SPIN CORRELATION ENERGY" in calc["data"]:
-                    calc["data"]["LCCSD OPPOSITE-SPIN CORRELATION ENERGY"] = (
-                        calc["data"]["LCCSD CORRELATION ENERGY"]
-                        - calc["data"]["LCCSD SAME-SPIN CORRELATION ENERGY"]
-                        - calc["data"]["LCCSD SINGLES ENERGY"]
-                    )
-
-        if "CCD CORRELATION ENERGY" in calc["data"]:
-            calc["data"]["CCD TOTAL ENERGY"] = calc["data"]["CCD CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
-            if "CCD SINGLES ENERGY" in calc["data"]:
-                calc["data"]["CCD DOUBLES ENERGY"] = (
-                    calc["data"]["CCD CORRELATION ENERGY"] - calc["data"]["CCD SINGLES ENERGY"]
-                )
-                if "CCD SAME-SPIN CORRELATION ENERGY" in calc["data"]:
-                    calc["data"]["CCD OPPOSITE-SPIN CORRELATION ENERGY"] = (
-                        calc["data"]["CCD CORRELATION ENERGY"]
-                        - calc["data"]["CCD SAME-SPIN CORRELATION ENERGY"]
-                        - calc["data"]["CCD SINGLES ENERGY"]
-                    )
-
-        if "CCSD CORRELATION ENERGY" in calc["data"]:
-            calc["data"]["CCSD TOTAL ENERGY"] = (
-                calc["data"]["CCSD CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
-            )
-            if "CCSD SINGLES ENERGY" in calc["data"]:
-                calc["data"]["CCSD DOUBLES ENERGY"] = (
-                    calc["data"]["CCSD CORRELATION ENERGY"] - calc["data"]["CCSD SINGLES ENERGY"]
-                )
-                if "CCSD SAME-SPIN CORRELATION ENERGY" in calc["data"]:
-                    calc["data"]["CCSD OPPOSITE-SPIN CORRELATION ENERGY"] = (
-                        calc["data"]["CCSD CORRELATION ENERGY"]
-                        - calc["data"]["CCSD SAME-SPIN CORRELATION ENERGY"]
-                        - calc["data"]["CCSD SINGLES ENERGY"]
-                    )
-
-        if "T(CCSD) CORRECTION ENERGY" in calc["data"]:
-            calc["data"]["CCSD+T(CCSD) CORRELATION ENERGY"] = (
-                calc["data"]["CCSD CORRELATION ENERGY"] + calc["data"]["T(CCSD) CORRECTION ENERGY"]
-            )
-            calc["data"]["CCSD+T(CCSD) TOTAL ENERGY"] = (
-                calc["data"]["CCSD+T(CCSD) CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
-            )
-
-        if "(T) CORRECTION ENERGY" in calc["data"]:
-            calc["data"]["CCSD(T) CORRELATION ENERGY"] = (
-                calc["data"]["CCSD CORRELATION ENERGY"] + calc["data"]["(T) CORRECTION ENERGY"]
-            )
-            calc["data"]["CCSD(T) TOTAL ENERGY"] = (
-                calc["data"]["CCSD(T) CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
-            )
-
-        if "A-(T) CORRECTION ENERGY" in calc["data"]:
-            calc["data"]["A-CCSD(T) CORRELATION ENERGY"] = (
-                calc["data"]["CCSD CORRELATION ENERGY"] + calc["data"]["A-(T) CORRECTION ENERGY"]
-            )
-            calc["data"]["A-CCSD(T) TOTAL ENERGY"] = (
-                calc["data"]["A-CCSD(T) CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
-            )
-
-        if "CCSDT-1A CORRELATION ENERGY" in calc["data"]:
-            calc["data"]["CCSDT-1A TOTAL ENERGY"] = (
-                calc["data"]["CCSDT-1A CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
-            )
-
-        if "CCSDT-1B CORRELATION ENERGY" in calc["data"]:
-            calc["data"]["CCSDT-1B TOTAL ENERGY"] = (
-                calc["data"]["CCSDT-1B CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
-            )
-
-        if "CCSDT-2 CORRELATION ENERGY" in calc["data"]:
-            calc["data"]["CCSDT-2 TOTAL ENERGY"] = (
-                calc["data"]["CCSDT-2 CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
-            )
-
-        if "CCSDT-3 CORRELATION ENERGY" in calc["data"]:
-            calc["data"]["CCSDT-3 TOTAL ENERGY"] = (
-                calc["data"]["CCSDT-3 CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
-            )
-
-        if "CCSDT CORRELATION ENERGY" in calc["data"]:
-            calc["data"]["CCSDT TOTAL ENERGY"] = (
-                calc["data"]["CCSDT CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
-            )
-
-        if "(Q) CORRECTION ENERGY" in calc["data"]:
-            calc["data"]["CCSDT(Q) CORRELATION ENERGY"] = (
-                calc["data"]["CCSDT CORRELATION ENERGY"] + calc["data"]["(Q) CORRECTION ENERGY"]
-            )
-            calc["data"]["CCSDT(Q) TOTAL ENERGY"] = (
-                calc["data"]["CCSDT(Q) CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
-            )
-
-        if "CCSDTQ CORRELATION ENERGY" in calc["data"]:
-            calc["data"]["CCSDTQ TOTAL ENERGY"] = (
-                calc["data"]["CCSDTQ CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
-            )
-
-        if "OMP2 CORRELATION ENERGY" in calc["data"]:
-            if calc["data"]["OMP2 CORRELATION ENERGY"] == _knownmissing:
-                calc["data"]["OMP2 TOTAL ENERGY"] = _knownmissing
-                calc["data"]["OMP2 OPPOSITE-SPIN CORRELATION ENERGY"] = _knownmissing
-            else:
-                calc["data"]["OMP2 TOTAL ENERGY"] = (
-                    calc["data"]["OMP2 CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
-                )
-                if "OMP2 SAME-SPIN CORRELATION ENERGY" in calc["data"]:
-                    if calc["data"]["OMP2 SAME-SPIN CORRELATION ENERGY"] == _knownmissing:
-                        calc["data"]["OMP2 OPPOSITE-SPIN CORRELATION ENERGY"] = _knownmissing
-                    else:
-                        calc["data"]["OMP2 OPPOSITE-SPIN CORRELATION ENERGY"] = (
-                            calc["data"]["OMP2 CORRELATION ENERGY"]
-                            - calc["data"]["OMP2 REFERENCE CORRECTION ENERGY"]
-                            - calc["data"]["OMP2 SAME-SPIN CORRELATION ENERGY"]
+                        calc["data"]["SCS-MP2 TOTAL ENERGY"] = (
+                            calc["data"]["SCS-MP2 CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
                         )
 
-        if "OMP2.5 CORRELATION ENERGY" in calc["data"]:
-            if calc["data"]["OMP2.5 CORRELATION ENERGY"] == _knownmissing:
-                calc["data"]["OMP2.5 TOTAL ENERGY"] = _knownmissing
-                calc["data"]["OMP2.5 OPPOSITE-SPIN CORRELATION ENERGY"] = _knownmissing
-            else:
-                calc["data"]["OMP2.5 TOTAL ENERGY"] = (
-                    calc["data"]["OMP2.5 CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
+            if "MP3 CORRELATION ENERGY" in calc["data"]:
+                calc["data"]["MP3 TOTAL ENERGY"] = (
+                    calc["data"]["MP3 CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
                 )
-                if "OMP2.5 SAME-SPIN CORRELATION ENERGY" in calc["data"]:
-                    if calc["data"]["OMP2.5 SAME-SPIN CORRELATION ENERGY"] == _knownmissing:
-                        calc["data"]["OMP2.5 OPPOSITE-SPIN CORRELATION ENERGY"] = _knownmissing
-                    else:
-                        calc["data"]["OMP2.5 OPPOSITE-SPIN CORRELATION ENERGY"] = (
-                            calc["data"]["OMP2.5 CORRELATION ENERGY"]
-                            - calc["data"]["OMP2.5 REFERENCE CORRECTION ENERGY"]
-                            - calc["data"]["OMP2.5 SAME-SPIN CORRELATION ENERGY"]
+                if "MP2 CORRELATION ENERGY" in calc["data"]:
+                    calc["data"]["MP2.5 CORRELATION ENERGY"] = 0.5 * (
+                        calc["data"]["MP3 CORRELATION ENERGY"] + calc["data"]["MP2 CORRELATION ENERGY"]
+                    )
+                    calc["data"]["MP2.5 TOTAL ENERGY"] = (
+                        calc["data"]["MP2.5 CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
+                    )
+
+                if "MP3 SINGLES ENERGY" in calc["data"]:
+                    calc["data"]["MP3 DOUBLES ENERGY"] = (
+                        calc["data"]["MP3 CORRELATION ENERGY"] - calc["data"]["MP3 SINGLES ENERGY"]
+                    )
+                    if "MP2 SINGLES ENERGY" in calc["data"]:
+                        calc["data"]["MP2.5 SINGLES ENERGY"] = 0.5 * (
+                            calc["data"]["MP3 SINGLES ENERGY"] + calc["data"]["MP2 SINGLES ENERGY"]
+                        )
+                        calc["data"]["MP2.5 DOUBLES ENERGY"] = (
+                            calc["data"]["MP2.5 CORRELATION ENERGY"] - calc["data"]["MP2.5 SINGLES ENERGY"]
+                        )
+                    if "MP3 SAME-SPIN CORRELATION ENERGY" in calc["data"]:
+                        calc["data"]["MP3 OPPOSITE-SPIN CORRELATION ENERGY"] = (
+                            calc["data"]["MP3 CORRELATION ENERGY"]
+                            - calc["data"]["MP3 SAME-SPIN CORRELATION ENERGY"]
+                            - calc["data"]["MP3 SINGLES ENERGY"]
+                        )
+                        if "MP2 SAME-SPIN CORRELATION ENERGY" in calc["data"]:
+                            calc["data"]["MP2.5 SAME-SPIN CORRELATION ENERGY"] = 0.5 * (
+                                calc["data"]["MP3 SAME-SPIN CORRELATION ENERGY"]
+                                + calc["data"]["MP2 SAME-SPIN CORRELATION ENERGY"]
+                            )
+                            calc["data"]["MP2.5 OPPOSITE-SPIN CORRELATION ENERGY"] = (
+                                calc["data"]["MP2.5 CORRELATION ENERGY"]
+                                - calc["data"]["MP2.5 SAME-SPIN CORRELATION ENERGY"]
+                                - calc["data"]["MP2.5 SINGLES ENERGY"]
+                            )
+
+            if (
+                "MP3 TOTAL GRADIENT" in calc["data"]
+                and "MP2 TOTAL GRADIENT" in calc["data"]
+                and "HF TOTAL GRADIENT" in calc["data"]
+            ):
+                calc["data"]["MP2.5 TOTAL GRADIENT"] = 0.5 * (
+                    calc["data"]["MP3 TOTAL GRADIENT"] + calc["data"]["MP2 TOTAL GRADIENT"]
+                )
+
+            if "MP4(SDQ) CORRELATION ENERGY" in calc["data"]:
+                calc["data"]["MP4(SDQ) TOTAL ENERGY"] = (
+                    calc["data"]["MP4(SDQ) CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
+                )
+                if "MP4(T) CORRECTION ENERGY" in calc["data"]:
+                    calc["data"]["MP4 CORRELATION ENERGY"] = (
+                        calc["data"]["MP4(SDQ) CORRELATION ENERGY"] + calc["data"]["MP4(T) CORRECTION ENERGY"]
+                    )
+                    calc["data"]["MP4 TOTAL ENERGY"] = (
+                        calc["data"]["MP4 CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
+                    )
+                    if "MP3 CORRELATION ENERGY" in calc["data"]:
+                        calc["data"]["MP4 CORRECTION ENERGY"] = (
+                            calc["data"]["MP4 CORRELATION ENERGY"] - calc["data"]["MP3 CORRELATION ENERGY"]
                         )
 
-        if "OMP3 CORRELATION ENERGY" in calc["data"]:
-            if calc["data"]["OMP3 CORRELATION ENERGY"] == _knownmissing:
-                calc["data"]["OMP3 TOTAL ENERGY"] = _knownmissing
-                calc["data"]["OMP3 OPPOSITE-SPIN CORRELATION ENERGY"] = _knownmissing
-            else:
-                calc["data"]["OMP3 TOTAL ENERGY"] = (
-                    calc["data"]["OMP3 CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
+            if "CISD CORRELATION ENERGY" in calc["data"]:
+                calc["data"]["CISD TOTAL ENERGY"] = (
+                    calc["data"]["CISD CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
                 )
-                if "OMP3 SAME-SPIN CORRELATION ENERGY" in calc["data"]:
-                    if calc["data"]["OMP3 SAME-SPIN CORRELATION ENERGY"] == _knownmissing:
-                        calc["data"]["OMP3 OPPOSITE-SPIN CORRELATION ENERGY"] = _knownmissing
-                    else:
-                        calc["data"]["OMP3 OPPOSITE-SPIN CORRELATION ENERGY"] = (
-                            calc["data"]["OMP3 CORRELATION ENERGY"]
-                            - calc["data"]["OMP3 REFERENCE CORRECTION ENERGY"]
-                            - calc["data"]["OMP3 SAME-SPIN CORRELATION ENERGY"]
+
+            if "QCISD CORRELATION ENERGY" in calc["data"]:
+                calc["data"]["QCISD TOTAL ENERGY"] = (
+                    calc["data"]["QCISD CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
+                )
+                if "QCISD(T) CORRECTION ENERGY" in calc["data"]:
+                    calc["data"]["QCISD(T) CORRELATION ENERGY"] = (
+                        calc["data"]["QCISD CORRELATION ENERGY"] + calc["data"]["QCISD(T) CORRECTION ENERGY"]
+                    )
+                    calc["data"]["QCISD(T) TOTAL ENERGY"] = (
+                        calc["data"]["QCISD(T) CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
+                    )
+
+            if "FCI CORRELATION ENERGY" in calc["data"]:
+                calc["data"]["FCI TOTAL ENERGY"] = (
+                    calc["data"]["FCI CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
+                )
+
+            if "REMP2 CORRELATION ENERGY" in calc["data"]:
+                calc["data"]["REMP2 TOTAL ENERGY"] = (
+                    calc["data"]["REMP2 CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
+                )
+                if "REMP2 SINGLES ENERGY" in calc["data"]:
+                    calc["data"]["REMP2 DOUBLES ENERGY"] = (
+                        calc["data"]["REMP2 CORRELATION ENERGY"] - calc["data"]["REMP2 SINGLES ENERGY"]
+                    )
+                    if "REMP2 SAME-SPIN CORRELATION ENERGY" in calc["data"]:
+                        calc["data"]["REMP2 OPPOSITE-SPIN CORRELATION ENERGY"] = (
+                            calc["data"]["REMP2 CORRELATION ENERGY"]
+                            - calc["data"]["REMP2 SAME-SPIN CORRELATION ENERGY"]
+                            - calc["data"]["REMP2 SINGLES ENERGY"]
                         )
 
-        if "OREMP2 CORRELATION ENERGY" in calc["data"]:
-            if calc["data"]["OREMP2 CORRELATION ENERGY"] == _knownmissing:
-                calc["data"]["OREMP2 TOTAL ENERGY"] = _knownmissing
-                calc["data"]["OREMP2 OPPOSITE-SPIN CORRELATION ENERGY"] = _knownmissing
-            else:
-                calc["data"]["OREMP2 TOTAL ENERGY"] = (
-                    calc["data"]["OREMP2 CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
+            if "LCCD CORRELATION ENERGY" in calc["data"]:
+                calc["data"]["LCCD TOTAL ENERGY"] = (
+                    calc["data"]["LCCD CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
                 )
-                if "OREMP2 SAME-SPIN CORRELATION ENERGY" in calc["data"]:
-                    if calc["data"]["OREMP2 SAME-SPIN CORRELATION ENERGY"] == _knownmissing:
-                        calc["data"]["OREMP2 OPPOSITE-SPIN CORRELATION ENERGY"] = _knownmissing
-                    else:
-                        calc["data"]["OREMP2 OPPOSITE-SPIN CORRELATION ENERGY"] = (
-                            calc["data"]["OREMP2 CORRELATION ENERGY"]
-                            - calc["data"]["OREMP2 REFERENCE CORRECTION ENERGY"]
-                            - calc["data"]["OREMP2 SAME-SPIN CORRELATION ENERGY"]
+                if "LCCD SINGLES ENERGY" in calc["data"]:
+                    calc["data"]["LCCD DOUBLES ENERGY"] = (
+                        calc["data"]["LCCD CORRELATION ENERGY"] - calc["data"]["LCCD SINGLES ENERGY"]
+                    )
+                    if "LCCD SAME-SPIN CORRELATION ENERGY" in calc["data"]:
+                        calc["data"]["LCCD OPPOSITE-SPIN CORRELATION ENERGY"] = (
+                            calc["data"]["LCCD CORRELATION ENERGY"]
+                            - calc["data"]["LCCD SAME-SPIN CORRELATION ENERGY"]
+                            - calc["data"]["LCCD SINGLES ENERGY"]
                         )
 
-        if "OLCCD CORRELATION ENERGY" in calc["data"]:
-            calc["data"]["OLCCD TOTAL ENERGY"] = (
-                calc["data"]["OLCCD CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
-            )
-            if "OLCCD SAME-SPIN CORRELATION ENERGY" in calc["data"]:
-                if calc["data"]["OLCCD SAME-SPIN CORRELATION ENERGY"] == _knownmissing:
-                    calc["data"]["OLCCD OPPOSITE-SPIN CORRELATION ENERGY"] = _knownmissing
+            if "LCCSD CORRELATION ENERGY" in calc["data"]:
+                calc["data"]["LCCSD TOTAL ENERGY"] = (
+                    calc["data"]["LCCSD CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
+                )
+                if "LCCSD SINGLES ENERGY" in calc["data"]:
+                    calc["data"]["LCCSD DOUBLES ENERGY"] = (
+                        calc["data"]["LCCSD CORRELATION ENERGY"] - calc["data"]["LCCSD SINGLES ENERGY"]
+                    )
+                    if "LCCSD SAME-SPIN CORRELATION ENERGY" in calc["data"]:
+                        calc["data"]["LCCSD OPPOSITE-SPIN CORRELATION ENERGY"] = (
+                            calc["data"]["LCCSD CORRELATION ENERGY"]
+                            - calc["data"]["LCCSD SAME-SPIN CORRELATION ENERGY"]
+                            - calc["data"]["LCCSD SINGLES ENERGY"]
+                        )
+
+            if "CCD CORRELATION ENERGY" in calc["data"]:
+                calc["data"]["CCD TOTAL ENERGY"] = (
+                    calc["data"]["CCD CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
+                )
+                if "CCD SINGLES ENERGY" in calc["data"]:
+                    calc["data"]["CCD DOUBLES ENERGY"] = (
+                        calc["data"]["CCD CORRELATION ENERGY"] - calc["data"]["CCD SINGLES ENERGY"]
+                    )
+                    if "CCD SAME-SPIN CORRELATION ENERGY" in calc["data"]:
+                        calc["data"]["CCD OPPOSITE-SPIN CORRELATION ENERGY"] = (
+                            calc["data"]["CCD CORRELATION ENERGY"]
+                            - calc["data"]["CCD SAME-SPIN CORRELATION ENERGY"]
+                            - calc["data"]["CCD SINGLES ENERGY"]
+                        )
+
+            if "CCSD CORRELATION ENERGY" in calc["data"]:
+                calc["data"]["CCSD TOTAL ENERGY"] = (
+                    calc["data"]["CCSD CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
+                )
+                if "CCSD SINGLES ENERGY" in calc["data"]:
+                    calc["data"]["CCSD DOUBLES ENERGY"] = (
+                        calc["data"]["CCSD CORRELATION ENERGY"] - calc["data"]["CCSD SINGLES ENERGY"]
+                    )
+                    if "CCSD SAME-SPIN CORRELATION ENERGY" in calc["data"]:
+                        calc["data"]["CCSD OPPOSITE-SPIN CORRELATION ENERGY"] = (
+                            calc["data"]["CCSD CORRELATION ENERGY"]
+                            - calc["data"]["CCSD SAME-SPIN CORRELATION ENERGY"]
+                            - calc["data"]["CCSD SINGLES ENERGY"]
+                        )
+
+            if "T(CCSD) CORRECTION ENERGY" in calc["data"]:
+                calc["data"]["CCSD+T(CCSD) CORRELATION ENERGY"] = (
+                    calc["data"]["CCSD CORRELATION ENERGY"] + calc["data"]["T(CCSD) CORRECTION ENERGY"]
+                )
+                calc["data"]["CCSD+T(CCSD) TOTAL ENERGY"] = (
+                    calc["data"]["CCSD+T(CCSD) CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
+                )
+
+            if "(T) CORRECTION ENERGY" in calc["data"]:
+                calc["data"]["CCSD(T) CORRELATION ENERGY"] = (
+                    calc["data"]["CCSD CORRELATION ENERGY"] + calc["data"]["(T) CORRECTION ENERGY"]
+                )
+                calc["data"]["CCSD(T) TOTAL ENERGY"] = (
+                    calc["data"]["CCSD(T) CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
+                )
+
+            if "A-(T) CORRECTION ENERGY" in calc["data"]:
+                calc["data"]["A-CCSD(T) CORRELATION ENERGY"] = (
+                    calc["data"]["CCSD CORRELATION ENERGY"] + calc["data"]["A-(T) CORRECTION ENERGY"]
+                )
+                calc["data"]["A-CCSD(T) TOTAL ENERGY"] = (
+                    calc["data"]["A-CCSD(T) CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
+                )
+
+            if "CCSDT-1A CORRELATION ENERGY" in calc["data"]:
+                calc["data"]["CCSDT-1A TOTAL ENERGY"] = (
+                    calc["data"]["CCSDT-1A CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
+                )
+
+            if "CCSDT-1B CORRELATION ENERGY" in calc["data"]:
+                calc["data"]["CCSDT-1B TOTAL ENERGY"] = (
+                    calc["data"]["CCSDT-1B CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
+                )
+
+            if "CCSDT-2 CORRELATION ENERGY" in calc["data"]:
+                calc["data"]["CCSDT-2 TOTAL ENERGY"] = (
+                    calc["data"]["CCSDT-2 CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
+                )
+
+            if "CCSDT-3 CORRELATION ENERGY" in calc["data"]:
+                calc["data"]["CCSDT-3 TOTAL ENERGY"] = (
+                    calc["data"]["CCSDT-3 CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
+                )
+
+            if "CCSDT CORRELATION ENERGY" in calc["data"]:
+                calc["data"]["CCSDT TOTAL ENERGY"] = (
+                    calc["data"]["CCSDT CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
+                )
+
+            if "(Q) CORRECTION ENERGY" in calc["data"]:
+                calc["data"]["CCSDT(Q) CORRELATION ENERGY"] = (
+                    calc["data"]["CCSDT CORRELATION ENERGY"] + calc["data"]["(Q) CORRECTION ENERGY"]
+                )
+                calc["data"]["CCSDT(Q) TOTAL ENERGY"] = (
+                    calc["data"]["CCSDT(Q) CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
+                )
+
+            if "CCSDTQ CORRELATION ENERGY" in calc["data"]:
+                calc["data"]["CCSDTQ TOTAL ENERGY"] = (
+                    calc["data"]["CCSDTQ CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
+                )
+
+            if "OMP2 CORRELATION ENERGY" in calc["data"]:
+                if calc["data"]["OMP2 CORRELATION ENERGY"] == _knownmissing:
+                    calc["data"]["OMP2 TOTAL ENERGY"] = _knownmissing
+                    calc["data"]["OMP2 OPPOSITE-SPIN CORRELATION ENERGY"] = _knownmissing
                 else:
-                    calc["data"]["OLCCD OPPOSITE-SPIN CORRELATION ENERGY"] = (
-                        calc["data"]["OLCCD CORRELATION ENERGY"]
-                        - calc["data"]["OLCCD REFERENCE CORRECTION ENERGY"]
-                        - calc["data"]["OLCCD SAME-SPIN CORRELATION ENERGY"]
+                    calc["data"]["OMP2 TOTAL ENERGY"] = (
+                        calc["data"]["OMP2 CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
+                    )
+                    if "OMP2 SAME-SPIN CORRELATION ENERGY" in calc["data"]:
+                        if calc["data"]["OMP2 SAME-SPIN CORRELATION ENERGY"] == _knownmissing:
+                            calc["data"]["OMP2 OPPOSITE-SPIN CORRELATION ENERGY"] = _knownmissing
+                        else:
+                            calc["data"]["OMP2 OPPOSITE-SPIN CORRELATION ENERGY"] = (
+                                calc["data"]["OMP2 CORRELATION ENERGY"]
+                                - calc["data"]["OMP2 REFERENCE CORRECTION ENERGY"]
+                                - calc["data"]["OMP2 SAME-SPIN CORRELATION ENERGY"]
+                            )
+
+            if "OMP2.5 CORRELATION ENERGY" in calc["data"]:
+                if calc["data"]["OMP2.5 CORRELATION ENERGY"] == _knownmissing:
+                    calc["data"]["OMP2.5 TOTAL ENERGY"] = _knownmissing
+                    calc["data"]["OMP2.5 OPPOSITE-SPIN CORRELATION ENERGY"] = _knownmissing
+                else:
+                    calc["data"]["OMP2.5 TOTAL ENERGY"] = (
+                        calc["data"]["OMP2.5 CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
+                    )
+                    if "OMP2.5 SAME-SPIN CORRELATION ENERGY" in calc["data"]:
+                        if calc["data"]["OMP2.5 SAME-SPIN CORRELATION ENERGY"] == _knownmissing:
+                            calc["data"]["OMP2.5 OPPOSITE-SPIN CORRELATION ENERGY"] = _knownmissing
+                        else:
+                            calc["data"]["OMP2.5 OPPOSITE-SPIN CORRELATION ENERGY"] = (
+                                calc["data"]["OMP2.5 CORRELATION ENERGY"]
+                                - calc["data"]["OMP2.5 REFERENCE CORRECTION ENERGY"]
+                                - calc["data"]["OMP2.5 SAME-SPIN CORRELATION ENERGY"]
+                            )
+
+            if "OMP3 CORRELATION ENERGY" in calc["data"]:
+                if calc["data"]["OMP3 CORRELATION ENERGY"] == _knownmissing:
+                    calc["data"]["OMP3 TOTAL ENERGY"] = _knownmissing
+                    calc["data"]["OMP3 OPPOSITE-SPIN CORRELATION ENERGY"] = _knownmissing
+                else:
+                    calc["data"]["OMP3 TOTAL ENERGY"] = (
+                        calc["data"]["OMP3 CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
+                    )
+                    if "OMP3 SAME-SPIN CORRELATION ENERGY" in calc["data"]:
+                        if calc["data"]["OMP3 SAME-SPIN CORRELATION ENERGY"] == _knownmissing:
+                            calc["data"]["OMP3 OPPOSITE-SPIN CORRELATION ENERGY"] = _knownmissing
+                        else:
+                            calc["data"]["OMP3 OPPOSITE-SPIN CORRELATION ENERGY"] = (
+                                calc["data"]["OMP3 CORRELATION ENERGY"]
+                                - calc["data"]["OMP3 REFERENCE CORRECTION ENERGY"]
+                                - calc["data"]["OMP3 SAME-SPIN CORRELATION ENERGY"]
+                            )
+
+            if "OREMP2 CORRELATION ENERGY" in calc["data"]:
+                if calc["data"]["OREMP2 CORRELATION ENERGY"] == _knownmissing:
+                    calc["data"]["OREMP2 TOTAL ENERGY"] = _knownmissing
+                    calc["data"]["OREMP2 OPPOSITE-SPIN CORRELATION ENERGY"] = _knownmissing
+                else:
+                    calc["data"]["OREMP2 TOTAL ENERGY"] = (
+                        calc["data"]["OREMP2 CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
+                    )
+                    if "OREMP2 SAME-SPIN CORRELATION ENERGY" in calc["data"]:
+                        if calc["data"]["OREMP2 SAME-SPIN CORRELATION ENERGY"] == _knownmissing:
+                            calc["data"]["OREMP2 OPPOSITE-SPIN CORRELATION ENERGY"] = _knownmissing
+                        else:
+                            calc["data"]["OREMP2 OPPOSITE-SPIN CORRELATION ENERGY"] = (
+                                calc["data"]["OREMP2 CORRELATION ENERGY"]
+                                - calc["data"]["OREMP2 REFERENCE CORRECTION ENERGY"]
+                                - calc["data"]["OREMP2 SAME-SPIN CORRELATION ENERGY"]
+                            )
+
+            if "OLCCD CORRELATION ENERGY" in calc["data"]:
+                calc["data"]["OLCCD TOTAL ENERGY"] = (
+                    calc["data"]["OLCCD CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
+                )
+                if "OLCCD SAME-SPIN CORRELATION ENERGY" in calc["data"]:
+                    if calc["data"]["OLCCD SAME-SPIN CORRELATION ENERGY"] == _knownmissing:
+                        calc["data"]["OLCCD OPPOSITE-SPIN CORRELATION ENERGY"] = _knownmissing
+                    else:
+                        calc["data"]["OLCCD OPPOSITE-SPIN CORRELATION ENERGY"] = (
+                            calc["data"]["OLCCD CORRELATION ENERGY"]
+                            - calc["data"]["OLCCD REFERENCE CORRECTION ENERGY"]
+                            - calc["data"]["OLCCD SAME-SPIN CORRELATION ENERGY"]
+                        )
+
+            if "OCCD CORRELATION ENERGY" in calc["data"]:
+                calc["data"]["OCCD TOTAL ENERGY"] = (
+                    calc["data"]["OCCD CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
+                )
+                if "OCCD SAME-SPIN CORRELATION ENERGY" in calc["data"]:
+                    calc["data"]["OCCD OPPOSITE-SPIN CORRELATION ENERGY"] = (
+                        calc["data"]["OCCD CORRELATION ENERGY"]
+                        - calc["data"]["OCCD REFERENCE CORRECTION ENERGY"]
+                        - calc["data"]["OCCD SAME-SPIN CORRELATION ENERGY"]
                     )
 
-        if "OCCD CORRELATION ENERGY" in calc["data"]:
-            calc["data"]["OCCD TOTAL ENERGY"] = (
-                calc["data"]["OCCD CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
-            )
-            if "OCCD SAME-SPIN CORRELATION ENERGY" in calc["data"]:
-                calc["data"]["OCCD OPPOSITE-SPIN CORRELATION ENERGY"] = (
-                    calc["data"]["OCCD CORRELATION ENERGY"]
-                    - calc["data"]["OCCD REFERENCE CORRECTION ENERGY"]
-                    - calc["data"]["OCCD SAME-SPIN CORRELATION ENERGY"]
-                )
+            if "O(T) CORRECTION ENERGY" in calc["data"]:
+                if calc["data"]["O(T) CORRECTION ENERGY"] == _knownmissing:
+                    calc["data"]["OCCD(T) CORRELATION ENERGY"] = _knownmissing
+                    calc["data"]["OCCD(T) TOTAL ENERGY"] = _knownmissing
+                else:
+                    calc["data"]["OCCD(T) CORRELATION ENERGY"] = (
+                        calc["data"]["OCCD CORRELATION ENERGY"] + calc["data"]["O(T) CORRECTION ENERGY"]
+                    )
+                    calc["data"]["OCCD(T) TOTAL ENERGY"] = (
+                        calc["data"]["OCCD(T) CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
+                    )
 
-        if "O(T) CORRECTION ENERGY" in calc["data"]:
-            if calc["data"]["O(T) CORRECTION ENERGY"] == _knownmissing:
-                calc["data"]["OCCD(T) CORRELATION ENERGY"] = _knownmissing
-                calc["data"]["OCCD(T) TOTAL ENERGY"] = _knownmissing
-            else:
-                calc["data"]["OCCD(T) CORRELATION ENERGY"] = (
-                    calc["data"]["OCCD CORRELATION ENERGY"] + calc["data"]["O(T) CORRECTION ENERGY"]
-                )
-                calc["data"]["OCCD(T) TOTAL ENERGY"] = (
-                    calc["data"]["OCCD(T) CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
-                )
+            if "A-O(T) CORRECTION ENERGY" in calc["data"]:
+                if calc["data"]["A-O(T) CORRECTION ENERGY"] == _knownmissing:
+                    calc["data"]["A-OCCD(T) CORRELATION ENERGY"] = _knownmissing
+                    calc["data"]["A-OCCD(T) TOTAL ENERGY"] = _knownmissing
+                else:
+                    calc["data"]["A-OCCD(T) CORRELATION ENERGY"] = (
+                        calc["data"]["OCCD CORRELATION ENERGY"] + calc["data"]["A-O(T) CORRECTION ENERGY"]
+                    )
+                    calc["data"]["A-OCCD(T) TOTAL ENERGY"] = (
+                        calc["data"]["A-OCCD(T) CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
+                    )
 
-        if "A-O(T) CORRECTION ENERGY" in calc["data"]:
-            if calc["data"]["A-O(T) CORRECTION ENERGY"] == _knownmissing:
-                calc["data"]["A-OCCD(T) CORRELATION ENERGY"] = _knownmissing
-                calc["data"]["A-OCCD(T) TOTAL ENERGY"] = _knownmissing
-            else:
-                calc["data"]["A-OCCD(T) CORRELATION ENERGY"] = (
-                    calc["data"]["OCCD CORRELATION ENERGY"] + calc["data"]["A-O(T) CORRECTION ENERGY"]
-                )
-                calc["data"]["A-OCCD(T) TOTAL ENERGY"] = (
-                    calc["data"]["A-OCCD(T) CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
-                )
-
-    calc["data"].update(_std_generics[f"{calc['meta']['system']}_{calc['meta']['basis']}_{calc['meta']['fcae']}"])
+        calc["data"].update(_std_generics[f"{calc['meta']['system']}_{calc['meta']['basis']}_{calc['meta']['fcae']}"])
 
 
 def answer_hash(**kwargs):

--- a/qcengine/programs/tests/standard_suite_ref.py
+++ b/qcengine/programs/tests/standard_suite_ref.py
@@ -8242,6 +8242,11 @@ _std_suite = [
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.04857381,
             "(T) CORRECTION ENERGY": -0.0019363109218456449,
             "A-(T) CORRECTION ENERGY": -0.00196099,  # dfocc
+            "OLCCD REFERENCE CORRECTION ENERGY": 0.00055222,  # dfocc
+            "OLCCD CORRELATION ENERGY": -0.21043798,  # dfocc
+            "OLCCD SAME-SPIN CORRELATION ENERGY": 41,  # dfocc
+            "OCCD REFERENCE CORRECTION ENERGY": 0.00051128,  # dfocc
+            "OCCD CORRELATION ENERGY": -0.20864567,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(6).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(36).reshape((6, 6)),
         },
@@ -8284,6 +8289,11 @@ _std_suite = [
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.05017955,
             "(T) CORRECTION ENERGY": -0.00523867,
             "A-(T) CORRECTION ENERGY": -0.00523629,  # dfocc
+            "OLCCD REFERENCE CORRECTION ENERGY": 0.00118959,  # dfocc
+            "OLCCD CORRELATION ENERGY": -0.23304784,  # dfocc
+            "OLCCD SAME-SPIN CORRELATION ENERGY": 42,  # dfocc
+            "OCCD REFERENCE CORRECTION ENERGY": 0.00112446,  # dfocc
+            "OCCD CORRELATION ENERGY": -0.22912033,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -8326,6 +8336,11 @@ _std_suite = [
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.05801141,
             "(T) CORRECTION ENERGY": -0.00726395,
             "A-(T) CORRECTION ENERGY": -0.00718178,  # dfocc
+            "OLCCD REFERENCE CORRECTION ENERGY": 0.00135219,  # dfocc
+            "OLCCD CORRELATION ENERGY": -0.28000417,  # dfocc
+            "OLCCD SAME-SPIN CORRELATION ENERGY": 43,  # dfocc
+            "OCCD REFERENCE CORRECTION ENERGY": 0.00127925,  # dfocc
+            "OCCD CORRELATION ENERGY": -0.27541700,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -8404,6 +8419,11 @@ _std_suite = [
             "CCSD SINGLES ENERGY": 0.0,
             "(T) CORRECTION ENERGY": -0.00062617,  # dfocc
             "A-(T) CORRECTION ENERGY": -0.00060935,  # dfocc
+            "OLCCD REFERENCE CORRECTION ENERGY": 0.00148385,  # dfocc
+            "OLCCD CORRELATION ENERGY": -0.08473702,  # dfocc
+            "OLCCD SAME-SPIN CORRELATION ENERGY": -0.00244894,  # dfocc
+            "OCCD REFERENCE CORRECTION ENERGY": 0.00116602,  # dfocc
+            "OCCD CORRELATION ENERGY": -0.08218460,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(144).reshape((12, 12)),
         },
@@ -8446,6 +8466,11 @@ _std_suite = [
             "CCSD SINGLES ENERGY": 0.0,
             "(T) CORRECTION ENERGY": -0.00384403,  # dfocc
             "A-(T) CORRECTION ENERGY": -0.00376420,  # dfocc
+            "OLCCD REFERENCE CORRECTION ENERGY": 0.00111173,  # dfocc
+            "OLCCD CORRELATION ENERGY": -0.17810919,  # dfocc
+            "OLCCD SAME-SPIN CORRELATION ENERGY": -0.03447266,  # dfocc
+            "OCCD REFERENCE CORRECTION ENERGY": 0.00098769,  # dfocc
+            "OCCD CORRELATION ENERGY": -0.17372338,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -8488,6 +8513,11 @@ _std_suite = [
             "CCSD SINGLES ENERGY": 0.0,
             "(T) CORRECTION ENERGY": -0.00516682,  # dfocc
             "A-(T) CORRECTION ENERGY": -0.00506455,  # dfocc
+            "OLCCD REFERENCE CORRECTION ENERGY": 0.00128557,  # dfocc
+            "OLCCD CORRELATION ENERGY": -0.21805538,  # dfocc
+            "OLCCD SAME-SPIN CORRELATION ENERGY": -0.04051681,  # dfocc
+            "OCCD REFERENCE CORRECTION ENERGY": 0.00115506,  # dfocc
+            "OCCD CORRELATION ENERGY": -0.21313921,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -8511,6 +8541,11 @@ _std_suite = [
                 # dfocc findif-5 ae cd+cd
                 [0.0, 0.0, 0.01359215, 0.0, 0.0, -0.01312116, 0.0, 0.01031541, -0.0002355, 0.0, -0.01031541, -0.0002355]
             ).reshape((-1, 3)),
+            "OLCCD REFERENCE CORRECTION ENERGY": -0.00004009,  # dfocc
+            "OLCCD CORRELATION ENERGY": -0.08626069,  # dfocc
+            "OLCCD SAME-SPIN CORRELATION ENERGY": -0.00244892,  # dfocc
+            "OCCD REFERENCE CORRECTION ENERGY": -0.00035764,  # dfocc
+            "OCCD CORRELATION ENERGY": -0.08370826,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(144).reshape((12, 12)),
         },
@@ -8543,6 +8578,11 @@ _std_suite = [
                     -0.012794480501,
                 ]
             ).reshape((-1, 3)),
+            "OLCCD REFERENCE CORRECTION ENERGY": -0.00330177,  # dfocc
+            "OLCCD CORRELATION ENERGY": -0.18252269,  # dfocc
+            "OLCCD SAME-SPIN CORRELATION ENERGY": -0.03447262,  # dfocc
+            "OCCD REFERENCE CORRECTION ENERGY": -0.00342574,  # dfocc
+            "OCCD CORRELATION ENERGY": -0.17813688,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -8575,6 +8615,11 @@ _std_suite = [
                     -0.006942026833,
                 ]
             ).reshape((-1, 3)),
+            "OLCCD REFERENCE CORRECTION ENERGY": -0.00332424,  # dfocc
+            "OLCCD CORRELATION ENERGY": -0.22266511,  # dfocc
+            "OLCCD SAME-SPIN CORRELATION ENERGY": -0.04051680,  # dfocc
+            "OCCD REFERENCE CORRECTION ENERGY": -0.00345464,  # dfocc
+            "OCCD CORRELATION ENERGY": -0.21774895,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -8616,6 +8661,8 @@ _std_suite = [
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.04787083,
             "(T) CORRECTION ENERGY": -0.0019204203743072874,
             "A-(T) CORRECTION ENERGY": -0.00194413,  # dfocc
+            "OCCD REFERENCE CORRECTION ENERGY": 0.00051178,  # dfocc
+            "OCCD CORRELATION ENERGY": -0.20682760,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(6).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(36).reshape((6, 6)),
         },
@@ -8658,6 +8705,8 @@ _std_suite = [
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.04939986,
             "(T) CORRECTION ENERGY": -0.00521248,
             "A-(T) CORRECTION ENERGY": -0.00520980,  # dfocc
+            "OCCD REFERENCE CORRECTION ENERGY": 0.00112772,  # dfocc
+            "OCCD CORRELATION ENERGY": -0.22699047,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -8700,6 +8749,8 @@ _std_suite = [
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.05405638,
             "(T) CORRECTION ENERGY": -0.00709686,
             "A-(T) CORRECTION ENERGY": -0.00701826,  # dfocc
+            "OCCD REFERENCE CORRECTION ENERGY": 0.00122690,  # dfocc
+            "OCCD CORRELATION ENERGY": -0.25006391,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -8778,6 +8829,8 @@ _std_suite = [
             "CCSD SINGLES ENERGY": 0.0,
             "(T) CORRECTION ENERGY": -0.00060403,  # dfocc
             "A-(T) CORRECTION ENERGY": -0.00058790,  # dfocc
+            "OCCD REFERENCE CORRECTION ENERGY": 0.00117357,  # dfocc
+            "OCCD CORRELATION ENERGY": -0.08136638,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(144).reshape((12, 12)),
         },
@@ -8820,6 +8873,8 @@ _std_suite = [
             "CCSD SINGLES ENERGY": 0.0,
             "(T) CORRECTION ENERGY": -0.00381140,  # dfocc
             "A-(T) CORRECTION ENERGY": -0.00373215,  # dfocc
+            "OCCD REFERENCE CORRECTION ENERGY": 0.00098847,  # dfocc
+            "OCCD CORRELATION ENERGY": -0.17163549,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -8862,6 +8917,8 @@ _std_suite = [
             "CCSD SINGLES ENERGY": 0.0,
             "(T) CORRECTION ENERGY": -0.00498288,  # dfocc
             "A-(T) CORRECTION ENERGY": -0.00488266,  # dfocc
+            "OCCD REFERENCE CORRECTION ENERGY": 0.00109104,  # dfocc
+            "OCCD CORRELATION ENERGY": -0.18823687,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -8898,6 +8955,8 @@ _std_suite = [
                     -0.00024246,
                 ]
             ).reshape((-1, 3)),
+            "OCCD REFERENCE CORRECTION ENERGY": -0.00035009,  # dfocc
+            "OCCD CORRELATION ENERGY": -0.08289004,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(144).reshape((12, 12)),
         },
@@ -8930,6 +8989,8 @@ _std_suite = [
                     -0.01318846179,
                 ]
             ).reshape((-1, 3)),
+            "OCCD REFERENCE CORRECTION ENERGY": -0.00342489,  # dfocc
+            "OCCD CORRELATION ENERGY": -0.17604899,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -8962,6 +9023,8 @@ _std_suite = [
                     -0.007444881162,
                 ]
             ).reshape((-1, 3)),
+            "OCCD REFERENCE CORRECTION ENERGY": -0.00351863,  # dfocc
+            "OCCD CORRELATION ENERGY": -0.19284661,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -9492,6 +9555,15 @@ _std_suite = [
                         -0.,             -0.,             -0.003068357914]
             ).reshape((-1, 3)),
             "A-(T) CORRECTION ENERGY": -0.00196275,  # dfocc
+            "OLCCD REFERENCE CORRECTION ENERGY": 0.00055271,  # dfocc
+            "OLCCD CORRELATION ENERGY": -0.21056994,  # dfocc
+            "OLCCD TOTAL GRADIENT": np.zeros(6).reshape((-1, 3)),
+            "OCCD REFERENCE CORRECTION ENERGY": 0.00051171,  # dfocc
+            "OCCD CORRELATION ENERGY": -0.20877456,  # dfocc
+            "OCCD TOTAL GRADIENT": np.array(  # dfocc
+                       [ 0.,              0.,              0.001829701274,
+                        -0.,             -0.,             -0.001829701274]
+            ).reshape((-1, 3)),
             # "XXX TOTAL GRADIENT": np.zeros(6).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(36).reshape((6, 6)),
         },
@@ -9558,6 +9630,20 @@ _std_suite = [
                         -0.,             -0.00604923838,  -0.005100003226]
             ).reshape((-1, 3)),
             "A-(T) CORRECTION ENERGY": -0.00524100,  # dfocc
+            "OLCCD REFERENCE CORRECTION ENERGY": 0.00118928,  # dfocc
+            "OLCCD CORRELATION ENERGY": -0.23317306,  # dfocc
+            "OLCCD TOTAL GRADIENT": np.array(  # dfocc
+                       [ 0.,              0.,              0.009760324413,
+                        -0.,              0.005852719747, -0.004880162207,
+                        -0.,             -0.005852719747, -0.004880162207]
+            ).reshape((-1, 3)),
+            "OCCD REFERENCE CORRECTION ENERGY": 0.00112410,  # dfocc
+            "OCCD CORRELATION ENERGY": -0.22924045,  # dfocc
+            "OCCD TOTAL GRADIENT": np.array(  # dfocc
+                       [ 0.,              0.,              0.007259061848,
+                        -0.,              0.00447396049,  -0.003629530924,
+                        -0.,             -0.00447396049,  -0.003629530924]
+            ).reshape((-1, 3)),
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -9614,6 +9700,16 @@ _std_suite = [
                          0.,              0.000742939441,  0.000108706333]
             ).reshape((-1, 3)),
             "A-(T) CORRECTION ENERGY": -0.00718001,  # dfocc
+            "OLCCD REFERENCE CORRECTION ENERGY": 0.00135231,  # dfocc
+            "OLCCD CORRELATION ENERGY": -0.27998133,  # dfocc
+            "OLCCD TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
+            "OCCD REFERENCE CORRECTION ENERGY": 0.00127939,  # dfocc
+            "OCCD CORRELATION ENERGY": -0.27539517,  # dfocc
+            "OCCD TOTAL GRADIENT": np.array(  # dfocc
+                       [ 0.,             -0.,             -0.003670657573,
+                        -0.,             -0.002477953535,  0.001835328787,
+                         0.,              0.002477953535,  0.001835328786]
+            ).reshape((-1, 3)),
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -9704,6 +9800,17 @@ _std_suite = [
                          0.,             -0.014962374742, -0.000028968144]
             ).reshape((-1, 3)),
             "A-(T) CORRECTION ENERGY": -0.00060972,  # dfocc
+            "OLCCD REFERENCE CORRECTION ENERGY": 0.00148572,  # dfocc
+            "OLCCD CORRELATION ENERGY": -0.08481145,  # dfocc
+            "OLCCD SAME-SPIN CORRELATION ENERGY": -0.00245014,  # dfocc
+            "OCCD REFERENCE CORRECTION ENERGY": 0.00116757,  # dfocc
+            "OCCD CORRELATION ENERGY": -0.08225498,  # dfocc
+            "OCCD TOTAL GRADIENT": np.array(  # dfocc
+                       [-0.,              0.,              0.005192785742,
+                         0.,             -0.,             -0.005046571537,
+                        -0.,              0.014877326081, -0.000073107103,
+                         0.,             -0.014877326081, -0.000073107103]
+            ).reshape((-1, 3)),
             # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(144).reshape((12, 12)),
         },
@@ -9763,6 +9870,21 @@ _std_suite = [
                         -0.,             -0.016805034066, -0.015574387725]
             ).reshape((-1, 3)),
             "A-(T) CORRECTION ENERGY": -0.00376812,  # dfocc
+            "OLCCD REFERENCE CORRECTION ENERGY": 0.00111162,  # dfocc
+            "OLCCD CORRELATION ENERGY": -0.17819693,  # dfocc
+            "OLCCD SAME-SPIN CORRELATION ENERGY": -0.03442235,  # dfocc
+            "OLCCD TOTAL GRADIENT": np.array(  # dfocc
+                       [-0.,             -0.,              0.03186203099,
+                         0.,              0.01725870275,  -0.015931015497,
+                        -0.,             -0.01725870275,  -0.015931015497]
+            ).reshape((-1, 3)),
+            "OCCD REFERENCE CORRECTION ENERGY": 0.00098759,  # dfocc
+            "OCCD CORRELATION ENERGY": -0.17380640,  # dfocc
+            "OCCD TOTAL GRADIENT": np.array(  # dfocc
+                       [-0.,             -0.,              0.02914585699 ,
+                         0.,              0.015744650608, -0.014572928495,
+                        -0.,             -0.015744650608, -0.014572928496]
+            ).reshape((-1, 3)),
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -9822,6 +9944,16 @@ _std_suite = [
                          0.,             -0.008236968052, -0.009509290722]
             ).reshape((-1, 3)),
             "A-(T) CORRECTION ENERGY": -0.00506341,  # dfocc
+            "OLCCD REFERENCE CORRECTION ENERGY": 0.00128551,  # dfocc
+            "OLCCD CORRELATION ENERGY": -0.21803893,  # dfocc
+            "OLCCD SAME-SPIN CORRELATION ENERGY": -0.04051003,  # dfocc
+            "OCCD REFERENCE CORRECTION ENERGY": 0.00115503,  # dfocc
+            "OCCD CORRELATION ENERGY": -0.21312358,  # dfocc
+            "OCCD TOTAL GRADIENT": np.array(  # dfocc
+                       [ 0.,              0.,              0.016674719968,
+                        -0.,              0.007064080694, -0.008337359984,
+                         0.,             -0.007064080694, -0.008337359984]
+            ).reshape((-1, 3)),
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -9860,6 +9992,17 @@ _std_suite = [
             ).reshape((-1, 3)),
             "LCCD CORRELATION ENERGY": -0.0834776542,  # p4n
             "LCCD TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
+            "OLCCD REFERENCE CORRECTION ENERGY": -0.00003862,  # dfocc
+            "OLCCD CORRELATION ENERGY": -0.08633549,  # dfocc
+            "OLCCD SAME-SPIN CORRELATION ENERGY": -0.00245012,  # dfocc
+            "OCCD REFERENCE CORRECTION ENERGY": -0.00035646,  # dfocc
+            "OCCD CORRELATION ENERGY": -0.08377901,  # dfocc
+            "OCCD TOTAL GRADIENT": np.array(  # dfocc
+                       [-0.,              0.,              0.005192980829,
+                         0.,             -0.,             -0.005046758888,
+                        -0.,              0.014877324353, -0.00007311097 ,
+                         0.,             -0.014877324353, -0.00007311097 ]
+            ).reshape((-1, 3)),
             # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(144).reshape((12, 12)),
         },
@@ -9894,6 +10037,21 @@ _std_suite = [
                 ]
             ).reshape((-1, 3)),
             "LCCD CORRELATION ENERGY": -0.1792603912,  # p4n
+            "OLCCD REFERENCE CORRECTION ENERGY": -0.00330233,  # dfocc
+            "OLCCD CORRELATION ENERGY": -0.18261089,  # dfocc
+            "OLCCD SAME-SPIN CORRELATION ENERGY": -0.03442231,  # dfocc
+            "OLCCD TOTAL GRADIENT": np.array(  # dfocc
+                       [-0.,             -0.,              0.031864743   ,
+                         0.,              0.017258564742, -0.0159323715  ,
+                        -0.,             -0.017258564742, -0.0159323715  ]
+            ).reshape((-1, 3)),
+            "OCCD REFERENCE CORRECTION ENERGY": -0.00342630,  # dfocc
+            "OCCD CORRELATION ENERGY": -0.17822036,  # dfocc
+            "OCCD TOTAL GRADIENT": np.array(  # dfocc
+                       [-0.,             -0.,              0.029147612271,
+                         0.,              0.015744923333, -0.014573806135,
+                        -0.,             -0.015744923333, -0.014573806135]
+            ).reshape((-1, 3)),
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -9928,6 +10086,16 @@ _std_suite = [
                 ]
             ).reshape((-1, 3)),
             "LCCD CORRELATION ENERGY": -0.2190866990,  # p4n
+            "OLCCD REFERENCE CORRECTION ENERGY": -0.00332461,  # dfocc
+            "OLCCD CORRELATION ENERGY": -0.22264897,  # dfocc
+            "OLCCD SAME-SPIN CORRELATION ENERGY": -0.04051002,  # dfocc
+            "OCCD REFERENCE CORRECTION ENERGY": -0.00345497,  # dfocc
+            "OCCD CORRELATION ENERGY": -0.21773362,  # dfocc
+            "OCCD TOTAL GRADIENT": np.array(  # dfocc
+                       [ 0.,              0.,              0.016673805473,
+                        -0.,              0.00706348269,  -0.008336902738,
+                         0.,             -0.00706348269,  -0.008336902735]
+            ).reshape((-1, 3)),
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -9984,6 +10152,12 @@ _std_suite = [
                         -0.,             -0.,             -0.003412477814]
             ).reshape((-1, 3)),
             "A-(T) CORRECTION ENERGY": -0.00194585,  # dfocc
+            "OCCD REFERENCE CORRECTION ENERGY": 0.00051223,  # dfocc
+            "OCCD CORRELATION ENERGY": -0.20695630,  # dfocc
+            "OCCD TOTAL GRADIENT": np.array(  # dfocc
+                       [ 0.,              0.,              0.002245649472,
+                        -0.,             -0.,             -0.002245649472]
+            ).reshape((-1, 3)),
             # "XXX TOTAL GRADIENT": np.zeros(6).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(36).reshape((6, 6)),
         },
@@ -10050,6 +10224,13 @@ _std_suite = [
                         -0.,             -0.006421774051, -0.005400604283]
             ).reshape((-1, 3)),
             "A-(T) CORRECTION ENERGY": -0.00521446,  # dfocc
+            "OCCD REFERENCE CORRECTION ENERGY": 0.00112736,  # dfocc
+            "OCCD CORRELATION ENERGY": -0.22711014,  # dfocc
+            "OCCD TOTAL GRADIENT": np.array(  # dfocc
+                       [ 0.,             -0.,              0.007977308047,
+                        -0.,              0.004884097985, -0.003988654024,
+                        -0.,             -0.004884097985, -0.003988654024]
+            ).reshape((-1, 3)),
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -10116,6 +10297,13 @@ _std_suite = [
                          0.,              0.000361314051, -0.000308753262]
             ).reshape((-1, 3)),
             "A-(T) CORRECTION ENERGY": -0.00701651,  # dfocc
+            "OCCD REFERENCE CORRECTION ENERGY": 0.00122701,  # dfocc
+            "OCCD CORRELATION ENERGY": -0.25004962,  # dfocc
+            "OCCD TOTAL GRADIENT": np.array(  # dfocc
+                       [ 0.,             -0.,             -0.002738848137,
+                        -0.,             -0.00205614215,   0.001369424069,
+                         0.,              0.00205614215,   0.001369424068]
+            ).reshape((-1, 3)),
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -10206,6 +10394,14 @@ _std_suite = [
                          0.,             -0.014958703713, -0.000035200787]
             ).reshape((-1, 3)),
             "A-(T) CORRECTION ENERGY": -0.00058825,  # dfocc
+            "OCCD REFERENCE CORRECTION ENERGY": 0.00117508,  # dfocc
+            "OCCD CORRELATION ENERGY": -0.08143642,  # dfocc
+            "OCCD TOTAL GRADIENT": np.array(  # dfocc
+                       [-0.,              0.,              0.004941864874,
+                         0.,             -0.,             -0.004784287208,
+                        -0.,              0.014873119825, -0.000078788833,
+                         0.,             -0.014873119825, -0.000078788833]
+            ).reshape((-1, 3)),
             # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(144).reshape((12, 12)),
         },
@@ -10265,6 +10461,13 @@ _std_suite = [
                         -0.,             -0.017296807836, -0.015961537154]
             ).reshape((-1, 3)),
             "A-(T) CORRECTION ENERGY": -0.00373604,  # dfocc
+            "OCCD REFERENCE CORRECTION ENERGY": 0.00098836,  # dfocc
+            "OCCD CORRELATION ENERGY": -0.17171798,  # dfocc
+            "OCCD TOTAL GRADIENT": np.array(  # dfocc
+                       [-0.,             -0.,              0.030026015485,
+                         0.,              0.016268136174, -0.015013007742,
+                        -0.,             -0.016268136173, -0.015013007743]
+            ).reshape((-1, 3)),
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -10324,6 +10527,13 @@ _std_suite = [
                          0.,             -0.008716203188, -0.010003589367]
             ).reshape((-1, 3)),
             "A-(T) CORRECTION ENERGY": -0.00488153,  # dfocc
+            "OCCD REFERENCE CORRECTION ENERGY": 0.00109104,  # dfocc
+            "OCCD CORRELATION ENERGY": -0.18822673,  # dfocc
+            "OCCD TOTAL GRADIENT": np.array(  # dfocc
+                       [ 0.,              0.,              0.017782847456,
+                        -0.,              0.007591037208, -0.008891423727,
+                         0.,             -0.007591037209, -0.008891423729]
+            ).reshape((-1, 3)),
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -10361,6 +10571,14 @@ _std_suite = [
                 ]
             ).reshape((-1, 3)),
             "LCCD CORRELATION ENERGY": -0.0824737155,  # p4n
+            "OCCD REFERENCE CORRECTION ENERGY": -0.00034891,  # dfocc
+            "OCCD CORRELATION ENERGY": -0.08296046,  # dfocc
+            "OCCD TOTAL GRADIENT": np.array(  # dfocc
+                       [-0.,              0.,              0.00494137578 ,
+                         0.,             -0.,             -0.004783814597,
+                        -0.,              0.014873122524, -0.000078780591,
+                         0.,             -0.014873122524, -0.000078780591]
+            ).reshape((-1, 3)),
             # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(144).reshape((12, 12)),
         },
@@ -10395,6 +10613,13 @@ _std_suite = [
                 ]
             ).reshape((-1, 3)),
             "LCCD CORRELATION ENERGY": -0.1769909051,  # p4n
+            "OCCD REFERENCE CORRECTION ENERGY": -0.00342546,  # dfocc
+            "OCCD CORRELATION ENERGY": -0.17613194,  # dfocc
+            "OCCD TOTAL GRADIENT": np.array(  # dfocc
+                       [-0.,              0.,              0.030027564344,
+                         0.,              0.016268433623, -0.015013782162,
+                        -0.,             -0.016268433623, -0.015013782182]
+            ).reshape((-1, 3)),
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -10429,6 +10654,13 @@ _std_suite = [
                 ]
             ).reshape((-1, 3)),
             "LCCD CORRELATION ENERGY": -0.1939804718,  # p4n
+            "OCCD REFERENCE CORRECTION ENERGY": -0.00351899,  # dfocc
+            "OCCD CORRELATION ENERGY": -0.19283677,  # dfocc
+            "OCCD TOTAL GRADIENT": np.array(
+                       [ 0.,              0.,              0.017781529683,
+                        -0.,              0.007590440485, -0.008890764841,
+                         0.,             -0.007590440485, -0.008890764842]
+            ).reshape((-1, 3)),
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },

--- a/qcengine/programs/tests/standard_suite_ref.py
+++ b/qcengine/programs/tests/standard_suite_ref.py
@@ -458,6 +458,10 @@ _hess_scf_nh2_adz_cd_rohf = np.zeros(81).reshape((9, 9))
 #       * "OLCCD TOTAL GRADIENT" in CONV-FC-CONV
 #       * "O(T) CORRECTION ENERGY in CONV-AE-CONV and CONV-FC-CONV
 #       * "A-O(T) CORRECTION ENERGY" in CONV-AE-CONV and CONV-FC-CONV
+#       * "OMP2/OMP2.5/OMP3/OREMP REFERENCE CORRECTION ENERGY" in CONV-FC-CONV for rhf/uhf/rohf
+#       * "OMP2/OMP2.5/OMP3/OREMP CORRELATION ENERGY" in CONV-FC-CONV for rhf/uhf/rohf
+#       * "OMP2/OMP2.5/OMP3/OREMP TOTAL GRADIENT" in CONV-FC-CONV for rhf/uhf/rohf
+#       * "OMP2/OMP2.5/OMP3/OREMP SAME-SPIN CORRELATION ENERGY" in CONV-FC-CONV for uhf/rohf
 _knownmissing = "KnownMissing"
 
 _std_suite = [
@@ -508,6 +512,9 @@ _std_suite = [
             "QCISD CORRELATION ENERGY": -0.20892771089382,  # vcc
             "QCISD(T) CORRECTION ENERGY": -0.00182210,  # vcc
             "FCI CORRELATION ENERGY": -0.21117389325,  # detci
+            "REMP CORRELATION ENERGY": -0.20840575987435,  # occ, tight
+            "REMP SINGLES ENERGY": 0.0,
+            "REMP SAME-SPIN CORRELATION ENERGY": -0.04954400816816,  # occ, tight
             "LCCD CORRELATION ENERGY": -0.2099060277,  # p4n
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.048339903547,  # fnocc
@@ -671,6 +678,34 @@ _std_suite = [
                     0.000000000000000,
                     -0.003507320893113,
                 ]
+            ).reshape((-1, 3)),
+            "OMP2 REFERENCE CORRECTION ENERGY": 0.000704890964,  # occ, tight
+            "OMP2 CORRELATION ENERGY": -0.204465719970,  # occ, tight
+            "OMP2 SAME-SPIN CORRELATION ENERGY": -0.054616313597,  # occ, tight
+            "OMP2 TOTAL GRADIENT": np.array(  # occ, tight
+             [ 0., 0.,  0.004107528173,
+               0., 0., -0.004107528173]
+            ).reshape((-1, 3)),
+            "OMP2.5 REFERENCE CORRECTION ENERGY": 0.000571728736,  # occ, tight
+            "OMP2.5 CORRELATION ENERGY": -0.205686837008,  # occ, tight
+            "OMP2.5 SAME-SPIN CORRELATION ENERGY": -0.052301161413,  # occ, tight
+            "OMP2.5 TOTAL GRADIENT": np.array(  # occ, tight
+              [ 0.,   0.000000000000,     0.002017001118,
+                0.,   0.000000000000,    -0.002017001118]
+            ).reshape((-1, 3)),
+            "OMP3 REFERENCE CORRECTION ENERGY": 0.000467222482,  # occ, tight
+            "OMP3 CORRELATION ENERGY": -0.206935131375,  # occ, tight
+            "OMP3 SAME-SPIN CORRELATION ENERGY": -0.050007707662,  # occ, tight
+            "OMP3 TOTAL GRADIENT": np.array(  # occ, tight
+                [   0., 0., -0.000007413433,
+                    0., 0.,  0.000007413433]
+            ).reshape((-1, 3)),
+            "OREMP REFERENCE CORRECTION ENERGY": 0.000553304064,  # occ, tight
+            "OREMP CORRELATION ENERGY": -0.208942935871,  # occ, tight
+            "OREMP SAME-SPIN CORRELATION ENERGY": -0.049683397802,  # occ, tight
+            "OREMP TOTAL GRADIENT": np.array(  # occ, tight
+              [ 0.,  0.000000000000,     0.002830089047,
+                0.,  0.000000000000,    -0.002830089047]
             ).reshape((-1, 3)),
             "OLCCD REFERENCE CORRECTION ENERGY": 0.0005522939,  # p4n
             "OLCCD CORRELATION ENERGY": -0.2104417743,  # p4n
@@ -843,6 +878,9 @@ _std_suite = [
             "CISD CORRELATION ENERGY": -0.21978965712829,  # vcc
             "QCISD CORRELATION ENERGY": -0.22998871354660,  # vcc
             "QCISD(T) CORRECTION ENERGY": -0.0048836279,  # vcc
+            "REMP CORRELATION ENERGY": -0.229445317607,  # occ, tight
+            "REMP SINGLES ENERGY": 0.0,
+            "REMP SAME-SPIN CORRELATION ENERGY": -0.051382139941,  # occ, tight
             "LCCD CORRELATION ENERGY": -0.2318870702,  # p4n
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.049937236558,  # fnocc
@@ -1487,6 +1525,38 @@ _std_suite = [
                 ]
             ).reshape((-1, 3)),
             "CCSDTQ CORRELATION ENERGY": -0.235338854850175,  # ncc
+            "OMP2 REFERENCE CORRECTION ENERGY": 0.002352035679,  # occ, tight
+            "OMP2 CORRELATION ENERGY": -0.224125328536,  # occ, tight
+            "OMP2 SAME-SPIN CORRELATION ENERGY": -0.058141813805,  # occ, tight
+            "OMP2 TOTAL GRADIENT": np.array(  # occ, tight
+                [ 0.,  0.,  0.012093662469,
+                  0.,  0.006798848063,   -0.006046831235,
+                  0., -0.006798848063,   -0.006046831235]
+            ).reshape((-1, 3)),
+            "OMP2.5 REFERENCE CORRECTION ENERGY": 0.001534835679,  # occ, tight
+            "OMP2.5 CORRELATION ENERGY": -0.225651726817,  # occ, tight
+            "OMP2.5 SAME-SPIN CORRELATION ENERGY": -0.055105451161,  # occ, tight
+            "OMP2.5 TOTAL GRADIENT": np.array(  # occ, tight
+              [ 0.,   0.000000000000,     0.008280964210,
+                0.,   0.004780030747,    -0.004140482105,
+                0.,  -0.004780030747,    -0.004140482105]
+            ).reshape((-1, 3)),
+            "OMP3 REFERENCE CORRECTION ENERGY": 0.000953570304,  # occ, tight
+            "OMP3 CORRELATION ENERGY": -0.227372086899,  # occ, tight
+            "OMP3 SAME-SPIN CORRELATION ENERGY": -0.052239106558,  # occ, tight
+            "OMP3 TOTAL GRADIENT": np.array(  # occ, tight
+                [   0.,  0.000000000000,     0.004803850255,
+                    0.,  0.002953922342,    -0.002401925128,
+                    0., -0.002953922342,    -0.002401925128]
+            ).reshape((-1, 3)),
+            "OREMP REFERENCE CORRECTION ENERGY": 0.00128167136578,  # occ, tight
+            "OREMP CORRELATION ENERGY": -0.23069139385821,  # occ, tight
+            "OREMP SAME-SPIN CORRELATION ENERGY": -0.05189818473696,  # occ, tight
+            "OREMP TOTAL GRADIENT": np.array(  # occ, tight
+               [    0., -0.000000000000,     0.009103029917,
+                    0.,  0.005405690204,    -0.004551514958,
+                    0., -0.005405690204,    -0.004551514958]
+            ).reshape((-1, 3)),
             "OLCCD REFERENCE CORRECTION ENERGY": 0.0011895155,  # p4n
             "OLCCD CORRELATION ENERGY": -0.2330452995,  # p4n
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.0503175223,  # occ
@@ -1673,6 +1743,9 @@ _std_suite = [
             "CISD CORRELATION ENERGY": -0.26425382513286,  # vcc
             "QCISD CORRELATION ENERGY": -0.27614913924585,  # vcc
             "QCISD(T) CORRECTION ENERGY": -0.00704158,  # vcc
+            "REMP CORRELATION ENERGY": -0.276444865873,  # occ, tight
+            "REMP SINGLES ENERGY": 0.0,
+            "REMP SAME-SPIN CORRELATION ENERGY": -0.059323770883,  # occ, tight
             "LCCD CORRELATION ENERGY": -0.2786913134,  # p4n
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.057792990490,  # fnocc
@@ -2487,6 +2560,38 @@ _std_suite = [
                 ]
             ).reshape((-1, 3)),
             "CCSDTQ CORRELATION ENERGY": -0.283376955140291,  # ncc
+            "OMP2 REFERENCE CORRECTION ENERGY": 0.002513901693,  # occ, tight
+            "OMP2 CORRELATION ENERGY": -0.272599646070,  # occ, tight
+            "OMP2 SAME-SPIN CORRELATION ENERGY": -0.066843168345,  # occ, tight
+            "OMP2 TOTAL GRADIENT": np.array(  # occ, tight
+              [ 0.,  0.000000000000,     0.001853244534,
+                0.,  0.000249902550,    -0.000926622267,
+                0., -0.000249902550,    -0.000926622267]
+            ).reshape((-1, 3)),
+            "OMP2.5 REFERENCE CORRECTION ENERGY": 0.001691543451,  # occ, tight
+            "OMP2.5 CORRELATION ENERGY": -0.273211228305,  # occ, tight
+            "OMP2.5 SAME-SPIN CORRELATION ENERGY": -0.063331759367,  # occ, tight
+            "OMP2.5 TOTAL GRADIENT": np.array(  # occ, tight
+              [ 0.,   0.000000000000,    -0.002291101232,
+                0.,  -0.001990147396,     0.001145550616,
+                0.,   0.001990147396,     0.001145550616]
+            ).reshape((-1, 3)),
+            "OMP3 REFERENCE CORRECTION ENERGY": 0.001090059672,  # occ, tight
+            "OMP3 CORRELATION ENERGY": -0.274015056808,  # occ, tight
+            "OMP3 SAME-SPIN CORRELATION ENERGY": -0.059986220382,  # occ, tight
+            "OMP3 TOTAL GRADIENT": np.array(  # occ, tight
+                [   0.,  0.000000000000,    -0.006148152213,
+                    0., -0.004066707268,     0.003074076107,
+                    0.,  0.004066707268,     0.003074076107]
+            ).reshape((-1, 3)),
+            "OREMP REFERENCE CORRECTION ENERGY": 0.001444328268,  # occ, tight
+            "OREMP CORRELATION ENERGY": -0.277848169449,  # occ, tight
+            "OREMP SAME-SPIN CORRELATION ENERGY": -0.059932090515,  # occ, tight
+            "OREMP TOTAL GRADIENT": np.array(  # occ, tight
+              [ 0.,  0.000000000000,    -0.001616411571,
+                0., -0.001508635375,     0.000808205786,
+                0.,  0.001508635375,     0.000808205786]
+            ).reshape((-1, 3)),
             "OLCCD REFERENCE CORRECTION ENERGY": 0.0013521561,  # p4n
             "OLCCD CORRELATION ENERGY": -0.2800053174,  # p4n
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.0582676514,  # occ
@@ -2758,6 +2863,9 @@ _std_suite = [
             "CISD CORRELATION ENERGY": -0.08014448073265,  # vcc
             "QCISD CORRELATION ENERGY": -0.08218197897917,  # vcc
             "QCISD(T) CORRECTION ENERGY": -0.00062359,  # vcc only
+            "REMP CORRELATION ENERGY": -0.07803997531851,  # occ, tight
+            "REMP SINGLES ENERGY": 0.0,
+            "REMP SAME-SPIN CORRELATION ENERGY": -0.00233934205346,  # occ, tight
             "LCCD CORRELATION ENERGY": -0.0834347185,  # p4n
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0024003297,  # occ
@@ -3342,6 +3450,42 @@ _std_suite = [
             "CCSDT-2 CORRELATION ENERGY": -0.082795702684,  # ecc
             "CCSDT-3 CORRELATION ENERGY": -0.08280038799307,  # vcc
             "CCSDT CORRELATION ENERGY": -0.08311156413461,  # vcc
+            "OMP2 REFERENCE CORRECTION ENERGY": 0.000395359637,  # occ, tight
+            "OMP2 CORRELATION ENERGY": -0.059864579866,  # occ, tight
+            "OMP2 SAME-SPIN CORRELATION ENERGY": -0.001971155898,  # occ, tight
+            "OMP2 TOTAL GRADIENT": np.array(  # occ, tight
+                [   0.,  0.000000000000,     0.012017558262,
+                    0.,  0.000000000000,    -0.011623172725,
+                    0.,  0.010549443964,    -0.000197192768,
+                    0., -0.010549443964,    -0.000197192768]
+            ).reshape((-1, 3)),
+            "OMP2.5 REFERENCE CORRECTION ENERGY": 0.000564671059,  # occ, tight
+            "OMP2.5 CORRELATION ENERGY": -0.067680196985,  # occ, tight
+            "OMP2.5 SAME-SPIN CORRELATION ENERGY": -0.002198682496,  # occ, tight
+            "OMP2.5 TOTAL GRADIENT": np.array(  # occ, tight
+              [ 0.,   0.000000000000,     0.010260851431,
+                0.,   0.000000000000,    -0.009981279417,
+                0.,   0.011818192519,    -0.000139786007,
+                0.,  -0.011818192519,    -0.000139786007]
+            ).reshape((-1, 3)),
+            "OMP3 REFERENCE CORRECTION ENERGY": 0.000777674538,  # occ, tight
+            "OMP3 CORRELATION ENERGY": -0.075531256945,  # occ, tight
+            "OMP3 SAME-SPIN CORRELATION ENERGY": -0.002426022161,  # occ, tight
+            "OMP3 TOTAL GRADIENT": np.array(  # occ, tight
+                [   0.,  0.000000000000,     0.008456348171,
+                    0.,  0.000000000000,    -0.008291902042,
+                    0.,  0.013097750811,    -0.000082223065,
+                    0., -0.013097750811,    -0.000082223065]
+            ).reshape((-1, 3)),
+            "OREMP REFERENCE CORRECTION ENERGY": 0.001061018532,  # occ, tight
+            "OREMP CORRELATION ENERGY": -0.078996001732,  # occ, tight
+            "OREMP SAME-SPIN CORRELATION ENERGY": -0.002398210306,  # occ, tight
+            "OREMP TOTAL GRADIENT": np.array(  # occ, tight
+              [ 0.,  0.000000000000,     0.005898073051,
+                0.,  0.000000000000,    -0.005790147152,
+                0.,  0.014384641403,    -0.000053962950,
+                0., -0.014384641403,    -0.000053962950]
+            ).reshape((-1, 3)),
             "OLCCD REFERENCE CORRECTION ENERGY": 0.0014842084,  # p4n
             "OLCCD CORRELATION ENERGY": -0.0847413506,  # p4n
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.0024486744,  # occ
@@ -3442,6 +3586,9 @@ _std_suite = [
             "CISD CORRELATION ENERGY": -0.16787805277043,  # vcc
             "QCISD CORRELATION ENERGY": -0.17409647936869,  # vcc
             "QCISD(T) CORRECTION ENERGY": -0.00371845,  # vcc only
+            "REMP CORRELATION ENERGY": -0.172501515758,  # occ, tight
+            "REMP SINGLES ENERGY": 0.0,
+            "REMP SAME-SPIN CORRELATION ENERGY": -0.034548274152,  # occ, tight
             "LCCD CORRELATION ENERGY": -0.1770086091,  # p4n
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0341268118,  # occ
@@ -3596,6 +3743,38 @@ _std_suite = [
                 [[0.0, 0.0, 0.03102835], [0.0, 0.01674637, -0.01551417], [0.0, -0.01674637, -0.01551417]]
             ),
             "CCSDT CORRELATION ENERGY": -0.17817199774450,  # vcc
+            "OMP2 REFERENCE CORRECTION ENERGY": 0.001367125249,  # occ, tight
+            "OMP2 CORRELATION ENERGY": -0.156193539287,  # occ, tight
+            "OMP2 SAME-SPIN CORRELATION ENERGY": -0.035974458829,  # occ, tight
+            "OMP2 TOTAL GRADIENT": np.array(  # occ, tight
+              [ 0.,  0.000000000000,     0.026928654402,
+                0.,  0.014250914503,    -0.013464327201,
+                0., -0.014250914503,    -0.013464327201]
+            ).reshape((-1, 3)),
+            "OMP2.5 REFERENCE CORRECTION ENERGY": 0.001173901427,  # occ, tight
+            "OMP2.5 CORRELATION ENERGY": -0.164044987798,  # occ, tight
+            "OMP2.5 SAME-SPIN CORRELATION ENERGY": -0.035847752938,  # occ, tight
+            "OMP2.5 TOTAL GRADIENT": np.array(  # occ, tight
+              [ 0.,   0.000000000000,     0.027494393497,
+                0.,   0.014585953475,    -0.013747196748,
+                0.,  -0.014585953475,    -0.013747196748]
+            ).reshape((-1, 3)),
+            "OMP3 REFERENCE CORRECTION ENERGY": 0.001024209316,  # occ, tight
+            "OMP3 CORRELATION ENERGY": -0.171933638522,  # occ, tight
+            "OMP3 SAME-SPIN CORRELATION ENERGY": -0.035747352644,  # occ, tight
+            "OMP3 TOTAL GRADIENT": np.array(  # occ, tight
+                [   0.,  0.000000000000,     0.028120207496,
+                    0.,  0.014956911575,    -0.014060103748,
+                    0., -0.014956911575,    -0.014060103748]
+            ).reshape((-1, 3)),
+            "OREMP REFERENCE CORRECTION ENERGY": 0.00111233720168,  # occ, tight
+            "OREMP CORRELATION ENERGY": -0.17359939909712,  # occ, tight
+            "OREMP SAME-SPIN CORRELATION ENERGY": -0.03496212583967,  # occ, tight
+            "OREMP TOTAL GRADIENT": np.array(  # occ, tight
+                [   0.,  0.000000000000,     0.030225286483,
+                    0.,  0.016238459426,    -0.015112643242,
+                    0., -0.016238459426,    -0.015112643242]
+            ).reshape((-1, 3)),
             "OLCCD REFERENCE CORRECTION ENERGY": 0.0011118724,  # p4n
             "OLCCD CORRELATION ENERGY": -0.1781057943,  # p4n
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.0344689234,  # occ
@@ -3692,6 +3871,9 @@ _std_suite = [
             "CISD CORRELATION ENERGY": -0.20576009250440,  # vcc
             "QCISD CORRELATION ENERGY": -0.21351003301667,  # vcc
             "QCISD(T) CORRECTION ENERGY": -0.00505349,  # vcc only
+            "REMP CORRELATION ENERGY": -0.212452538490,  # occ, tight
+            "REMP SINGLES ENERGY": 0.0,
+            "REMP SAME-SPIN CORRELATION ENERGY": -0.040608279810,  # occ, tight
             "LCCD CORRELATION ENERGY": -0.2167878305,  # p4n
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0401306050,  # occ
@@ -3837,6 +4019,38 @@ _std_suite = [
             "CCSDT-2 CORRELATION ENERGY": -0.218253889761,  # ecc
             "CCSDT-3 CORRELATION ENERGY": -0.21827269362849,  # vcc
             "CCSDT CORRELATION ENERGY": -0.21884856037681,  # vcc
+            "OMP2 REFERENCE CORRECTION ENERGY": 0.001570623297,  # occ, tight
+            "OMP2 CORRELATION ENERGY": -0.197071770029,  # occ, tight
+            "OMP2 SAME-SPIN CORRELATION ENERGY": -0.042459313035,  # occ, tight
+            "OMP2 TOTAL GRADIENT": np.array(  # occ, tight
+                [   0.,  0.000000000000,     0.015314078302,
+                    0.,  0.006156840975,    -0.007657039151,
+                    0., -0.006156840975,    -0.007657039151]
+            ).reshape((-1, 3)),
+            "OMP2.5 REFERENCE CORRECTION ENERGY": 0.001350812375,  # occ, tight
+            "OMP2.5 CORRELATION ENERGY": -0.204522615491,  # occ, tight
+            "OMP2.5 SAME-SPIN CORRELATION ENERGY": -0.042086148458,  # occ, tight
+            "OMP2.5 TOTAL GRADIENT": np.array(  # occ, tight
+              [ 0.,   0.000000000000,     0.015411835251,
+                0.,   0.006162364663,    -0.007705917626,
+                0.,  -0.006162364663,    -0.007705917626]
+            ).reshape((-1, 3)),
+            "OMP3 REFERENCE CORRECTION ENERGY": 0.001177767799,  # occ, tight
+            "OMP3 CORRELATION ENERGY": -0.212015174087,  # occ, tight
+            "OMP3 SAME-SPIN CORRELATION ENERGY": -0.041743491888,  # occ, tight
+            "OMP3 TOTAL GRADIENT": np.array(  # occ, tight
+                [   0.,  0.000000000000,     0.015569868835,
+                    0.,  0.006203313670,    -0.007784934417,
+                    0., -0.006203313670,    -0.007784934417]
+            ).reshape((-1, 3)),
+            "OREMP REFERENCE CORRECTION ENERGY": 0.001287772670,  # occ, tight
+            "OREMP CORRELATION ENERGY": -0.213723933328,  # occ, tight
+            "OREMP SAME-SPIN CORRELATION ENERGY": -0.041063372010,  # occ, tight
+            "OREMP TOTAL GRADIENT": np.array(  # occ, tight
+              [ 0.,  0.000000000000,     0.017901979677,
+                0.,  0.007592988824,    -0.008950989839,
+                0., -0.007592988824,    -0.008950989839]
+            ).reshape((-1, 3)),
             "OLCCD REFERENCE CORRECTION ENERGY": 0.0012856903,  # p4n
             "OLCCD CORRELATION ENERGY": -0.2180560836,  # p4n
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.0405122800,  # occ
@@ -4132,6 +4346,42 @@ _std_suite = [
                 ]
             ),
             "CCSDT CORRELATION ENERGY": -0.08463562959121,  # vcc
+            "OMP2 REFERENCE CORRECTION ENERGY": -0.001128749117,  # occ, tight
+            "OMP2 CORRELATION ENERGY": -0.061388690115,  # occ, tight
+            "OMP2 SAME-SPIN CORRELATION ENERGY": -0.001971155774,  # occ, tight
+            "OMP2 TOTAL GRADIENT": np.array(  # occ, tight
+                [   0.,  0.000000000000,     0.012017560624,
+                    0.,  0.000000000000,    -0.011623175532,
+                    0.,  0.010549441086,    -0.000197192546,
+                    0., -0.010549441086,    -0.000197192546]
+            ).reshape((-1, 3)),
+            "OMP2.5 REFERENCE CORRECTION ENERGY": -0.000959439798,  # occ, tight
+            "OMP2.5 CORRELATION ENERGY": -0.069204306750,  # occ, tight
+            "OMP2.5 SAME-SPIN CORRELATION ENERGY": -0.002198682531,  # occ, tight
+            "OMP2.5 TOTAL GRADIENT": np.array(  # occ, tight
+              [ 0.,   0.000000000000,     0.010260857036,
+                0.,   0.000000000000,    -0.009981284641,
+                0.,   0.011818192175,    -0.000139786197,
+                0.,  -0.011818192175,    -0.000139786197]
+            ).reshape((-1, 3)),
+            "OMP3 REFERENCE CORRECTION ENERGY": -0.000746435584,  # occ, tight
+            "OMP3 CORRELATION ENERGY": -0.077055367311,  # occ, tight
+            "OMP3 SAME-SPIN CORRELATION ENERGY": -0.002426022153,  # occ, tight
+            "OMP3 TOTAL GRADIENT": np.array(  # occ, tight
+                [   0.,  0.000000000000,     0.008456347254,
+                    0.,  0.000000000000,    -0.008291901023,
+                    0.,  0.013097750617,    -0.000082223115,
+                    0., -0.013097750617,    -0.000082223115]
+            ).reshape((-1, 3)),
+            "OREMP REFERENCE CORRECTION ENERGY": -0.000463092111,  # occ, tight
+            "OREMP CORRELATION ENERGY": -0.080520111623,  # occ, tight
+            "OREMP SAME-SPIN CORRELATION ENERGY": -0.002398210414,  # occ, tight
+            "OREMP TOTAL GRADIENT": np.array(  # occ, tight
+              [ 0.,  0.000000000000,     0.005898074368,
+                0.,  0.000000000000,    -0.005790150595,
+                0.,  0.014384643442,    -0.000053961887,
+                0., -0.014384643442,    -0.000053961887]
+            ).reshape((-1, 3)),
             "OLCCD REFERENCE CORRECTION ENERGY": -0.0000399018,  # p4n
             "OLCCD CORRELATION ENERGY": -0.0862654609,  # p4n
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.0024486744,  # occ
@@ -4266,6 +4516,38 @@ _std_suite = [
                 ]
             ),
             "CCSDT CORRELATION ENERGY": -0.18258437583017,  # vcc
+            "OMP2 REFERENCE CORRECTION ENERGY": -0.003046592318,  # occ, tight
+            "OMP2 CORRELATION ENERGY": -0.160607243189,  # occ, tight
+            "OMP2 SAME-SPIN CORRELATION ENERGY": -0.035974454782,  # occ, tight
+            "OMP2 TOTAL GRADIENT": np.array(  # occ, tight
+              [ 0.,  0.000000000000,     0.026928663612,
+                0.,  0.014250907985,    -0.013464331806,
+                0., -0.014250907985,    -0.013464331806]
+            ).reshape((-1, 3)),
+            "OMP2.5 REFERENCE CORRECTION ENERGY": -0.003239801580,  # occ, tight
+            "OMP2.5 CORRELATION ENERGY": -0.168458692138,  # occ, tight
+            "OMP2.5 SAME-SPIN CORRELATION ENERGY": -0.035847753329,  # occ, tight
+            "OMP2.5 TOTAL GRADIENT": np.array(  # occ, tight
+              [ 0.,   0.000000000000,     0.027494386758,
+                0.,   0.014585950370,    -0.013747193379,
+                0.,  -0.014585950370,    -0.013747193379]
+            ).reshape((-1, 3)),
+            "OMP3 REFERENCE CORRECTION ENERGY": -0.003389494582,  # occ, tight
+            "OMP3 CORRELATION ENERGY": -0.176347342433,  # occ, tight
+            "OMP3 SAME-SPIN CORRELATION ENERGY": -0.035747352645,  # occ, tight
+            "OMP3 TOTAL GRADIENT": np.array(  # occ, tight
+              [ 0.,  0.000000000000,     0.028120207297,
+                0.,  0.014956911348,    -0.014060103648,
+                0., -0.014956911348,    -0.014060103648]
+            ).reshape((-1, 3)),
+            "OREMP REFERENCE CORRECTION ENERGY": -0.003301366872,  # occ, tight
+            "OREMP CORRELATION ENERGY": -0.178013102573,  # occ, tight
+            "OREMP SAME-SPIN CORRELATION ENERGY": -0.034962125667,  # occ, tight
+            "OREMP TOTAL GRADIENT": np.array(  # occ, tight
+              [ 0.,  0.000000000000,     0.030225286965,
+                0.,  0.016238460656,    -0.015112643483,
+                0., -0.016238460656,    -0.015112643483]
+            ).reshape((-1, 3)),
             "OLCCD REFERENCE CORRECTION ENERGY": -0.0033018315,  # p4n
             "OLCCD CORRELATION ENERGY": -0.1825194982,  # p4n
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.0344689234,  # occ
@@ -4395,6 +4677,38 @@ _std_suite = [
                 ]
             ),
             "CCSDT CORRELATION ENERGY": -0.22345631762464,  # vcc
+            "OMP2 REFERENCE CORRECTION ENERGY": -0.003039092557,  # occ, tight
+            "OMP2 CORRELATION ENERGY": -0.201681478150,  # occ, tight
+            "OMP2 SAME-SPIN CORRELATION ENERGY": -0.042459312118,  # occ, tight
+            "OMP2 TOTAL GRADIENT": np.array(  # occ, tight
+                [   0.,  0.000000000000,     0.015314087546,
+                    0.,  0.006156841239,    -0.007657043773,
+                    0., -0.006156841239,    -0.007657043773]
+            ).reshape((-1, 3)),
+            "OMP2.5 REFERENCE CORRECTION ENERGY": -0.003258895747,  # occ, tight
+            "OMP2.5 CORRELATION ENERGY": -0.209132323529,  # occ, tight
+            "OMP2.5 SAME-SPIN CORRELATION ENERGY": -0.042086148395,  # occ, tight
+            "OMP2.5 TOTAL GRADIENT": np.array(  # occ, tight
+              [ 0.,   0.000000000000,     0.015411833442,
+                0.,   0.006162364110,    -0.007705916721,
+                0.,  -0.006162364110,    -0.007705916721]
+            ).reshape((-1, 3)),
+            "OMP3 REFERENCE CORRECTION ENERGY": -0.003431940343,  # occ, tight
+            "OMP3 CORRELATION ENERGY": -0.216624882230,  # occ, tight
+            "OMP3 SAME-SPIN CORRELATION ENERGY": -0.041743491868,  # occ, tight
+            "OMP3 TOTAL GRADIENT": np.array(  # occ, tight
+                [   0.,  0.000000000000,     0.015569867435,
+                    0.,  0.006203313291,    -0.007784933717,
+                    0., -0.006203313291,    -0.007784933717]
+            ).reshape((-1, 3)),
+            "OREMP REFERENCE CORRECTION ENERGY": -0.003321935448,  # occ, tight
+            "OREMP CORRELATION ENERGY": -0.218333639848,  # occ, tight
+            "OREMP SAME-SPIN CORRELATION ENERGY": -0.041063372384,  # occ, tight
+            "OREMP TOTAL GRADIENT": np.array(  # occ, tight
+              [ 0.,  0.000000000000,     0.017901994172,
+                0.,  0.007592995571,    -0.008950997086,
+                0., -0.007592995571,    -0.008950997086]
+            ).reshape((-1, 3)),
             "OLCCD REFERENCE CORRECTION ENERGY": -0.0033240178,  # p4n
             "OLCCD CORRELATION ENERGY": -0.2226657917,  # p4n
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.0405122800,  # occ
@@ -4487,6 +4801,9 @@ _std_suite = [
             "QCISD CORRELATION ENERGY": -0.20699674383631,  # vcc
             "QCISD(T) CORRECTION ENERGY": -0.00180789,  # vcc
             "FCI CORRELATION ENERGY": -0.2092292951,  # detci
+            "REMP CORRELATION ENERGY": -0.20642733451785,  # occ, tight
+            "REMP SINGLES ENERGY": 0.0,
+            "REMP SAME-SPIN CORRELATION ENERGY": -0.04882718129882,  # occ, tight
             "LCCD CORRELATION ENERGY": -0.2079585027,  # p4n
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.047635656759,  # fnocc
@@ -4598,6 +4915,18 @@ _std_suite = [
             "[Q] CORRECTION ENERGY": -0.000379506649993,  # ncc
             "(Q) CORRECTION ENERGY": -0.000413051703749,  # ncc
             "CCSDTQ CORRELATION ENERGY": -0.209218171097884,  # ncc
+            "OMP2 REFERENCE CORRECTION ENERGY": _knownmissing,
+            "OMP2 CORRELATION ENERGY": _knownmissing,
+            "OMP2 TOTAL GRADIENT": _knownmissing,
+            "OMP2.5 REFERENCE CORRECTION ENERGY": _knownmissing,
+            "OMP2.5 CORRELATION ENERGY": _knownmissing,
+            "OMP2.5 TOTAL GRADIENT": _knownmissing,
+            "OMP3 REFERENCE CORRECTION ENERGY": _knownmissing,
+            "OMP3 CORRELATION ENERGY": _knownmissing,
+            "OMP3 TOTAL GRADIENT": _knownmissing,
+            "OREMP REFERENCE CORRECTION ENERGY": _knownmissing,
+            "OREMP CORRELATION ENERGY": _knownmissing,
+            "OREMP TOTAL GRADIENT": _knownmissing,
             "OLCCD REFERENCE CORRECTION ENERGY": 0.0005535161,  # p4n (core-occ rotations neglected)
             "OLCCD CORRELATION ENERGY": -0.2086206237,  # p4n (core-occ rotations neglected)
             "OLCCD TOTAL GRADIENT": _knownmissing,
@@ -4755,6 +5084,9 @@ _std_suite = [
             "CISD CORRELATION ENERGY": -0.21764746560900,  # vcc
             "QCISD CORRELATION ENERGY": -0.22775040212176,  # vcc
             "QCISD(T) CORRECTION ENERGY": -0.00485806,  # vcc
+            "REMP CORRELATION ENERGY": -0.227138458433,  # occ, tight
+            "REMP SINGLES ENERGY": 0.0,
+            "REMP SAME-SPIN CORRELATION ENERGY": -0.050586597452,  # occ, tight
             "LCCD CORRELATION ENERGY": -0.2296135965,  # p4n
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.049154543318,  # fnocc
@@ -5101,6 +5433,18 @@ _std_suite = [
             "[Q] CORRECTION ENERGY": -0.000288788062660,  # ncc
             "(Q) CORRECTION ENERGY": -0.000503838444143,  # ncc
             "CCSDTQ CORRELATION ENERGY": -0.233074721244323,  # ncc
+            "OMP2 REFERENCE CORRECTION ENERGY": _knownmissing,
+            "OMP2 CORRELATION ENERGY": _knownmissing,
+            "OMP2 TOTAL GRADIENT": _knownmissing,
+            "OMP2.5 REFERENCE CORRECTION ENERGY": _knownmissing,
+            "OMP2.5 CORRELATION ENERGY": _knownmissing,
+            "OMP2.5 TOTAL GRADIENT": _knownmissing,
+            "OMP3 REFERENCE CORRECTION ENERGY": _knownmissing,
+            "OMP3 CORRELATION ENERGY": _knownmissing,
+            "OMP3 TOTAL GRADIENT": _knownmissing,
+            "OREMP REFERENCE CORRECTION ENERGY": _knownmissing,
+            "OREMP CORRELATION ENERGY": _knownmissing,
+            "OREMP TOTAL GRADIENT": _knownmissing,
             "OLCCD REFERENCE CORRECTION ENERGY": 0.0011942797,  # p4n (core-occ rotations neglected)
             "OLCCD CORRELATION ENERGY": -0.2309009256,  # p4n (core-occ rotations neglected)
             "OLCCD TOTAL GRADIENT": _knownmissing,
@@ -5258,6 +5602,9 @@ _std_suite = [
             "CISD CORRELATION ENERGY": -0.24016600239402,  # vcc
             "QCISD CORRELATION ENERGY": -0.25077731041751,  # vcc
             "QCISD(T) CORRECTION ENERGY": -0.00687323,  # vcc
+            "REMP CORRELATION ENERGY": -0.251018009939,  # occ, tight
+            "REMP SINGLES ENERGY": 0.0,
+            "REMP SAME-SPIN CORRELATION ENERGY": -0.055360085349,  # occ, tight
             "LCCD CORRELATION ENERGY": -0.2531942099,  # p4n
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.053842594884,  # fnocc
@@ -5840,6 +6187,18 @@ _std_suite = [
             "[Q] CORRECTION ENERGY": -0.000151213601440,  # ncc
             "(Q) CORRECTION ENERGY": -0.000368016662584,  # ncc
             "CCSDTQ CORRELATION ENERGY": -0.257824320323573,  # ncc
+            "OMP2 REFERENCE CORRECTION ENERGY": _knownmissing,
+            "OMP2 CORRELATION ENERGY": _knownmissing,
+            "OMP2 TOTAL GRADIENT": _knownmissing,
+            "OMP2.5 REFERENCE CORRECTION ENERGY": _knownmissing,
+            "OMP2.5 CORRELATION ENERGY": _knownmissing,
+            "OMP2.5 TOTAL GRADIENT": _knownmissing,
+            "OMP3 REFERENCE CORRECTION ENERGY": _knownmissing,
+            "OMP3 CORRELATION ENERGY": _knownmissing,
+            "OMP3 TOTAL GRADIENT": _knownmissing,
+            "OREMP REFERENCE CORRECTION ENERGY": _knownmissing,
+            "OREMP CORRELATION ENERGY": _knownmissing,
+            "OREMP TOTAL GRADIENT": _knownmissing,
             "OLCCD REFERENCE CORRECTION ENERGY": 0.0012982937,  # p4n (core-occ rotations neglected)
             "OLCCD CORRELATION ENERGY": -0.2544819317,  # p4n (core-occ rotations neglected)
             "OLCCD TOTAL GRADIENT": _knownmissing,
@@ -6083,6 +6442,9 @@ _std_suite = [
             "CISD CORRELATION ENERGY": -0.07917581082828,  # vcc
             "QCISD CORRELATION ENERGY": -0.08117897504733,  # vcc
             "QCISD(T) CORRECTION ENERGY": -0.00060269,  # vcc only
+            "REMP CORRELATION ENERGY": -0.07701467620060,  # occ, tight
+            "REMP SINGLES ENERGY": 0.0,
+            "REMP SAME-SPIN CORRELATION ENERGY": -0.00219044944957,  # occ. tight
             "LCCD CORRELATION ENERGY": -0.0824313452,  # p4n
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0022532590,  # occ
@@ -6495,6 +6857,22 @@ _std_suite = [
             "CCSDT-2 CORRELATION ENERGY": -0.081772292290,  # ecc
             "CCSDT-3 CORRELATION ENERGY": -0.08177701734273,  # vcc
             "CCSDT CORRELATION ENERGY": -0.08208821205578,  # vcc
+            "OMP2 REFERENCE CORRECTION ENERGY": _knownmissing,
+            "OMP2 CORRELATION ENERGY": _knownmissing,
+            "OMP2 SAME-SPIN CORRELATION ENERGY": _knownmissing,
+            "OMP2 TOTAL GRADIENT": _knownmissing,
+            "OMP2.5 REFERENCE CORRECTION ENERGY": _knownmissing,
+            "OMP2.5 CORRELATION ENERGY": _knownmissing,
+            "OMP2.5 SAME-SPIN CORRELATION ENERGY": _knownmissing,
+            "OMP2.5 TOTAL GRADIENT": _knownmissing,
+            "OMP3 REFERENCE CORRECTION ENERGY": _knownmissing,
+            "OMP3 CORRELATION ENERGY": _knownmissing,
+            "OMP3 SAME-SPIN CORRELATION ENERGY": _knownmissing,
+            "OMP3 TOTAL GRADIENT": _knownmissing,
+            "OREMP REFERENCE CORRECTION ENERGY": _knownmissing,
+            "OREMP CORRELATION ENERGY": _knownmissing,
+            "OREMP SAME-SPIN CORRELATION ENERGY": _knownmissing,
+            "OREMP TOTAL GRADIENT": _knownmissing,
             "OLCCD REFERENCE CORRECTION ENERGY": 0.0014923056,  # p4n (core-occ rotations neglected)
             "OLCCD CORRELATION ENERGY": -0.0839163095,  # p4n (core-occ rotations neglected)
             "OLCCD SAME-SPIN CORRELATION ENERGY": _knownmissing,
@@ -6563,6 +6941,9 @@ _std_suite = [
             "CISD CORRELATION ENERGY": -0.16574719763576,  # vcc
             "QCISD CORRELATION ENERGY": -0.17187325792329,  # vcc
             "QCISD(T) CORRECTION ENERGY": -0.00368626,  # vcc only
+            "REMP CORRELATION ENERGY": -0.170214503998,  # occ, tight
+            "REMP SINGLES ENERGY": 0.0,
+            "REMP SAME-SPIN CORRELATION ENERGY": -0.033849141454,  # occ, tight
             "LCCD CORRELATION ENERGY": -0.1747537294,  # p4n
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0334378864,  # occ
@@ -6734,6 +7115,22 @@ _std_suite = [
                 [[0.0, 0.0, 0.03180282], [0.0, 0.01723825, -0.01590141], [0.0, -0.01723825, -0.01590141]]
             ),
             "CCSDT CORRELATION ENERGY": -0.17591978591647,  # vcc
+            "OMP2 REFERENCE CORRECTION ENERGY": _knownmissing,
+            "OMP2 CORRELATION ENERGY": _knownmissing,
+            "OMP2 SAME-SPIN CORRELATION ENERGY": _knownmissing,
+            "OMP2 TOTAL GRADIENT": _knownmissing,
+            "OMP2.5 REFERENCE CORRECTION ENERGY": _knownmissing,
+            "OMP2.5 CORRELATION ENERGY": _knownmissing,
+            "OMP2.5 SAME-SPIN CORRELATION ENERGY": _knownmissing,
+            "OMP2.5 TOTAL GRADIENT": _knownmissing,
+            "OMP3 REFERENCE CORRECTION ENERGY": _knownmissing,
+            "OMP3 CORRELATION ENERGY": _knownmissing,
+            "OMP3 SAME-SPIN CORRELATION ENERGY": _knownmissing,
+            "OMP3 TOTAL GRADIENT": _knownmissing,
+            "OREMP REFERENCE CORRECTION ENERGY": _knownmissing,
+            "OREMP CORRELATION ENERGY": _knownmissing,
+            "OREMP SAME-SPIN CORRELATION ENERGY": _knownmissing,
+            "OREMP TOTAL GRADIENT": _knownmissing,
             "OLCCD REFERENCE CORRECTION ENERGY": 0.0011137749,  # p4n (core-occ rotations neglected)
             "OLCCD CORRELATION ENERGY": -0.1759973931,  # p4n (core-occ rotations neglected)
             "OLCCD SAME-SPIN CORRELATION ENERGY": _knownmissing,
@@ -6802,6 +7199,9 @@ _std_suite = [
             "CISD CORRELATION ENERGY": -0.18202095532782,  # vcc
             "QCISD CORRELATION ENERGY": -0.18852342173162,  # vcc
             "QCISD(T) CORRECTION ENERGY": -0.00487511,  # vcc only
+            "REMP CORRELATION ENERGY": -0.187474026696,  # occ, tight
+            "REMP SINGLES ENERGY": 0.0,
+            "REMP SAME-SPIN CORRELATION ENERGY": -0.037232180981,  # occ, tight
             "LCCD CORRELATION ENERGY": -0.1917024115,  # p4n
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0367596656,  # occ
@@ -6934,6 +7334,22 @@ _std_suite = [
             "CCSDT-2 CORRELATION ENERGY": -0.193087540038,  # vcc
             "CCSDT-3 CORRELATION ENERGY": -0.19310599643349,  # vcc
             "CCSDT CORRELATION ENERGY": -0.19368177447948,  # vcc
+            "OMP2 REFERENCE CORRECTION ENERGY": _knownmissing,
+            "OMP2 CORRELATION ENERGY": _knownmissing,
+            "OMP2 SAME-SPIN CORRELATION ENERGY": _knownmissing,
+            "OMP2 TOTAL GRADIENT": _knownmissing,
+            "OMP2.5 REFERENCE CORRECTION ENERGY": _knownmissing,
+            "OMP2.5 CORRELATION ENERGY": _knownmissing,
+            "OMP2.5 SAME-SPIN CORRELATION ENERGY": _knownmissing,
+            "OMP2.5 TOTAL GRADIENT": _knownmissing,
+            "OMP3 REFERENCE CORRECTION ENERGY": _knownmissing,
+            "OMP3 CORRELATION ENERGY": _knownmissing,
+            "OMP3 SAME-SPIN CORRELATION ENERGY": _knownmissing,
+            "OMP3 TOTAL GRADIENT": _knownmissing,
+            "OREMP REFERENCE CORRECTION ENERGY": _knownmissing,
+            "OREMP CORRELATION ENERGY": _knownmissing,
+            "OREMP SAME-SPIN CORRELATION ENERGY": _knownmissing,
+            "OREMP TOTAL GRADIENT": _knownmissing,
             "OLCCD REFERENCE CORRECTION ENERGY": 0.0012186690,  # p4n (core-occ rotations neglected)
             "OLCCD CORRELATION ENERGY": -0.1929863522,  # p4n (core-occ rotations neglected)
             "OLCCD SAME-SPIN CORRELATION ENERGY": _knownmissing,
@@ -7192,6 +7608,22 @@ _std_suite = [
             ).reshape((-1, 3)),
             "(T) CORRECTION ENERGY": -0.00068823,  # cfour only
             "CCSDT CORRELATION ENERGY": -0.08361110233142,  # vcc
+            "OMP2 REFERENCE CORRECTION ENERGY": _knownmissing,
+            "OMP2 CORRELATION ENERGY": _knownmissing,
+            "OMP2 SAME-SPIN CORRELATION ENERGY": _knownmissing,
+            "OMP2 TOTAL GRADIENT": _knownmissing,
+            "OMP2.5 REFERENCE CORRECTION ENERGY": _knownmissing,
+            "OMP2.5 CORRELATION ENERGY": _knownmissing,
+            "OMP2.5 SAME-SPIN CORRELATION ENERGY": _knownmissing,
+            "OMP2.5 TOTAL GRADIENT": _knownmissing,
+            "OMP3 REFERENCE CORRECTION ENERGY": _knownmissing,
+            "OMP3 CORRELATION ENERGY": _knownmissing,
+            "OMP3 SAME-SPIN CORRELATION ENERGY": _knownmissing,
+            "OMP3 TOTAL GRADIENT": _knownmissing,
+            "OREMP REFERENCE CORRECTION ENERGY": _knownmissing,
+            "OREMP CORRELATION ENERGY": _knownmissing,
+            "OREMP SAME-SPIN CORRELATION ENERGY": _knownmissing,
+            "OREMP TOTAL GRADIENT": _knownmissing,
             "OLCCD REFERENCE CORRECTION ENERGY": -0.0000318047,  # p4n (core-occ rotations neglected)
             "OLCCD CORRELATION ENERGY": -0.0854404197,  # p4n (core-occ rotations neglected)
             "OLCCD SAME-SPIN CORRELATION ENERGY": _knownmissing,
@@ -7282,6 +7714,22 @@ _std_suite = [
             ).reshape((-1, 3)),
             "(T) CORRECTION ENERGY": -0.003863167899,  # cfour only
             "CCSDT CORRELATION ENERGY": -0.18030677104047,  # vcc (different orbs: -0.18031166502580)
+            "OMP2 REFERENCE CORRECTION ENERGY": _knownmissing,
+            "OMP2 CORRELATION ENERGY": _knownmissing,
+            "OMP2 SAME-SPIN CORRELATION ENERGY": _knownmissing,
+            "OMP2 TOTAL GRADIENT": _knownmissing,
+            "OMP2.5 REFERENCE CORRECTION ENERGY": _knownmissing,
+            "OMP2.5 CORRELATION ENERGY": _knownmissing,
+            "OMP2.5 SAME-SPIN CORRELATION ENERGY": _knownmissing,
+            "OMP2.5 TOTAL GRADIENT": _knownmissing,
+            "OMP3 REFERENCE CORRECTION ENERGY": _knownmissing,
+            "OMP3 CORRELATION ENERGY": _knownmissing,
+            "OMP3 SAME-SPIN CORRELATION ENERGY": _knownmissing,
+            "OMP3 TOTAL GRADIENT": _knownmissing,
+            "OREMP REFERENCE CORRECTION ENERGY": _knownmissing,
+            "OREMP CORRELATION ENERGY": _knownmissing,
+            "OREMP SAME-SPIN CORRELATION ENERGY": _knownmissing,
+            "OREMP TOTAL GRADIENT": _knownmissing,
             "OLCCD REFERENCE CORRECTION ENERGY": -0.0032999290,  # p4n (core-occ rotations neglected)
             "OLCCD CORRELATION ENERGY": -0.1804110970,  # p4n (core-occ rotations neglected)
             "OLCCD SAME-SPIN CORRELATION ENERGY": _knownmissing,
@@ -7375,6 +7823,22 @@ _std_suite = [
             ).reshape((-1, 3)),
             "(T) CORRECTION ENERGY": -0.00504351,  # cfour only
             "CCSDT CORRELATION ENERGY": -0.19824510672649,  # vcc
+            "OMP2 REFERENCE CORRECTION ENERGY": _knownmissing,
+            "OMP2 CORRELATION ENERGY": _knownmissing,
+            "OMP2 SAME-SPIN CORRELATION ENERGY": _knownmissing,
+            "OMP2 TOTAL GRADIENT": _knownmissing,
+            "OMP2.5 REFERENCE CORRECTION ENERGY": _knownmissing,
+            "OMP2.5 CORRELATION ENERGY": _knownmissing,
+            "OMP2.5 SAME-SPIN CORRELATION ENERGY": _knownmissing,
+            "OMP2.5 TOTAL GRADIENT": _knownmissing,
+            "OMP3 REFERENCE CORRECTION ENERGY": _knownmissing,
+            "OMP3 CORRELATION ENERGY": _knownmissing,
+            "OMP3 SAME-SPIN CORRELATION ENERGY": _knownmissing,
+            "OMP3 TOTAL GRADIENT": _knownmissing,
+            "OREMP REFERENCE CORRECTION ENERGY": _knownmissing,
+            "OREMP CORRELATION ENERGY": _knownmissing,
+            "OREMP SAME-SPIN CORRELATION ENERGY": _knownmissing,
+            "OREMP TOTAL GRADIENT": _knownmissing,
             "OLCCD REFERENCE CORRECTION ENERGY": -0.0033910391,  # p4n (core-occ rotations neglected)
             "OLCCD CORRELATION ENERGY": -0.1975960603,  # p4n (core-occ rotations neglected)
             "OLCCD SAME-SPIN CORRELATION ENERGY": _knownmissing,
@@ -8366,6 +8830,8 @@ _std_suite = [
                 # dfocc findif-5
                 [ 0., 0., -0.000926981449, 0., 0., 0.000926981449]
             ).reshape((-1, 3)),
+            "REMP CORRELATION ENERGY": -0.208401248910,  # dfocc, tight
+            "REMP SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.20990226,  # dfocc
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD TOTAL GRADIENT": np.array(
@@ -8377,6 +8843,14 @@ _std_suite = [
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.04857381,
             "(T) CORRECTION ENERGY": -0.00193631092143,  # dfocc, tight
             "A-(T) CORRECTION ENERGY": -0.00196099396220,  # dfocc, tight
+            "OMP2 REFERENCE CORRECTION ENERGY": 0.000704847713,  # dfocc, tight
+            "OMP2 CORRELATION ENERGY": -0.204457056936,  # dfocc, tight
+            "OMP2.5 REFERENCE CORRECTION ENERGY": 0.000571702068,  # dfocc, tight
+            "OMP2.5 CORRELATION ENERGY": -0.205680612213,  # dfocc, tight
+            "OMP3 REFERENCE CORRECTION ENERGY": 0.000467209128,  # dfocc, tight
+            "OMP3 CORRELATION ENERGY": -0.206931341471,  # dfocc, tight
+            "OREMP REFERENCE CORRECTION ENERGY": 0.000553277131,  # dfocc, tight
+            "OREMP CORRELATION ENERGY": -0.208938401219,  # dfocc, tight
             "OLCCD REFERENCE CORRECTION ENERGY": 0.000552265186,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.210437984945,  # dfocc, tight
             "OCCD REFERENCE CORRECTION ENERGY": 0.000511278480,  # dfocc, tight
@@ -8418,6 +8892,8 @@ _std_suite = [
             ).reshape((-1, 3)),
             "MP3 CORRELATION ENERGY": -0.22643303,  # dfocc
             "MP3 SINGLES ENERGY": 0.0,
+            "REMP CORRELATION ENERGY": -0.229445833755,  # dfocc, tight
+            "REMP SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.23188949,  # dfocc
             "LCCD SINGLES ENERGY": 0.0000000000,
             "CCSD CORRELATION ENERGY": -0.22941289840818,  # dfocc, tight
@@ -8425,6 +8901,14 @@ _std_suite = [
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.05017955,
             "(T) CORRECTION ENERGY": -0.00523866932915,  # dfocc, tight
             "A-(T) CORRECTION ENERGY": -0.00523628844912,  # dfocc, tight
+            "OMP2 REFERENCE CORRECTION ENERGY": 0.002352399946,  # dfocc, tight
+            "OMP2 CORRELATION ENERGY": -0.224116136177,  # dfocc, tight
+            "OMP2.5 REFERENCE CORRECTION ENERGY": 0.001535058364,  # dfocc, tight
+            "OMP2.5 CORRELATION ENERGY": -0.225648131745,  # dfocc, tight
+            "OMP3 REFERENCE CORRECTION ENERGY": 0.000953721118,  # dfocc, tight
+            "OMP3 CORRELATION ENERGY": -0.227374133013,  # dfocc, tight
+            "OREMP REFERENCE CORRECTION ENERGY": 0.00128180471179,  # dfocc, tight
+            "OREMP CORRELATION ENERGY": -0.23069205056701,  # dfocc, right
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001189623873,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.233047836839,  # dfocc, tight
             "OCCD REFERENCE CORRECTION ENERGY": 0.001124461842,  # dfocc, tight
@@ -8466,6 +8950,8 @@ _std_suite = [
             ).reshape((-1, 3)),
             "MP3 CORRELATION ENERGY": -0.27294416,  # dfocc
             "MP3 SINGLES ENERGY": 0.0,
+            "REMP CORRELATION ENERGY": -0.276442808601,  # dfocc, tight
+            "REMP SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.27869015,  # dfocc
             "LCCD SINGLES ENERGY": 0.0000000000,
             "CCSD CORRELATION ENERGY": -0.27570421327166,  # dfocc, tight
@@ -8473,6 +8959,14 @@ _std_suite = [
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.05801141,
             "(T) CORRECTION ENERGY": -0.00726394807275,  # dfocc, tight
             "A-(T) CORRECTION ENERGY": -0.00718177622315,  # dfocc, tight
+            "OMP2 REFERENCE CORRECTION ENERGY": 0.002513733031,  # dfocc, tight
+            "OMP2 CORRELATION ENERGY": -0.272591834175,  # dfocc, tight
+            "OMP2.5 REFERENCE CORRECTION ENERGY": 0.001691501139,  # dfocc, tight
+            "OMP2.5 CORRELATION ENERGY": -0.273207190194,  # dfocc, tight
+            "OMP3 REFERENCE CORRECTION ENERGY": 0.001090092456,  # dfocc, tight
+            "OMP3 CORRELATION ENERGY": -0.274014744975,  # dfocc, tight
+            "OREMP REFERENCE CORRECTION ENERGY": 0.001444318022,  # dfocc, tight
+            "OREMP CORRELATION ENERGY": -0.277846110170,  # dfocc, tight
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001352168423,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.280004165823,  # dfocc, tight
             "OCCD REFERENCE CORRECTION ENERGY": 0.001279252698,  # dfocc, tight
@@ -8534,6 +9028,9 @@ _std_suite = [
                     -0.00011515114,
                 ]
             ).reshape((-1, 3)),
+            "REMP CORRELATION ENERGY": -0.078034068730,  # dfocc, tight
+            "REMP SINGLES ENERGY": 0.0,
+            "REMP SAME-SPIN CORRELATION ENERGY": -0.002339588819,  # dfocc, tight
             "LCCD CORRELATION ENERGY": -0.08343038,  # dfocc
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.00240059,  # dfocc
@@ -8557,6 +9054,17 @@ _std_suite = [
             "CCSD SINGLES ENERGY": 0.0,
             "(T) CORRECTION ENERGY": -0.00062616540400,  # dfocc, tight
             "A-(T) CORRECTION ENERGY": -0.00060935179141,  # dfocc, tight
+            "OMP2 REFERENCE CORRECTION ENERGY": 0.000395339866,  # dfocc, tight
+            "OMP2 CORRELATION ENERGY": -0.059851604202,  # dfocc, tight
+            "OMP2 SAME-SPIN CORRELATION ENERGY": -0.001971334763,  # dfocc, tight
+            "OMP2.5 REFERENCE CORRECTION ENERGY": 0.000564647007,  # dfocc, tight
+            "OMP2.5 CORRELATION ENERGY": -0.067670676114,  # dfocc, tight
+            "OMP2.5 SAME-SPIN CORRELATION ENERGY": -0.002198889579,  # dfocc, tight
+            "OMP3 REFERENCE CORRECTION ENERGY": 0.000777636403,  # dfocc, tight
+            "OMP3 CORRELATION ENERGY": -0.075525183445,  # dfocc, tight
+            "OMP3 SAME-SPIN CORRELATION ENERGY": -0.002426255771,  # dfocc, tight
+            "OREMP REFERENCE CORRECTION ENERGY": 0.001061022340,  # dfocc, tight
+            "OREMP CORRELATION ENERGY": -0.078990084532,  # dfocc, tight
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001484257667,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.084737023607,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.002448903277,  # dfocc, tight
@@ -8599,6 +9107,9 @@ _std_suite = [
             "MP3 CORRELATION ENERGY": -0.17091879,  # dfocc
             "MP3 SINGLES ENERGY": 0.0,
             "MP3 SAME-SPIN CORRELATION ENERGY": -0.03533750,  # dfocc
+            "REMP CORRELATION ENERGY": -0.172502759037,  # dfocc, tight
+            "REMP SINGLES ENERGY": 0.0,
+            "REMP SAME-SPIN CORRELATION ENERGY": -0.034552222422,  # dfocc, tight
             "LCCD CORRELATION ENERGY": -0.17701192,  # dfocc
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.03413070,  # dfocc
@@ -8606,6 +9117,17 @@ _std_suite = [
             "CCSD SINGLES ENERGY": 0.0,
             "(T) CORRECTION ENERGY": -0.00384402655927,  # dfocc, tight
             "A-(T) CORRECTION ENERGY": -0.00376419871586,  # dfocc, tight
+            "OMP2 REFERENCE CORRECTION ENERGY": 0.001367410529,  # dfocc, tight
+            "OMP2 CORRELATION ENERGY": -0.156184908805,  # dfocc, tight
+            "OMP2 SAME-SPIN CORRELATION ENERGY": -0.035978726948,  # dfocc, tight
+            "OMP2.5 REFERENCE CORRECTION ENERGY": 0.001174113090,  # dfocc, tight
+            "OMP2.5 CORRELATION ENERGY": -0.164041684333,  # dfocc, tight
+            "OMP2.5 SAME-SPIN CORRELATION ENERGY": -0.035851868032,  # dfocc, tight
+            "OMP3 REFERENCE CORRECTION ENERGY": 0.001024364167,  # dfocc, tight
+            "OMP3 CORRELATION ENERGY": -0.171935686596,  # dfocc, tight
+            "OMP3 SAME-SPIN CORRELATION ENERGY": -0.035751323781,  # dfocc, tight
+            "OREMP REFERENCE CORRECTION ENERGY": 0.00111244830766,  # dfocc, tight
+            "OREMP CORRELATION ENERGY": -0.17360075617488,  # dfocc, tight
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001111961826,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.178109192111,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.034472712167,  # dfocc, tight
@@ -8648,6 +9170,9 @@ _std_suite = [
             "MP3 CORRELATION ENERGY": -0.21084618,  # dfocc
             "MP3 SINGLES ENERGY": 0.0,
             "MP3 SAME-SPIN CORRELATION ENERGY": -0.04130830,  # dfocc
+            "REMP CORRELATION ENERGY": -0.212450972170,  # dfocc, tight
+            "REMP SINGLES ENERGY": 0.0,
+            "REMP SAME-SPIN CORRELATION ENERGY": -0.040612908150,  # dfocc, tight
             "LCCD CORRELATION ENERGY": -0.21678706,  # dfocc
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.04013515,  # dfocc
@@ -8655,6 +9180,17 @@ _std_suite = [
             "CCSD SINGLES ENERGY": 0.0,
             "(T) CORRECTION ENERGY": -0.00516682217061,  # dfocc, tight
             "A-(T) CORRECTION ENERGY": -0.00506455138393,  # dfocc, tight
+            "OMP2 REFERENCE CORRECTION ENERGY": 0.001570622893,  # dfocc, tight
+            "OMP2 CORRELATION ENERGY": -0.197065813141,  # dfocc, tight
+            "OMP2 SAME-SPIN CORRELATION ENERGY": -0.042464346261,  # dfocc, tight
+            "OMP2.5 REFERENCE CORRECTION ENERGY": 0.001350861495,  # dfocc, tight
+            "OMP2.5 CORRELATION ENERGY": -0.204519387255,  # dfocc, tight
+            "OMP2.5 SAME-SPIN CORRELATION ENERGY": -0.042091026132,  # dfocc, tight
+            "OMP3 REFERENCE CORRECTION ENERGY": 0.001177850332,  # dfocc, tight
+            "OMP3 CORRELATION ENERGY": -0.212014665319,  # dfocc, tight
+            "OMP3 SAME-SPIN CORRELATION ENERGY": -0.041748214104,  # dfocc, tight
+            "OREMP REFERENCE CORRECTION ENERGY": 0.001287828667,  # dfocc, tight
+            "OREMP CORRELATION ENERGY": -0.213722428382,  # dfocc, tight
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001285760689,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.218055380962,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.040516816950,  # dfocc, tight
@@ -8685,6 +9221,17 @@ _std_suite = [
                 # dfocc findif-5 ae cd+cd
                 [0.0, 0.0, 0.01359215, 0.0, 0.0, -0.01312116, 0.0, 0.01031541, -0.0002355, 0.0, -0.01031541, -0.0002355]
             ).reshape((-1, 3)),
+            "OMP2 REFERENCE CORRECTION ENERGY": -0.001128324491,  # dfocc, tight
+            "OMP2 CORRELATION ENERGY": -0.061375267646,  # dfocc, tight
+            "OMP2 SAME-SPIN CORRELATION ENERGY": -0.001971334332,  # dfocc, tight
+            "OMP2.5 REFERENCE CORRECTION ENERGY": -0.000959016912,  # dfocc, tight
+            "OMP2.5 CORRELATION ENERGY": -0.069194339558,  # dfocc, tight
+            "OMP2.5 SAME-SPIN CORRELATION ENERGY": -0.002198888868,  # dfocc, tight
+            "OMP3 REFERENCE CORRECTION ENERGY": -0.000746026622,  # dfocc, tight
+            "OMP3 CORRELATION ENERGY": -0.077048846889,  # dfocc, tight
+            "OMP3 SAME-SPIN CORRELATION ENERGY": -0.002426255644,  # dfocc, tight
+            "OREMP REFERENCE CORRECTION ENERGY": -0.000462639536,  # dfocc, tight
+            "OREMP CORRELATION ENERGY": -0.080513747976,  # dfocc, tight
             "OLCCD REFERENCE CORRECTION ENERGY": -0.000039411002,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.086260687051,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.002448904007,  # dfocc, tight
@@ -8724,6 +9271,17 @@ _std_suite = [
                     -0.012794480501,
                 ]
             ).reshape((-1, 3)),
+            "OMP2 REFERENCE CORRECTION ENERGY": -0.003046091958,  # dfocc, tight
+            "OMP2 CORRELATION ENERGY": -0.160598409777,  # dfocc, tight
+            "OMP2 SAME-SPIN CORRELATION ENERGY": -0.035978726618,  # dfocc, tight
+            "OMP2.5 REFERENCE CORRECTION ENERGY": -0.003239390456,  # dfocc, tight
+            "OMP2.5 CORRELATION ENERGY": -0.168455185305,  # dfocc, tight
+            "OMP2.5 SAME-SPIN CORRELATION ENERGY": -0.035851867343,  # dfocc, tight
+            "OMP3 REFERENCE CORRECTION ENERGY": -0.003389139644,  # dfocc, tight
+            "OMP3 CORRELATION ENERGY": -0.176349187568,  # dfocc, tight
+            "OMP3 SAME-SPIN CORRELATION ENERGY": -0.035751323194,  # dfocc, tight
+            "OREMP REFERENCE CORRECTION ENERGY": -0.003301052810,  # dfocc, tight
+            "OREMP CORRELATION ENERGY": -0.178014257147,  # dfocc, tight
             "OLCCD REFERENCE CORRECTION ENERGY": -0.003301541633,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.182522693083,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.034472708888,  # dfocc, tight
@@ -8763,6 +9321,17 @@ _std_suite = [
                     -0.006942026833,
                 ]
             ).reshape((-1, 3)),
+            "OMP2 REFERENCE CORRECTION ENERGY": -0.003039111099,  # dfocc, tight
+            "OMP2 CORRELATION ENERGY": -0.201675545798,  # dfocc, tight
+            "OMP2 SAME-SPIN CORRELATION ENERGY": -0.042464346330,  # dfocc, tight
+            "OMP2.5 REFERENCE CORRECTION ENERGY": -0.003258874587,  # dfocc, tight
+            "OMP2.5 CORRELATION ENERGY": -0.209129119912,  # dfocc, tight
+            "OMP2.5 SAME-SPIN CORRELATION ENERGY": -0.042091025938,  # dfocc, tight
+            "OMP3 REFERENCE CORRECTION ENERGY": -0.003431885897,  # dfocc, tight
+            "OMP3 CORRELATION ENERGY": -0.216624397975,  # dfocc, tight
+            "OMP3 SAME-SPIN CORRELATION ENERGY": -0.041748214168,  # dfocc, tight
+            "OREMP REFERENCE CORRECTION ENERGY": -0.003321905366,  # dfocc, tight
+            "OREMP CORRELATION ENERGY": -0.218332161038,  # dfocc, tight
             "OLCCD REFERENCE CORRECTION ENERGY": -0.003323981369,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.222665113625,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.040516826809,  # dfocc, tight
@@ -8800,6 +9369,8 @@ _std_suite = [
                 # dfocc findif-5 fc cd+cd
                 [ 0., 0., -0.000588974421, 0., 0., 0.000588974421]
             ).reshape((-1, 3)),
+            "REMP CORRELATION ENERGY": -0.206423120122,  # dfocc, tight
+            "REMP SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.20795503,  # dfocc
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD TOTAL GRADIENT": np.array(
@@ -8811,6 +9382,14 @@ _std_suite = [
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.04787083,
             "(T) CORRECTION ENERGY": -0.00192042037371,  # dfocc, tight
             "A-(T) CORRECTION ENERGY": -0.00194413458399,  # dfocc, tight
+            "OMP2 REFERENCE CORRECTION ENERGY": 0.000702500011,  # dfocc, tight
+            "OMP2 CORRELATION ENERGY": -0.202330761197,  # dfocc, tight
+            "OMP2.5 REFERENCE CORRECTION ENERGY": 0.000571428855,  # dfocc, tight
+            "OMP2.5 CORRELATION ENERGY": -0.203698037577,  # dfocc, tight
+            "OMP3 REFERENCE CORRECTION ENERGY": 0.000468982166,  # dfocc, tight
+            "OMP3 CORRELATION ENERGY": -0.205112639670,  # dfocc, tight
+            "OREMP REFERENCE CORRECTION ENERGY": 0.000554016472,  # dfocc, tight
+            "OREMP CORRELATION ENERGY": -0.207066289816,  # dfocc, tight
             "OLCCD REFERENCE CORRECTION ENERGY": 0.000553491444,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.208617145287,  # dfocc, tight
             "OCCD REFERENCE CORRECTION ENERGY": 0.000511777936,  # dfocc, tight
@@ -8852,6 +9431,8 @@ _std_suite = [
             ).reshape((-1, 3)),
             "MP3 CORRELATION ENERGY": -0.22415794,  # dfocc
             "MP3 SINGLES ENERGY": 0.0,
+            "REMP CORRELATION ENERGY": -0.227139386881,  # dfocc, tight
+            "REMP SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.22961642,  # dfocc
             "LCCD SINGLES ENERGY": 0.0000000000,
             "CCSD CORRELATION ENERGY": -0.22717606848165,  # dfocc, tight
@@ -8859,6 +9440,14 @@ _std_suite = [
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.04939986,
             "(T) CORRECTION ENERGY": -0.00521247873234,  # dfocc, tight
             "A-(T) CORRECTION ENERGY": -0.00520979601465,  # dfocc, tight
+            "OMP2 REFERENCE CORRECTION ENERGY": 0.002351861704,  # dfocc, tight
+            "OMP2 CORRELATION ENERGY": -0.221658768039,  # dfocc, tight
+            "OMP2.5 REFERENCE CORRECTION ENERGY": 0.001538083685,  # dfocc, tight
+            "OMP2.5 CORRELATION ENERGY": -0.223336430535,  # dfocc, tight
+            "OMP3 REFERENCE CORRECTION ENERGY": 0.000960343766,  # dfocc, tight
+            "OMP3 CORRELATION ENERGY": -0.225227488953,  # dfocc, tight
+            "OREMP REFERENCE CORRECTION ENERGY": 0.00128588799768,  # dfocc, tight
+            "OREMP CORRELATION ENERGY": -0.22849477192663,  # dfocc, tight
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001194389384,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.230903883683,  # dfocc, tight
             "OCCD REFERENCE CORRECTION ENERGY": 0.001127721989,  # dfocc, tight
@@ -8900,6 +9489,8 @@ _std_suite = [
             ).reshape((-1, 3)),
             "MP3 CORRELATION ENERGY": -0.24747710,  # dfocc
             "MP3 SINGLES ENERGY": 0.0,
+            "REMP CORRELATION ENERGY": -0.251016068140,  # dfocc, tight
+            "REMP SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.25319315,  # dfocc
             "LCCD SINGLES ENERGY": 0.0000000000,
             "CCSD CORRELATION ENERGY": -0.25032938698805,  # dfocc, tight
@@ -8907,6 +9498,14 @@ _std_suite = [
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.05405638,
             "(T) CORRECTION ENERGY": -0.00709685911318,  # dfocc, tight
             "A-(T) CORRECTION ENERGY": -0.00701825978933,  # dfocc, tight
+            "OMP2 REFERENCE CORRECTION ENERGY": 0.002435969540,  # dfocc, tight
+            "OMP2 CORRELATION ENERGY": -0.247516285552,  # dfocc, tight
+            "OMP2.5 REFERENCE CORRECTION ENERGY": 0.001628337567,  # dfocc, tight
+            "OMP2.5 CORRELATION ENERGY": -0.247905627376,  # dfocc, tight
+            "OMP3 REFERENCE CORRECTION ENERGY": 0.001042085727,  # dfocc, tight
+            "OMP3 CORRELATION ENERGY": -0.248525576959,  # dfocc, tight
+            "OREMP REFERENCE CORRECTION ENERGY": 0.001387317415,  # dfocc, tight
+            "OREMP CORRELATION ENERGY": -0.252381884524,  # dfocc, tight
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001298302400,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.254480886451,  # dfocc, tight
             "OCCD REFERENCE CORRECTION ENERGY": 0.001226900919,  # dfocc, tight
@@ -8968,6 +9567,9 @@ _std_suite = [
                     -0.000121632922,
                 ]
             ).reshape((-1, 3)),
+            "REMP CORRELATION ENERGY": -0.077009033372,  # dfocc, tight
+            "REMP SINGLES ENERGY": 0.0,
+            "REMP SAME-SPIN CORRELATION ENERGY": -0.002190684009,  # dfocc, tight
             "LCCD CORRELATION ENERGY": -0.08242726,  # dfocc
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.00225350,  # dfocc
@@ -8991,6 +9593,17 @@ _std_suite = [
             "CCSD SINGLES ENERGY": 0.0,
             "(T) CORRECTION ENERGY": -0.00060403476990,  # dfocc, tight
             "A-(T) CORRECTION ENERGY": -0.00058789584036,  # dfocc, tight
+            "OMP2 REFERENCE CORRECTION ENERGY": 0.000393271089,  # dfocc, tight
+            "OMP2 CORRELATION ENERGY": -0.058955062039,  # dfocc, tight
+            "OMP2 SAME-SPIN CORRELATION ENERGY": -0.001822163929,  # dfocc, tight
+            "OMP2.5 REFERENCE CORRECTION ENERGY": 0.000564442101,  # dfocc, tight
+            "OMP2.5 CORRELATION ENERGY": -0.066788204166,  # dfocc, tight
+            "OMP2.5 SAME-SPIN CORRELATION ENERGY": -0.002049209044,  # dfocc, tight
+            "OMP3 REFERENCE CORRECTION ENERGY": 0.000780607023,  # dfocc, tight
+            "OMP3 CORRELATION ENERGY": -0.074661038269,  # dfocc, tight
+            "OMP3 SAME-SPIN CORRELATION ENERGY": -0.002276029266,  # dfocc, tight
+            "OREMP REFERENCE CORRECTION ENERGY": 0.001065407270,  # dfocc, tight
+            "OREMP CORRELATION ENERGY": -0.078143718483,  # dfocc, tight
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001492355224,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.083912298766,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.002307760137,  # dfocc, tight
@@ -9033,6 +9646,9 @@ _std_suite = [
             "MP3 CORRELATION ENERGY": -0.16863165,  # dfocc
             "MP3 SINGLES ENERGY": 0.0,
             "MP3 SAME-SPIN CORRELATION ENERGY": -0.03464009,  # dfocc
+            "REMP CORRELATION ENERGY": -0.170216188333,  # dfocc, tight
+            "REMP SINGLES ENERGY": 0.0,
+            "REMP SAME-SPIN CORRELATION ENERGY": -0.033852995535,  # dfocc, tight
             "LCCD CORRELATION ENERGY": -0.17475747,  # dfocc
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0334416820,  # dfocc
@@ -9040,6 +9656,17 @@ _std_suite = [
             "CCSD SINGLES ENERGY": 0.0,
             "(T) CORRECTION ENERGY": -0.00381139581323,  # dfocc, tight
             "A-(T) CORRECTION ENERGY": -0.00373214885816,  # dfocc, tight
+            "OMP2 REFERENCE CORRECTION ENERGY": 0.001360881782,  # dfocc, tight
+            "OMP2 CORRELATION ENERGY": -0.153818916860,  # dfocc, tight
+            "OMP2 SAME-SPIN CORRELATION ENERGY": -0.035194310016,  # dfocc, tight
+            "OMP2.5 REFERENCE CORRECTION ENERGY": 0.001172035292,  # dfocc, tight
+            "OMP2.5 CORRELATION ENERGY": -0.161781119255,  # dfocc, tight
+            "OMP2.5 SAME-SPIN CORRELATION ENERGY": -0.035088275618,  # dfocc, tight
+            "OMP3 REFERENCE CORRECTION ENERGY": 0.001026576887,  # dfocc, tight
+            "OMP3 CORRELATION ENERGY": -0.169784888805,  # dfocc, tight
+            "OMP3 SAME-SPIN CORRELATION ENERGY": -0.035012011899,  # dfocc, tight
+            "OREMP REFERENCE CORRECTION ENERGY": 0.00111325834527,  # dfocc, tight
+            "OREMP CORRELATION ENERGY": -0.17144631168723,  # dfocc, tight
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001113861889,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.176001256953,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.033743742943,  # dfocc, tight
@@ -9082,6 +9709,9 @@ _std_suite = [
             "MP3 CORRELATION ENERGY": -0.18575577,  # dfocc
             "MP3 SINGLES ENERGY": 0.0,
             "MP3 SAME-SPIN CORRELATION ENERGY": -0.03792717,  # dfocc
+            "REMP CORRELATION ENERGY": -0.187472566719,  # dfocc, tight
+            "REMP SINGLES ENERGY": 0.0,
+            "REMP SAME-SPIN CORRELATION ENERGY": -0.037236809266,  # dfocc, tight
             "LCCD CORRELATION ENERGY": -0.19170174,  # dfocc
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.03676422,  # dfocc
@@ -9089,6 +9719,17 @@ _std_suite = [
             "CCSD SINGLES ENERGY": 0.0,
             "(T) CORRECTION ENERGY": -0.00498288386522,  # dfocc, tight
             "A-(T) CORRECTION ENERGY": -0.00488265656152,  # dfocc, tight
+            "OMP2 REFERENCE CORRECTION ENERGY": 0.001480341549,  # dfocc, tight
+            "OMP2 CORRELATION ENERGY": -0.172676727210,  # dfocc, tight
+            "OMP2 SAME-SPIN CORRELATION ENERGY": -0.039024778995,  # dfocc, tight
+            "OMP2.5 REFERENCE CORRECTION ENERGY": 0.001273007276,  # dfocc, tight
+            "OMP2.5 CORRELATION ENERGY": -0.179776978593,  # dfocc, tight
+            "OMP2.5 SAME-SPIN CORRELATION ENERGY": -0.038629873581,  # dfocc, tight
+            "OMP3 REFERENCE CORRECTION ENERGY": 0.001112904383,  # dfocc, tight
+            "OMP3 CORRELATION ENERGY": -0.186933561283,  # dfocc, tight
+            "OMP3 SAME-SPIN CORRELATION ENERGY": -0.038275663827,  # dfocc, tight
+            "OREMP REFERENCE CORRECTION ENERGY": 0.001217841569,  # dfocc, tight
+            "OREMP CORRELATION ENERGY": -0.188746049630,  # dfocc, tight
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001218721333,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.192985744725,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.037047752001,  # dfocc, tight
@@ -9132,6 +9773,17 @@ _std_suite = [
                     -0.00024246,
                 ]
             ).reshape((-1, 3)),
+            "OMP2 REFERENCE CORRECTION ENERGY": -0.001130393431,  # dfocc, tight
+            "OMP2 CORRELATION ENERGY": -0.060478725483,  # dfocc, tight
+            "OMP2 SAME-SPIN CORRELATION ENERGY": -0.001822163952,  # dfocc, tight
+            "OMP2.5 REFERENCE CORRECTION ENERGY": -0.000959218077,  # dfocc, tight
+            "OMP2.5 CORRELATION ENERGY": -0.068311867609,  # dfocc, tight
+            "OMP2.5 SAME-SPIN CORRELATION ENERGY": -0.002049209005,  # dfocc, tight
+            "OMP3 REFERENCE CORRECTION ENERGY": -0.000743052999,  # dfocc, tight
+            "OMP3 CORRELATION ENERGY": -0.076184701712,  # dfocc, tight
+            "OMP3 SAME-SPIN CORRELATION ENERGY": -0.002276029277,  # dfocc, tight
+            "OREMP REFERENCE CORRECTION ENERGY": -0.000458253707,  # dfocc, tight
+            "OREMP CORRELATION ENERGY": -0.079667381927,  # dfocc, tight
             "OLCCD REFERENCE CORRECTION ENERGY": -0.000031311396,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.085435962210,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.002307761175,  # dfocc, tight
@@ -9171,6 +9823,17 @@ _std_suite = [
                     -0.01318846179,
                 ]
             ).reshape((-1, 3)),
+            "OMP2 REFERENCE CORRECTION ENERGY": -0.003052622179,  # dfocc, tight
+            "OMP2 CORRELATION ENERGY": -0.158232417832,  # dfocc, tight
+            "OMP2 SAME-SPIN CORRELATION ENERGY": -0.035194309944,  # dfocc, tight
+            "OMP2.5 REFERENCE CORRECTION ENERGY": -0.003241471192,  # dfocc, tight
+            "OMP2.5 CORRELATION ENERGY": -0.166194620227,  # dfocc, tight
+            "OMP2.5 SAME-SPIN CORRELATION ENERGY": -0.035088275359,  # dfocc, tight
+            "OMP3 REFERENCE CORRECTION ENERGY": -0.003386926686,  # dfocc, tight
+            "OMP3 CORRELATION ENERGY": -0.174198389777,  # dfocc, tight
+            "OMP3 SAME-SPIN CORRELATION ENERGY": -0.035012012647,  # dfocc, tight
+            "OREMP REFERENCE CORRECTION ENERGY": -0.00330024259293,  # dfocc, tight
+            "OREMP CORRELATION ENERGY": -0.17585981265919,  # dfocc, tight
             "OLCCD REFERENCE CORRECTION ENERGY": -0.003299640039,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.180414757924,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.033743734902,  # dfocc, tight
@@ -9210,6 +9873,17 @@ _std_suite = [
                     -0.007444881162,
                 ]
             ).reshape((-1, 3)),
+            "OMP2 REFERENCE CORRECTION ENERGY": -0.003129397648,  # dfocc, tight
+            "OMP2 CORRELATION ENERGY": -0.177286459867,  # dfocc, tight
+            "OMP2 SAME-SPIN CORRELATION ENERGY": -0.039024777173,  # dfocc, tight
+            "OMP2.5 REFERENCE CORRECTION ENERGY": -0.003336731502,  # dfocc, tight
+            "OMP2.5 CORRELATION ENERGY": -0.184386711249,  # dfocc, tight
+            "OMP2.5 SAME-SPIN CORRELATION ENERGY": -0.038629874099,  # dfocc, tight
+            "OMP3 REFERENCE CORRECTION ENERGY": -0.003496834047,  # dfocc, tight
+            "OMP3 CORRELATION ENERGY": -0.191543293940,  # dfocc, tight
+            "OMP3 SAME-SPIN CORRELATION ENERGY": -0.038275664440,  # dfocc, tight
+            "OREMP REFERENCE CORRECTION ENERGY": -0.003391896462,  # dfocc, tight
+            "OREMP CORRELATION ENERGY": -0.193355782287,  # dfocc, tight
             "OLCCD REFERENCE CORRECTION ENERGY": -0.003391009701,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.197595477381,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.037047749578,  # dfocc, tight
@@ -9725,8 +10399,10 @@ _std_suite = [
             "MP3 CORRELATION ENERGY": -0.20656153,  # dfocc
             "MP3 SINGLES ENERGY": 0.0,
             "MP3 TOTAL GRADIENT": np.array([0.0, 0.0, -0.000933466293, 0.0, 0.0, 0.000933466293]).reshape((-1, 3)),
+            "REMP CORRELATION ENERGY": -0.208504245426,  # dfocc, tight
+            "REMP SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.2100337333,  # p4n
-            "LCCD SINGLES ENERGY": 0.0000000000,
+            "LCCD SINGLES ENERGY": 0.0,
             "LCCD TOTAL GRADIENT": np.array([0.0, 0.0, 0.002183232102, 0.0, 0.0, -0.002183232102]).reshape((-1, 3)),
             "CCSD CORRELATION ENERGY": -0.20886881949604,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
@@ -9747,6 +10423,30 @@ _std_suite = [
                         -0.,             -0.,             -0.003068357914]
             ).reshape((-1, 3)),
             "A-(T) CORRECTION ENERGY": -0.00196274645521,  # dfocc, tight
+            "OMP2 REFERENCE CORRECTION ENERGY": 0.000705416559,  # dfocc, tight
+            "OMP2 CORRELATION ENERGY": -0.204449284608,  # dfocc, tight
+            "OMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
+                  [ 0.,  0.000000000000,     0.004079891926,
+                    0., -0.000000000000,    -0.004079891926]
+            ).reshape((-1, 3)),
+            "OMP2.5 REFERENCE CORRECTION ENERGY": 0.000572277516,  # dfocc, tight
+            "OMP2.5 CORRELATION ENERGY": -0.205719687105,  # dfocc, tight
+            "OMP2.5 TOTAL GRADIENT": np.array(  # dfocc, tight
+                  [ 0.,  0.000000000000,     0.001995568826,
+                    0., -0.000000000000,    -0.001995568826]
+            ).reshape((-1, 3)),
+            "OMP3 REFERENCE CORRECTION ENERGY": 0.000467850505,  # dfocc, tight
+            "OMP3 CORRELATION ENERGY": -0.207017324163,  # dfocc, tight
+            "OMP3 TOTAL GRADIENT": np.array(  # dfocc, tight
+                  [ 0.,  0.000000000000,    -0.000022521780,
+                    0., -0.000000000000,     0.000022521780]
+            ).reshape((-1, 3)),
+            "OREMP REFERENCE CORRECTION ENERGY": 0.000553781427,  # dfocc, tight
+            "OREMP CORRELATION ENERGY": -0.209041900252,  # dfocc, tight
+            "OREMP TOTAL GRADIENT": np.array(  # dfocc, tight
+                 [  0.,  0.000000000000,     0.002809444261,
+                    0., -0.000000000000,    -0.002809444261]
+            ).reshape((-1, 3)),
             "OLCCD REFERENCE CORRECTION ENERGY": 0.000552755815,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.210569944656,  # dfocc, tight
             "OLCCD TOTAL GRADIENT": np.array(  # dfocc, tight
@@ -9799,6 +10499,8 @@ _std_suite = [
             "MP3 TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.004009128141, 0.0, 0.002552803039, -0.00200456407, 0.0, -0.002552803039, -0.00200456407]
             ).reshape((-1, 3)),
+            "REMP CORRELATION ENERGY": -0.22954466014956,  # dfocc, tight
+            "REMP SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.2320149229,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD TOTAL GRADIENT": np.array(
@@ -9827,6 +10529,34 @@ _std_suite = [
                         -0.,             -0.00604923838,  -0.005100003226]
             ).reshape((-1, 3)),
             "A-(T) CORRECTION ENERGY": -0.00524100328791,  # dfocc, tight
+            "OMP2 REFERENCE CORRECTION ENERGY": 0.002353213091,  # dfocc, tight
+            "OMP2 CORRELATION ENERGY": -0.224108722336,  # dfocc, tight
+            "OMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
+                  [ 0.,  0.000000000000,     0.012090520150,
+                    0.,  0.006792038487,    -0.006045260075,
+                    0., -0.006792038487,    -0.006045260075]
+            ).reshape((-1, 3)),
+            "OMP2.5 REFERENCE CORRECTION ENERGY": 0.001535554696,  # dfocc, tight
+            "OMP2.5 CORRELATION ENERGY": -0.225687426127,  # dfocc, tight
+            "OMP2.5 TOTAL GRADIENT": np.array(  # dfocc, tight
+                  [ 0.,  0.000000000000,     0.008284981234,
+                    0.,  0.004775627693,    -0.004142490617,
+                    0., -0.004775627693,    -0.004142490617]
+            ).reshape((-1, 3)),
+            "OMP3 REFERENCE CORRECTION ENERGY": 0.000954089054,  # dfocc, tight
+            "OMP3 CORRELATION ENERGY": -0.227460339651,  # dfocc, tight
+            "OMP3 TOTAL GRADIENT": np.array(  # dfocc, tight
+                  [ 0., -0.000000000000,     0.004815233651,
+                    0.,  0.002952173310,    -0.002407616826,
+                    0., -0.002952173310,    -0.002407616826]
+            ).reshape((-1, 3)),
+            "OREMP REFERENCE CORRECTION ENERGY": 0.001281722402,  # dfocc, tight
+            "OREMP CORRELATION ENERGY": -0.23079090375495,  # dfocc, tight
+            "OREMP TOTAL GRADIENT": np.array(  # dfocc, tight
+              [ 0.,  0.000000000000,     0.009108870642,
+                0.,  0.005403366342,    -0.004554435321,
+                0., -0.005403366342,    -0.004554435321]
+            ).reshape((-1, 3)),
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001189314489,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.233173062606,  # dfocc, tight
             "OLCCD TOTAL GRADIENT": np.array(  # dfocc, tight
@@ -9881,6 +10611,8 @@ _std_suite = [
             "MP3 TOTAL GRADIENT": np.array(
                 [0.0, 0.0, -0.007037747646, 0.0, -0.004494031919, 0.003518873823, 0.0, 0.004494031919, 0.003518873823]
             ).reshape((-1, 3)),
+            "REMP CORRELATION ENERGY": -0.276419945808,  # dfocc, tight
+            "REMP SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.2786671617,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD TOTAL GRADIENT": np.array(
@@ -9899,6 +10631,34 @@ _std_suite = [
                          0.,              0.000742939441,  0.000108706333]
             ).reshape((-1, 3)),
             "A-(T) CORRECTION ENERGY": -0.00718000875661,  # dfocc, tight
+            "OMP2 REFERENCE CORRECTION ENERGY": 0.002514012770,  # dfocc, tight
+            "OMP2 CORRELATION ENERGY": -0.272569214076,  # dfocc, tight
+            "OMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
+                  [ 0., -0.000000000000,     0.001818176662,
+                    0.,  0.000241592175,    -0.000909088331,
+                    0., -0.000241592175,    -0.000909088331]
+            ).reshape((-1, 3)),
+            "OMP2.5 REFERENCE CORRECTION ENERGY": 0.001691695489,  # dfocc, tight
+            "OMP2.5 CORRELATION ENERGY": -0.273184743555,  # dfocc, tight
+            "OMP2.5 TOTAL GRADIENT": np.array(  # dfocc, tight
+                  [ 0., -0.000000000000,    -0.002325903973,
+                    0., -0.001998665869,     0.001162951987,
+                    0.,  0.001998665869,     0.001162951987]
+            ).reshape((-1, 3)),
+            "OMP3 REFERENCE CORRECTION ENERGY": 0.001090223846,  # dfocc, tight
+            "OMP3 CORRELATION ENERGY": -0.273992490969,  # dfocc, tight
+            "OMP3 TOTAL GRADIENT": np.array(  # dfocc, tight
+                  [ 0.,  0.000000000000,    -0.006182600264,
+                    0., -0.004075383127,     0.003091300132,
+                    0.,  0.004075383127,     0.003091300132]
+            ).reshape((-1, 3)),
+            "OREMP REFERENCE CORRECTION ENERGY": 0.001444459285,  # dfocc, tight
+            "OREMP CORRELATION ENERGY": -0.277823416296,  # dfocc, tight
+            "OREMP TOTAL GRADIENT": np.array(  # dfocc, tight
+                 [  0., -0.000000000000,    -0.001651592566,
+                    0., -0.001517469318,     0.000825796283,
+                    0.,  0.001517469318,     0.000825796283]
+            ).reshape((-1, 3)),
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001352291360,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.279981325469,  # dfocc, tight
             "OLCCD TOTAL GRADIENT": np.array(  # dfocc, tight
@@ -9970,6 +10730,9 @@ _std_suite = [
                     -0.00011437482,
                 ]
             ).reshape((-1, 3)),
+            "REMP CORRELATION ENERGY": -0.078090599375,  # dfocc, tight
+            "REMP SINGLES ENERGY": 0.0,
+            "REMP SAME-SPIN CORRELATION ENERGY": -0.002340709678,  # dfocc, tight
             "LCCD CORRELATION ENERGY": -0.0835030877,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0024016379,  # dfocc
@@ -10005,6 +10768,41 @@ _std_suite = [
                          0.,             -0.014962374742, -0.000028968144]
             ).reshape((-1, 3)),
             "A-(T) CORRECTION ENERGY": -0.00060971952519,  # dfocc, tight
+            "OMP2 REFERENCE CORRECTION ENERGY": 0.000396459592,  # dfocc, tight
+            "OMP2 CORRELATION ENERGY": -0.059832149673,  # dfocc, tight
+            "OMP2 SAME-SPIN CORRELATION ENERGY": -0.001972801620,  # dfocc, tight
+            "OMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
+                  [ 0.,  0.000000000000,     0.012031476427,
+                    0., -0.000000000000,    -0.011634888026,
+                    0.,  0.010540730273,    -0.000198294201,
+                    0., -0.010540730274,    -0.000198294201]
+            ).reshape((-1, 3)),
+            "OMP2.5 REFERENCE CORRECTION ENERGY": 0.000566397552,  # dfocc, tight
+            "OMP2.5 CORRELATION ENERGY": -0.067689046439,  # dfocc, tight
+            "OMP2.5 SAME-SPIN CORRELATION ENERGY": -0.002200309774,  # dfocc, tight
+            "OMP2.5 TOTAL GRADIENT": np.array(  # dfocc, tight
+                  [ 0.,  0.000000000000,     0.010263706524,
+                    0., -0.000000000000,    -0.009982176653,
+                    0.,  0.011813660618,    -0.000140764936,
+                    0., -0.011813660618,    -0.000140764936]
+            ).reshape((-1, 3)),
+            "OMP3 REFERENCE CORRECTION ENERGY": 0.000780187024,  # dfocc, tight
+            "OMP3 CORRELATION ENERGY": -0.075581499723,  # dfocc, tight
+            "OMP3 SAME-SPIN CORRELATION ENERGY": -0.002427625806,  # dfocc, tight
+            "OMP3 TOTAL GRADIENT": np.array(  # dfocc, tight
+                  [ 0.,  0.000000000000,     0.008448066470,
+                    0., -0.000000000000,    -0.008281866938,
+                    0.,  0.013097326629,    -0.000083099766,
+                    0., -0.013097326629,    -0.000083099766]
+            ).reshape((-1, 3)),
+            "OREMP REFERENCE CORRECTION ENERGY": 0.001063189693,  # dfocc, tight
+            "OREMP CORRELATION ENERGY": -0.079048591655,  # dfocc, tight
+            "OREMP TOTAL GRADIENT": np.array(  # dfocc, tight
+                 [  0.,  0.000000000000,     0.005890513253,
+                    0., -0.000000000000,    -0.005780178036,
+                    0.,  0.014386023476,    -0.000055167609,
+                    0., -0.014386023476,    -0.000055167609]
+            ).reshape((-1, 3)),
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001486131044,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.084811453110,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.002450103204,  # dfocc, tight
@@ -10063,6 +10861,9 @@ _std_suite = [
             "MP3 TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.027082665714, 0.0, 0.014406579724, -0.013541332857, 0.0, -0.014406579724, -0.013541332857]
             ).reshape((-1, 3)),
+            "REMP CORRELATION ENERGY": -0.17256998862940,  # dfocc, tight
+            "REMP SINGLES ENERGY": 0.0,
+            "REMP SAME-SPIN CORRELATION ENERGY": -0.03451443433327,  # dfocc, tight
             "LCCD CORRELATION ENERGY": -0.1770997033,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0340788149,  # dfocc
@@ -10083,6 +10884,37 @@ _std_suite = [
                         -0.,             -0.016805034066, -0.015574387725]
             ).reshape((-1, 3)),
             "A-(T) CORRECTION ENERGY": -0.00376812221828,  # dfocc, tight
+            "OMP2 REFERENCE CORRECTION ENERGY": 0.001367832301,  # dfocc, tight
+            "OMP2 CORRELATION ENERGY": -0.156173452626,  # dfocc, tight
+            "OMP2 SAME-SPIN CORRELATION ENERGY": -0.036004901480,  # dfocc, tight
+            "OMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
+                  [ 0., -0.000000000000,     0.026914388853,
+                    0.,  0.014240311996,    -0.013457194426,
+                    0., -0.014240311996,    -0.013457194426]
+            ).reshape((-1, 3)),
+            "OMP2.5 REFERENCE CORRECTION ENERGY": 0.001174470264,  # dfocc, tight
+            "OMP2.5 CORRELATION ENERGY": -0.164063461670,  # dfocc, tight
+            "OMP2.5 SAME-SPIN CORRELATION ENERGY": -0.035847923992,  # dfocc, tight
+            "OMP2.5 TOTAL GRADIENT": np.array(  # dfocc, tight
+                  [ 0., -0.000000000000,     0.027483211370,
+                    0.,  0.014576999156,    -0.013741605685,
+                    0., -0.014576999156,    -0.013741605685]
+            ).reshape((-1, 3)),
+            "OMP3 REFERENCE CORRECTION ENERGY": 0.001024687110,  # dfocc, tight
+            "OMP3 CORRELATION ENERGY": -0.171990731878,  # dfocc, tight
+            "OMP3 SAME-SPIN CORRELATION ENERGY": -0.035717311998,  # dfocc, tight
+            "OMP3 TOTAL GRADIENT": np.array(  # dfocc, tight
+                  [ 0., -0.000000000000,     0.028112148199,
+                    0.,  0.014949633980,    -0.014056074099,
+                    0., -0.014949633980,    -0.014056074099]
+            ).reshape((-1, 3)),
+            "OREMP REFERENCE CORRECTION ENERGY": 0.0011125246764,  # dfocc, tight
+            "OREMP CORRELATION ENERGY": -0.17366812020990,  # dfocc, tight
+            "OREMP TOTAL GRADIENT": np.array(  # dfocc, tight)
+              [ 0., -0.000000000000,     0.030213597936,
+                0.,  0.016231443797,    -0.015106798968,
+                0., -0.016231443797,    -0.015106798968]
+            ).reshape((-1, 3)),
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001111851483,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.178196933112,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.034422402711,  # dfocc, tight
@@ -10139,6 +10971,9 @@ _std_suite = [
             "MP3 TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.014412459072, 0.0, 0.005610368822, -0.007206229536, 0.0, -0.005610368822, -0.007206229536]
             ).reshape((-1, 3)),
+            "REMP CORRELATION ENERGY": -0.212434650458,  # dfocc, tight
+            "REMP SINGLES ENERGY": 0.0,
+            "REMP SAME-SPIN CORRELATION ENERGY": -0.040606132872,  # dfocc, tight
             "LCCD CORRELATION ENERGY": -0.2167706529,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0401283617,  # dfocc
@@ -10159,6 +10994,37 @@ _std_suite = [
                          0.,             -0.008236968052, -0.009509290722]
             ).reshape((-1, 3)),
             "A-(T) CORRECTION ENERGY": -0.00506341197521,  # dfocc, tight
+            "OMP2 REFERENCE CORRECTION ENERGY": 0.001570633341,  # dfocc, tight
+            "OMP2 CORRELATION ENERGY": -0.197048695120,  # dfocc, tight
+            "OMP2 SAME-SPIN CORRELATION ENERGY": -0.042457672915,  # dfocc, tight
+            "OMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
+                  [ 0.,  0.000000000000,     0.015291382216,
+                    0.,  0.006145115573,    -0.007645691108,
+                    0., -0.006145115573,    -0.007645691108]
+            ).reshape((-1, 3)),
+            "OMP2.5 REFERENCE CORRECTION ENERGY": 0.001350847967,  # dfocc, tight
+            "OMP2.5 CORRELATION ENERGY": -0.204503012944,  # dfocc, tight
+            "OMP2.5 SAME-SPIN CORRELATION ENERGY": -0.042084276114,  # dfocc, tight
+            "OMP2.5 TOTAL GRADIENT": np.array(  # dfocc, tight
+                  [ 0., -0.000000000000,     0.015388626332,
+                    0.,  0.006150433332,    -0.007694313166,
+                    0., -0.006150433332,    -0.007694313166]
+            ).reshape((-1, 3)),
+            "OMP3 REFERENCE CORRECTION ENERGY": 0.001177820960,  # dfocc, tight
+            "OMP3 CORRELATION ENERGY": -0.211999043568,  # dfocc, tight
+            "OMP3 SAME-SPIN CORRELATION ENERGY": -0.041741379825,  # dfocc, tight
+            "OMP3 TOTAL GRADIENT": np.array(  # dfocc, tight
+                  [ 0.,  0.000000000000,     0.015546142750,
+                    0.,  0.006191167357,    -0.007773071375,
+                    0., -0.006191167357,    -0.007773071375]
+            ).reshape((-1, 3)),
+            "OREMP REFERENCE CORRECTION ENERGY": 0.001287786460,  # dfocc, tight
+            "OREMP CORRELATION ENERGY": -0.213706080780,  # dfocc, tight
+            "OREMP TOTAL GRADIENT": np.array(  # dfocc, tight
+                 [  0., -0.000000000000,     0.017877890596,
+                    0.,  0.007580722221,    -0.008938945298,
+                    0., -0.007580722221,    -0.008938945298]
+            ).reshape((-1, 3)),
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001285702841,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.218038927594,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.040510034508,  # dfocc, tight
@@ -10214,6 +11080,41 @@ _std_suite = [
             ).reshape((-1, 3)),
             "LCCD CORRELATION ENERGY": -0.0834776542,  # p4n
             "LCCD TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
+            "OMP2 REFERENCE CORRECTION ENERGY": -0.001127578413,  # dfocc, tight
+            "OMP2 CORRELATION ENERGY": -0.061356186762,  # dfocc, tight
+            "OMP2 SAME-SPIN CORRELATION ENERGY": -0.001972801188,  # dfocc, tight
+            "OMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
+                  [ 0.,  0.000000000000,     0.012031487574,
+                    0., -0.000000000000,    -0.011634881724,
+                    0.,  0.010540719393,    -0.000198302925,
+                    0., -0.010540719393,    -0.000198302925]
+            ).reshape((-1, 3)),
+            "OMP2.5 REFERENCE CORRECTION ENERGY": -0.000957639989,  # dfocc, tight
+            "OMP2.5 CORRELATION ENERGY": -0.069213083529,  # dfocc, tight
+            "OMP2.5 SAME-SPIN CORRELATION ENERGY": -0.002200309067,  # dfocc, tight
+            "OMP2.5 TOTAL GRADIENT": np.array(  # dfocc, tight
+                  [ 0.,  0.000000000000,     0.010263733632,
+                    0., -0.000000000000,    -0.009982179290,
+                    0.,  0.011813639779,    -0.000140777171,
+                    0., -0.011813639779,    -0.000140777171]
+            ).reshape((-1, 3)),
+            "OMP3 REFERENCE CORRECTION ENERGY": -0.000743849641,  # dfocc, tight
+            "OMP3 CORRELATION ENERGY": -0.077105536812,  # dfocc, tight
+            "OMP3 SAME-SPIN CORRELATION ENERGY": -0.002427625679,  # dfocc, tight
+            "OMP3 TOTAL GRADIENT": np.array(  # dfocc, tight
+                  [ 0.,  0.000000000000,     0.008448077204,
+                    0., -0.000000000000,    -0.008281875978,
+                    0.,  0.013097326563,    -0.000083100613,
+                    0., -0.013097326563,    -0.000083100613]
+            ).reshape((-1, 3)),
+            "OREMP REFERENCE CORRECTION ENERGY": -0.000460845361,  # dfocc, tight
+            "OREMP CORRELATION ENERGY": -0.080572628744,  # dfocc, tight
+            "OREMP TOTAL GRADIENT": np.array(  # dfocc, tight
+                 [  0.,  0.000000000000,     0.005890487280,
+                    0., -0.000000000000,    -0.005780144920,
+                    0.,  0.014386015714,    -0.000055171180,
+                    0., -0.014386015714,    -0.000055171180]
+            ).reshape((-1, 3)),
             "OLCCD REFERENCE CORRECTION ENERGY": -0.000037911160,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.086335490199,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.002450103939,  # dfocc, tight
@@ -10267,6 +11168,37 @@ _std_suite = [
                 ]
             ).reshape((-1, 3)),
             "LCCD CORRELATION ENERGY": -0.1792603912,  # p4n
+            "OMP2 REFERENCE CORRECTION ENERGY": -0.003046129441,  # dfocc, tight
+            "OMP2 CORRELATION ENERGY": -0.160587412835,  # dfocc, tight
+            "OMP2 SAME-SPIN CORRELATION ENERGY": -0.036004901152,  # dfocc, tight
+            "OMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
+                  [ 0., -0.000000000000,     0.026914381459,
+                    0.,  0.014240313354,    -0.013457190729,
+                    0., -0.014240313354,    -0.013457190729]
+            ).reshape((-1, 3)),
+            "OMP2.5 REFERENCE CORRECTION ENERGY": -0.003239492526,  # dfocc, tight
+            "OMP2.5 CORRELATION ENERGY": -0.168477421879,  # dfocc, tight
+            "OMP2.5 SAME-SPIN CORRELATION ENERGY": -0.035847923306,  # dfocc, tight
+            "OMP2.5 TOTAL GRADIENT": np.array(  # dfocc, tight
+                  [ 0., -0.000000000000,     0.027483206969,
+                    0.,  0.014577000408,    -0.013741603485,
+                    0., -0.014577000408,    -0.013741603485]
+            ).reshape((-1, 3)),
+            "OMP3 REFERENCE CORRECTION ENERGY": -0.003389275946,  # dfocc, tight
+            "OMP3 CORRELATION ENERGY": -0.176404692086,  # dfocc, tight
+            "OMP3 SAME-SPIN CORRELATION ENERGY": -0.035717311411,  # dfocc, tight
+            "OMP3 TOTAL GRADIENT": np.array(  # dfocc, tight
+                  [ 0.,  0.000000000000,     0.028112143061,
+                    0.,  0.014949636932,    -0.014056071530,
+                    0., -0.014949636932,    -0.014056071530]
+            ).reshape((-1, 3)),
+            "OREMP REFERENCE CORRECTION ENERGY": -0.003301435451,  # dfocc, tight
+            "OREMP CORRELATION ENERGY": -0.178082080418,  # dfocc, tight
+            "OREMP TOTAL GRADIENT": np.array(  # dfocc, tight
+                 [  0., -0.000000000000,     0.030213608364,
+                    0.,  0.016231443474,    -0.015106804182,
+                    0., -0.016231443474,    -0.015106804182]
+            ).reshape((-1, 3)),
             "OLCCD REFERENCE CORRECTION ENERGY": -0.003302111181,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.182610893321,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.034422399491,  # dfocc, tight
@@ -10318,6 +11250,37 @@ _std_suite = [
                 ]
             ).reshape((-1, 3)),
             "LCCD CORRELATION ENERGY": -0.2190866990,  # p4n
+            "OMP2 REFERENCE CORRECTION ENERGY": -0.003039409981,  # dfocc, tight
+            "OMP2 CORRELATION ENERGY": -0.201658737065,  # dfocc, tight
+            "OMP2 SAME-SPIN CORRELATION ENERGY": -0.042457672983,  # dfocc, tight
+            "OMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
+                  [ 0., -0.000000000000,     0.015291380391,
+                    0.,  0.006145126895,    -0.007645690196,
+                    0., -0.006145126895,    -0.007645690196]
+            ).reshape((-1, 3)),
+            "OMP2.5 REFERENCE CORRECTION ENERGY": -0.003259197444,  # dfocc, tight
+            "OMP2.5 CORRELATION ENERGY": -0.209113054889,  # dfocc, tight
+            "OMP2.5 SAME-SPIN CORRELATION ENERGY": -0.042084275918,  # dfocc, tight
+            "OMP2.5 TOTAL GRADIENT": np.array(  # dfocc, tight
+                  [ 0., -0.000000000000,     0.015388624199,
+                    0.,  0.006150440601,    -0.007694312099,
+                    0., -0.006150440601,    -0.007694312099]
+            ).reshape((-1, 3)),
+            "OMP3 REFERENCE CORRECTION ENERGY": -0.003432224601,  # dfocc, tight
+            "OMP3 CORRELATION ENERGY": -0.216609085513,  # dfocc, tight
+            "OMP3 SAME-SPIN CORRELATION ENERGY": -0.041741379888,  # dfocc, tight
+            "OMP3 TOTAL GRADIENT": np.array(  # dfocc, tight
+                  [ 0., -0.000000000000,     0.015546139127,
+                    0.,  0.006191172928,    -0.007773069564,
+                    0., -0.006191172928,    -0.007773069564]
+            ).reshape((-1, 3)),
+            "OREMP REFERENCE CORRECTION ENERGY": -0.003322256873,  # dfocc, tight
+            "OREMP CORRELATION ENERGY": -0.218316122726,  # dfocc, tight
+            "OREMP TOTAL GRADIENT": np.array(  # dfocc, tight
+                 [  0., -0.000000000000,     0.017877876813,
+                    0.,  0.007580722265,    -0.008938938407,
+                    0., -0.007580722265,    -0.008938938407]
+            ).reshape((-1, 3)),
             "OLCCD REFERENCE CORRECTION ENERGY": -0.003324348494,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.222648969545,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.040510044397,  # dfocc, tight
@@ -10369,6 +11332,8 @@ _std_suite = [
             "MP3 CORRELATION ENERGY": -0.20461763,  # dfocc
             "MP3 SINGLES ENERGY": 0.0,
             "MP3 TOTAL GRADIENT": np.array([0.0, 0.0, -0.000595617648, 0.0, 0.0, 0.000595617648]).reshape((-1, 3)),
+            "REMP CORRELATION ENERGY": -0.206525739571,  # dfocc, tight
+            "REMP SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.2080860831,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD TOTAL GRADIENT": np.array([0.0, 0.0, 0.002514968877, 0.0, 0.0, -0.002514968877]).reshape((-1, 3)),
@@ -10391,6 +11356,30 @@ _std_suite = [
                         -0.,             -0.,             -0.003412477814]
             ).reshape((-1, 3)),
             "A-(T) CORRECTION ENERGY": -0.00194585245550,  # dfocc, tight
+            "OMP2 REFERENCE CORRECTION ENERGY": 0.000703072086,  # dfocc, tight
+            "OMP2 CORRELATION ENERGY": -0.202322737562,  # dfocc, tight
+            "OMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
+                  [ 0.,  0.000000000000,     0.004462211239,
+                    0., -0.000000000000,    -0.004462211239]
+            ).reshape((-1, 3)),
+            "OMP2.5 REFERENCE CORRECTION ENERGY": 0.000572012280,  # dfocc, tight
+            "OMP2.5 CORRELATION ENERGY": -0.203736894925,  # dfocc, tight
+            "OMP2.5 TOTAL GRADIENT": np.array(  # dfocc, tight
+                 [  0.,  0.000000000000,     0.002400349139,
+                    0., -0.000000000000,    -0.002400349139]
+            ).reshape((-1, 3)),
+            "OMP3 REFERENCE CORRECTION ENERGY": 0.000469635507,  # dfocc, tight
+            "OMP3 CORRELATION ENERGY": -0.205198445453,  # dfocc, tight
+            "OMP3 TOTAL GRADIENT": np.array(  # dfocc, tight
+                  [ 0.,  0.000000000000,     0.000413292087,
+                    0., -0.000000000000,    -0.000413292087]
+            ).reshape((-1, 3)),
+            "OREMP REFERENCE CORRECTION ENERGY": 0.000554531047,  # dfocc, tight
+            "OREMP CORRELATION ENERGY": -0.207169559461,  # dfocc, tight
+            "OREMP TOTAL GRADIENT": np.array(  # dfocc, tight
+              [ 0.,  0.000000000000,     0.003224769580,
+                0., -0.000000000000,    -0.003224769580]
+            ).reshape((-1, 3)),
             "OLCCD REFERENCE CORRECTION ENERGY": 0.000553992712,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.208748872411,  # dfocc, tight
             "OLCCD TOTAL GRADIENT": np.array(  # dfocc, tight
@@ -10443,6 +11432,8 @@ _std_suite = [
             "MP3 TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.004605219936, 0.0, 0.002923029606, -0.002302609968, 0.0, -0.002923029606, -0.002302609968]
             ).reshape((-1, 3)),
+            "REMP CORRELATION ENERGY": -0.22723769214209,  # dfocc, tight
+            "REMP SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.2297412879,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD TOTAL GRADIENT": np.array(
@@ -10471,6 +11462,34 @@ _std_suite = [
                         -0.,             -0.006421774051, -0.005400604283]
             ).reshape((-1, 3)),
             "A-(T) CORRECTION ENERGY": -0.00521446434812,  # dfocc, tight
+            "OMP2 REFERENCE CORRECTION ENERGY": 0.002352666762,  # dfocc, tight
+            "OMP2 CORRELATION ENERGY": -0.221650942141,  # dfocc, tight
+            "OMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
+                  [ 0., -0.000000000000,     0.012771605048,
+                    0.,  0.007190306206,    -0.006385802524,
+                    0., -0.007190306205,    -0.006385802524]
+            ).reshape((-1, 3)),
+            "OMP2.5 REFERENCE CORRECTION ENERGY": 0.001538577646,  # dfocc, tight
+            "OMP2.5 CORRELATION ENERGY": -0.223375325491,  # dfocc, tight
+            "OMP2.5 TOTAL GRADIENT": np.array(  # dfocc, tight
+                 [  0., -0.000000000000,     0.008996184043,
+                    0.,  0.005183828520,    -0.004498092021,
+                    0., -0.005183828519,    -0.004498092021]
+            ).reshape((-1, 3)),
+            "OMP3 REFERENCE CORRECTION ENERGY": 0.000960712694,  # dfocc, tight
+            "OMP3 CORRELATION ENERGY": -0.225313300040,  # dfocc, tight
+            "OMP3 TOTAL GRADIENT": np.array(  # dfocc, tight
+                  [ 0., -0.000000000000,     0.005564092786,
+                    0.,  0.003375822885,    -0.002782046393,
+                    0., -0.003375822885,    -0.002782046393]
+            ).reshape((-1, 3)),
+            "OREMP REFERENCE CORRECTION ENERGY": 0.001285806012,  # dfocc, tight
+            "OREMP CORRELATION ENERGY": -0.228593144538,  # dfocc, tight
+            "OREMP TOTAL GRADIENT": np.array(  # dfocc, tight
+             [ 0.0,  0.000000000000,     0.009830485254,
+               0.0,  0.005814222254,    -0.004915242627,
+               0.0, -0.005814222254,    -0.004915242627]
+            ).reshape((-1, 3)),
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001194079264,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.231028592985,  # dfocc, tight
             "OLCCD TOTAL GRADIENT": np.array(  # dfocc, tight
@@ -10525,6 +11544,8 @@ _std_suite = [
             "MP3 TOTAL GRADIENT": np.array(
                 [0.0, 0.0, -0.006198368687, 0.0, -0.004115138427, 0.003099184344, 0.0, 0.004115138427, 0.003099184344]
             ).reshape((-1, 3)),
+            "REMP CORRELATION ENERGY": -0.251000783874,  # dfocc, tight
+            "REMP SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.2531777549,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD TOTAL GRADIENT": np.array(
@@ -10553,6 +11574,34 @@ _std_suite = [
                          0.,              0.000361314051, -0.000308753262]
             ).reshape((-1, 3)),
             "A-(T) CORRECTION ENERGY": -0.00701650721029,  # dfocc, tight
+            "OMP2 REFERENCE CORRECTION ENERGY": 0.002436225037,  # dfocc, tight
+            "OMP2 CORRELATION ENERGY": -0.247501148905,  # dfocc, tight
+            "OMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
+                  [ 0., -0.000000000000,     0.002625578291,
+                    0.,  0.000602919468,    -0.001312789146,
+                    0., -0.000602919468,    -0.001312789146]
+            ).reshape((-1, 3)),
+            "OMP2.5 REFERENCE CORRECTION ENERGY": 0.001628506731,  # dfocc, tight
+            "OMP2.5 CORRELATION ENERGY": -0.247890696918,  # dfocc, tight
+            "OMP2.5 TOTAL GRADIENT": np.array(  # dfocc, tight
+                 [  0., -0.000000000000,    -0.001471303306,
+                    0., -0.001622363348,     0.000735651653,
+                    0.,  0.001622363348,     0.000735651653]
+            ).reshape((-1, 3)),
+            "OMP3 REFERENCE CORRECTION ENERGY": 0.001042188755,  # dfocc, tight
+            "OMP3 CORRELATION ENERGY": -0.248510869843,  # dfocc, tight
+            "OMP3 TOTAL GRADIENT": np.array(  # dfocc, tight
+                  [ 0., -0.000000000000,    -0.005274771244,
+                    0., -0.003679381392,     0.002637385622,
+                    0.,  0.003679381392,     0.002637385622]
+            ).reshape((-1, 3)),
+            "OREMP REFERENCE CORRECTION ENERGY": 0.001387432536,  # dfocc, tight
+            "OREMP CORRELATION ENERGY": -0.252366737687,  # dfocc, tight
+            "OREMP TOTAL GRADIENT": np.array(  # dfocc, tight
+              [ 0.,  0.000000000000,    -0.000767533552,
+                0., -0.001128632785,     0.000383766776,
+                0.,  0.001128632785,     0.000383766776]
+            ).reshape((-1, 3)),
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001298398813,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.254465606264,  # dfocc, tight
             "OLCCD TOTAL GRADIENT": np.array(  # dfocc, tight
@@ -10624,6 +11673,9 @@ _std_suite = [
                     -0.000120861314,
                 ]
             ).reshape((-1, 3)),
+            "REMP CORRELATION ENERGY": -0.077065229797,  # dfocc, tight
+            "REMP SINGLES ENERGY": 0.0,
+            "REMP SAME-SPIN CORRELATION ENERGY": -0.002191757201,  # dfocc, tight
             "LCCD CORRELATION ENERGY": -0.0824996438,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0022545103,  # dfocc
@@ -10659,6 +11711,41 @@ _std_suite = [
                          0.,             -0.014958703713, -0.000035200787]
             ).reshape((-1, 3)),
             "A-(T) CORRECTION ENERGY": -0.00058824527447,  # dfocc, tight
+            "OMP2 REFERENCE CORRECTION ENERGY": 0.000394385396,  # dfocc, tight
+            "OMP2 CORRELATION ENERGY": -0.058935159355,  # dfocc, tight
+            "OMP2 SAME-SPIN CORRELATION ENERGY": -0.001823537679,  # dfocc, tight
+            "OMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
+                  [ 0., -0.000000000000,     0.011816043382,
+                    0., -0.000000000000,    -0.011405170159,
+                    0.,  0.010534044966,    -0.000205436611,
+                    0., -0.010534044966,    -0.000205436611]
+            ).reshape((-1, 3)),
+            "OMP2.5 REFERENCE CORRECTION ENERGY": 0.000566186305,  # dfocc, tight
+            "OMP2.5 CORRELATION ENERGY": -0.066806131554,  # dfocc, tight
+            "OMP2.5 SAME-SPIN CORRELATION ENERGY": -0.002050540370,  # dfocc, tight
+            "OMP2.5 TOTAL GRADIENT": np.array(  # dfocc, tight
+                 [  0.,  0.000000000000,     0.010039510728,
+                    0., -0.000000000000,    -0.009744203205,
+                    0.,  0.011807411335,    -0.000147653762,
+                    0., -0.011807411335,    -0.000147653762]
+            ).reshape((-1, 3)),
+            "OMP3 REFERENCE CORRECTION ENERGY": 0.000783155015,  # dfocc, tight
+            "OMP3 CORRELATION ENERGY": -0.074716931449,  # dfocc, tight
+            "OMP3 SAME-SPIN CORRELATION ENERGY": -0.002277314389,  # dfocc, tight
+            "OMP3 TOTAL GRADIENT": np.array(  # dfocc, tight
+                  [ 0., -0.000000000000,     0.008212538414,
+                    0., -0.000000000000,    -0.008033077982,
+                    0.,  0.013091494156,    -0.000089730216,
+                    0., -0.013091494156,    -0.000089730216]
+            ).reshape((-1, 3)),
+            "OREMP REFERENCE CORRECTION ENERGY": 0.001067566021,  # dfocc, tight
+            "OREMP CORRELATION ENERGY": -0.078201861999,  # dfocc, tight
+            "OREMP TOTAL GRADIENT": np.array(  # dfocc, tight
+              [ 0.,  0.000000000000,     0.005652301943,
+                0., -0.000000000000,    -0.005529627660,
+                0.,  0.014380946092,    -0.000061337141,
+                0., -0.014380946092,    -0.000061337141]
+            ).reshape((-1, 3)),
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001494223667,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.083986395282,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.002308873939,  # dfocc, tight
@@ -10717,6 +11804,9 @@ _std_suite = [
             "MP3 TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.027853586058, 0.0, 0.014898421791, -0.013926793029, 0.0, -0.014898421791, -0.013926793029]
             ).reshape((-1, 3)),
+            "REMP CORRELATION ENERGY": -0.17028287893561,  # dfocc, tight
+            "REMP SINGLES ENERGY": 0.0,
+            "REMP SAME-SPIN CORRELATION ENERGY": -0.03381515362353,  # dfocc, tight
             "LCCD CORRELATION ENERGY": -0.1748446809,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0333897039,  # dfocc
@@ -10737,6 +11827,37 @@ _std_suite = [
                         -0.,             -0.017296807836, -0.015961537154]
             ).reshape((-1, 3)),
             "A-(T) CORRECTION ENERGY": -0.00373604126252,  # dfocc, tight
+            "OMP2 REFERENCE CORRECTION ENERGY": 0.001361296352,  # dfocc, tight
+            "OMP2 CORRELATION ENERGY": -0.153806958505,  # dfocc, tight
+            "OMP2 SAME-SPIN CORRELATION ENERGY": -0.035220509485,  # dfocc, tight
+            "OMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
+                  [ 0., -0.000000000000,     0.027773187697,
+                    0.,  0.014760469702,    -0.013886593849,
+                    0., -0.014760469702,    -0.013886593849]
+            ).reshape((-1, 3)),
+            "OMP2.5 REFERENCE CORRECTION ENERGY": 0.001172388039,  # dfocc, tight
+            "OMP2.5 CORRELATION ENERGY": -0.161802412521,  # dfocc, tight
+            "OMP2.5 SAME-SPIN CORRELATION ENERGY": -0.035084385482,  # dfocc, tight
+            "OMP2.5 TOTAL GRADIENT": np.array(  # dfocc, tight
+                 [  0., -0.000000000000,     0.028357272969,
+                    0.,  0.015100442421,    -0.014178636485,
+                    0., -0.015100442421,    -0.014178636485]
+            ).reshape((-1, 3)),
+            "OMP3 REFERENCE CORRECTION ENERGY": 0.001026896343,  # dfocc, tight
+            "OMP3 CORRELATION ENERGY": -0.169839459643,  # dfocc, tight
+            "OMP3 SAME-SPIN CORRELATION ENERGY": -0.034978089725,  # dfocc, tight
+            "OMP3 TOTAL GRADIENT": np.array(  # dfocc, tight
+                  [ 0., -0.000000000000,     0.029002023504,
+                    0.,  0.015477270320,    -0.014501011752,
+                    0., -0.015477270319,    -0.014501011752]
+            ).reshape((-1, 3)),
+            "OREMP REFERENCE CORRECTION ENERGY": 0.001113332083,  # dfocc, tight
+            "OREMP CORRELATION ENERGY": -0.171513122196,  # dfocc, tight
+            "OREMP TOTAL GRADIENT": np.array(  # dfocc, tight
+              [ 0., -0.000000000000,     0.031096217899,
+                0.,  0.016756071833,    -0.015548108949,
+                0., -0.016756071832,    -0.015548108949]
+            ).reshape((-1, 3)),
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001113749802,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.176088417240,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.033693410677,  # dfocc, tight
@@ -10793,6 +11914,9 @@ _std_suite = [
             "MP3 TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.015407701186, 0.0, 0.006091123422, -0.007703850593, 0.0, -0.006091123422, -0.007703850593]
             ).reshape((-1, 3)),
+            "REMP CORRELATION ENERGY": -0.187461784316,  # dfocc, tight
+            "REMP SINGLES ENERGY": 0.0,
+            "REMP SAME-SPIN CORRELATION ENERGY": -0.037230047131,  # dfocc, tight
             "LCCD CORRELATION ENERGY": -0.1916908596,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0367574293,
@@ -10813,6 +11937,37 @@ _std_suite = [
                          0.,             -0.008716203188, -0.010003589367]
             ).reshape((-1, 3)),
             "A-(T) CORRECTION ENERGY": -0.00488153123480,  # dfocc, tight
+            "OMP2 REFERENCE CORRECTION ENERGY": 0.001480332224,  # dfocc, tight
+            "OMP2 CORRELATION ENERGY": -0.172665177005,  # dfocc, tight
+            "OMP2 SAME-SPIN CORRELATION ENERGY": -0.039018138633,  # dfocc, tight
+            "OMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
+                  [ 0.,  0.000000000000,     0.016299386418,
+                    0.,  0.006629699700,    -0.008149693209,
+                    0., -0.006629699700,    -0.008149693209]
+            ).reshape((-1, 3)),
+            "OMP2.5 REFERENCE CORRECTION ENERGY": 0.001272971815,  # dfocc, tight
+            "OMP2.5 CORRELATION ENERGY": -0.179766145094,  # dfocc, tight
+            "OMP2.5 SAME-SPIN CORRELATION ENERGY": -0.038623138099,  # dfocc, tight
+            "OMP2.5 TOTAL GRADIENT": np.array(  # dfocc, tight
+                 [  0., -0.000000000000,     0.016424137432,
+                    0.,  0.006638678143,    -0.008212068716,
+                    0., -0.006638678143,    -0.008212068716]
+            ).reshape((-1, 3)),
+            "OMP3 REFERENCE CORRECTION ENERGY": 0.001112851260,  # dfocc, tight
+            "OMP3 CORRELATION ENERGY": -0.186923452541,  # dfocc, tight
+            "OMP3 SAME-SPIN CORRELATION ENERGY": -0.038268824767,  # dfocc, tight
+            "OMP3 TOTAL GRADIENT": np.array(  # dfocc, tight
+                  [ 0.,  0.000000000000,     0.016608938328,
+                    0.,  0.006684117862,    -0.008304469164,
+                    0., -0.006684117862,    -0.008304469164]
+            ).reshape((-1, 3)),
+            "OREMP REFERENCE CORRECTION ENERGY": 0.001217776401,  # dfocc, tight
+            "OREMP CORRELATION ENERGY": -0.188735219689,  # dfocc, tight
+            "OREMP TOTAL GRADIENT": np.array(  # dfocc, tight
+              [ 0.,  0.000000000000,     0.018940660731,
+                0.,  0.008076822926,    -0.009470330365,
+                0., -0.008076822926,    -0.009470330365]
+            ).reshape((-1, 3)),
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001218640112,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.192974799277,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.037040961442,  # dfocc, tight
@@ -10867,6 +12022,41 @@ _std_suite = [
                 ]
             ).reshape((-1, 3)),
             "LCCD CORRELATION ENERGY": -0.0824737155,  # p4n
+            "OMP2 REFERENCE CORRECTION ENERGY": -0.001129652787,  # dfocc, tight
+            "OMP2 CORRELATION ENERGY": -0.060459196444,  # dfocc, tight
+            "OMP2 SAME-SPIN CORRELATION ENERGY": -0.001823537706,  # dfocc, tight
+            "OMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
+                  [ 0.,  0.000000000000,     0.011816050823,
+                    0., -0.000000000000,    -0.011405176978,
+                    0.,  0.010534044979,    -0.000205436923,
+                    0., -0.010534044979,    -0.000205436923]
+            ).reshape((-1, 3)),
+            "OMP2.5 REFERENCE CORRECTION ENERGY": -0.000957847537,  # dfocc, tight
+            "OMP2.5 CORRELATION ENERGY": -0.068330168643,  # dfocc, tight
+            "OMP2.5 SAME-SPIN CORRELATION ENERGY": -0.002050540345,  # dfocc, tight
+            "OMP2.5 TOTAL GRADIENT": np.array(  # dfocc, tight
+                 [  0.,  0.000000000000,     0.010039462838,
+                    0., -0.000000000000,    -0.009744167884,
+                    0.,  0.011807418804,    -0.000147647477,
+                    0., -0.011807418804,    -0.000147647477]
+            ).reshape((-1, 3)),
+            "OMP3 REFERENCE CORRECTION ENERGY": -0.000740878651,  # dfocc, tight
+            "OMP3 CORRELATION ENERGY": -0.076240968538,  # dfocc, tight
+            "OMP3 SAME-SPIN CORRELATION ENERGY": -0.002277314395,  # dfocc, tight
+            "OMP3 TOTAL GRADIENT": np.array(  # dfocc, tight
+                  [ 0.,  0.000000000000,     0.008212498711,
+                    0., -0.000000000000,    -0.008033043130,
+                    0.,  0.013091495437,    -0.000089727790,
+                    0., -0.013091495437,    -0.000089727790]
+            ).reshape((-1, 3)),
+            "OREMP REFERENCE CORRECTION ENERGY": -0.000456469124,  # dfocc, tight
+            "OREMP CORRELATION ENERGY": -0.079725899088,  # dfocc, tight
+            "OREMP TOTAL GRADIENT": np.array(  # dfocc, tight
+              [ 0.,  0.000000000000,     0.005652293263,
+                0., -0.000000000000,    -0.005529605660,
+                0.,  0.014380930007,    -0.000061343802,
+                0., -0.014380930007,    -0.000061343802]
+            ).reshape((-1, 3)),
             "OLCCD REFERENCE CORRECTION ENERGY": -0.000029817721,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.085510432371,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.002308874960,  # dfocc, tight
@@ -10920,6 +12110,37 @@ _std_suite = [
                 ]
             ).reshape((-1, 3)),
             "LCCD CORRELATION ENERGY": -0.1769909051,  # p4n
+            "OMP2 REFERENCE CORRECTION ENERGY": -0.003052666882,  # dfocc, tight
+            "OMP2 CORRELATION ENERGY": -0.158220918714,  # dfocc, tight
+            "OMP2 SAME-SPIN CORRELATION ENERGY": -0.035220509402,  # dfocc, tight
+            "OMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
+                  [ 0., -0.000000000000,     0.027773186774,
+                    0.,  0.014760475104,    -0.013886593387,
+                    0., -0.014760475103,    -0.013886593387]
+            ).reshape((-1, 3)),
+            "OMP2.5 REFERENCE CORRECTION ENERGY": -0.003241577707,  # dfocc, tight
+            "OMP2.5 CORRELATION ENERGY": -0.166216372729,  # dfocc, tight
+            "OMP2.5 SAME-SPIN CORRELATION ENERGY": -0.035084385218,  # dfocc, tight
+            "OMP2.5 TOTAL GRADIENT": np.array(  # dfocc, tight
+                 [  0., -0.000000000000,     0.028357346855,
+                    0.,  0.015100453507,    -0.014178673427,
+                    0., -0.015100453507,    -0.014178673427]
+            ).reshape((-1, 3)),
+            "OMP3 REFERENCE CORRECTION ENERGY": -0.003387066455,  # dfocc, tight
+            "OMP3 CORRELATION ENERGY": -0.174253419851,  # dfocc, tight
+            "OMP3 SAME-SPIN CORRELATION ENERGY": -0.034978090484,  # dfocc, tight
+            "OMP3 TOTAL GRADIENT": np.array(  # dfocc, tight
+                  [ 0., -0.000000000000,     0.029002032180,
+                    0.,  0.015477263061,    -0.014501016090,
+                    0., -0.015477263061,    -0.014501016090]
+            ).reshape((-1, 3)),
+            "OREMP REFERENCE CORRECTION ENERGY": -0.003300628093,  # dfocc, tight
+            "OREMP CORRELATION ENERGY": -0.175927082404,  # dfocc, tight
+            "OREMP TOTAL GRADIENT": np.array(  # dfocc, tight
+              [ 0., -0.000000000000,     0.031096218276,
+                0.,  0.016756071943,    -0.015548109138,
+                0., -0.016756071943,    -0.015548109138]
+            ).reshape((-1, 3)),
             "OLCCD REFERENCE CORRECTION ENERGY": -0.003300211378,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.180502377447,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.033693402688,  # dfocc, tight
@@ -10971,6 +12192,37 @@ _std_suite = [
                 ]
             ).reshape((-1, 3)),
             "LCCD CORRELATION ENERGY": -0.1939804718,  # p4n
+            "OMP2 REFERENCE CORRECTION ENERGY": -0.003129716190,  # dfocc, tight
+            "OMP2 CORRELATION ENERGY": -0.177275218950,  # dfocc, tight
+            "OMP2 SAME-SPIN CORRELATION ENERGY": -0.039018136779,  # dfocc, tight
+            "OMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
+                  [ 0., -0.000000000000,     0.016299403030,
+                    0.,  0.006629703904,    -0.008149701515,
+                    0., -0.006629703904,    -0.008149701515]
+            ).reshape((-1, 3)),
+            "OMP2.5 REFERENCE CORRECTION ENERGY": -0.003337076220,  # dfocc, tight
+            "OMP2.5 CORRELATION ENERGY": -0.184376187039,  # dfocc, tight
+            "OMP2.5 SAME-SPIN CORRELATION ENERGY": -0.038623138676,  # dfocc, tight
+            "OMP2.5 TOTAL GRADIENT": np.array(  # dfocc, tight
+                 [  0., -0.000000000000,     0.016424136331,
+                    0.,  0.006638670952,    -0.008212068165,
+                    0., -0.006638670952,    -0.008212068165]
+            ).reshape((-1, 3)),
+            "OMP3 REFERENCE CORRECTION ENERGY": -0.003497196377,  # dfocc, tight
+            "OMP3 CORRELATION ENERGY": -0.191533494486,  # dfocc, tight
+            "OMP3 SAME-SPIN CORRELATION ENERGY": -0.038268825438,  # dfocc, tight
+            "OMP3 TOTAL GRADIENT": np.array(  # dfocc, tight
+                  [ 0.,  0.000000000000,     0.016608946514,
+                    0.,  0.006684114421,    -0.008304473257,
+                    0., -0.006684114421,    -0.008304473257]
+            ).reshape((-1, 3)),
+            "OREMP REFERENCE CORRECTION ENERGY": -0.003392270931,  # dfocc, tight
+            "OREMP CORRELATION ENERGY": -0.193345261634,  # dfocc, tight
+            "OREMP TOTAL GRADIENT": np.array(  # dfocc, tight
+              [ 0.,  0.000000000000,     0.018940651737,
+                0.,  0.008076829692,    -0.009470325868,
+                0., -0.008076829692,    -0.009470325868]
+            ).reshape((-1, 3)),
             "OLCCD REFERENCE CORRECTION ENERGY": -0.003391400191,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.197584841222,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.037040959020,  # dfocc, tight
@@ -11396,6 +12648,21 @@ def compute_derived_qcvars(std_suite_list):
         if "FCI CORRELATION ENERGY" in calc["data"]:
             calc["data"]["FCI TOTAL ENERGY"] = calc["data"]["FCI CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
 
+        if "REMP CORRELATION ENERGY" in calc["data"]:
+            calc["data"]["REMP TOTAL ENERGY"] = (
+                calc["data"]["REMP CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
+            )
+            if "REMP SINGLES ENERGY" in calc["data"]:
+                calc["data"]["REMP DOUBLES ENERGY"] = (
+                    calc["data"]["REMP CORRELATION ENERGY"] - calc["data"]["REMP SINGLES ENERGY"]
+                )
+                if "REMP SAME-SPIN CORRELATION ENERGY" in calc["data"]:
+                    calc["data"]["REMP OPPOSITE-SPIN CORRELATION ENERGY"] = (
+                        calc["data"]["REMP CORRELATION ENERGY"]
+                        - calc["data"]["REMP SAME-SPIN CORRELATION ENERGY"]
+                        - calc["data"]["REMP SINGLES ENERGY"]
+                    )
+
         if "LCCD CORRELATION ENERGY" in calc["data"]:
             calc["data"]["LCCD TOTAL ENERGY"] = (
                 calc["data"]["LCCD CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
@@ -11515,6 +12782,78 @@ def compute_derived_qcvars(std_suite_list):
             calc["data"]["CCSDTQ TOTAL ENERGY"] = (
                 calc["data"]["CCSDTQ CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
             )
+
+        if "OMP2 CORRELATION ENERGY" in calc["data"]:
+            if calc["data"]["OMP2 CORRELATION ENERGY"] == _knownmissing:
+                calc["data"]["OMP2 TOTAL ENERGY"] = _knownmissing
+                calc["data"]["OMP2 OPPOSITE-SPIN CORRELATION ENERGY"] = _knownmissing
+            else:
+                calc["data"]["OMP2 TOTAL ENERGY"] = (
+                    calc["data"]["OMP2 CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
+                )
+                if "OMP2 SAME-SPIN CORRELATION ENERGY" in calc["data"]:
+                    if calc["data"]["OMP2 SAME-SPIN CORRELATION ENERGY"] == _knownmissing:
+                        calc["data"]["OMP2 OPPOSITE-SPIN CORRELATION ENERGY"] = _knownmissing
+                    else:
+                        calc["data"]["OMP2 OPPOSITE-SPIN CORRELATION ENERGY"] = (
+                            calc["data"]["OMP2 CORRELATION ENERGY"]
+                            - calc["data"]["OMP2 REFERENCE CORRECTION ENERGY"]
+                            - calc["data"]["OMP2 SAME-SPIN CORRELATION ENERGY"]
+                        )
+
+        if "OMP2.5 CORRELATION ENERGY" in calc["data"]:
+            if calc["data"]["OMP2.5 CORRELATION ENERGY"] == _knownmissing:
+                calc["data"]["OMP2.5 TOTAL ENERGY"] = _knownmissing
+                calc["data"]["OMP2.5 OPPOSITE-SPIN CORRELATION ENERGY"] = _knownmissing
+            else:
+                calc["data"]["OMP2.5 TOTAL ENERGY"] = (
+                    calc["data"]["OMP2.5 CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
+                )
+                if "OMP2.5 SAME-SPIN CORRELATION ENERGY" in calc["data"]:
+                    if calc["data"]["OMP2.5 SAME-SPIN CORRELATION ENERGY"] == _knownmissing:
+                        calc["data"]["OMP2.5 OPPOSITE-SPIN CORRELATION ENERGY"] = _knownmissing
+                    else:
+                        calc["data"]["OMP2.5 OPPOSITE-SPIN CORRELATION ENERGY"] = (
+                            calc["data"]["OMP2.5 CORRELATION ENERGY"]
+                            - calc["data"]["OMP2.5 REFERENCE CORRECTION ENERGY"]
+                            - calc["data"]["OMP2.5 SAME-SPIN CORRELATION ENERGY"]
+                        )
+
+        if "OMP3 CORRELATION ENERGY" in calc["data"]:
+            if calc["data"]["OMP3 CORRELATION ENERGY"] == _knownmissing:
+                calc["data"]["OMP3 TOTAL ENERGY"] = _knownmissing
+                calc["data"]["OMP3 OPPOSITE-SPIN CORRELATION ENERGY"] = _knownmissing
+            else:
+                calc["data"]["OMP3 TOTAL ENERGY"] = (
+                    calc["data"]["OMP3 CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
+                )
+                if "OMP3 SAME-SPIN CORRELATION ENERGY" in calc["data"]:
+                    if calc["data"]["OMP3 SAME-SPIN CORRELATION ENERGY"] == _knownmissing:
+                        calc["data"]["OMP3 OPPOSITE-SPIN CORRELATION ENERGY"] = _knownmissing
+                    else:
+                        calc["data"]["OMP3 OPPOSITE-SPIN CORRELATION ENERGY"] = (
+                            calc["data"]["OMP3 CORRELATION ENERGY"]
+                            - calc["data"]["OMP3 REFERENCE CORRECTION ENERGY"]
+                            - calc["data"]["OMP3 SAME-SPIN CORRELATION ENERGY"]
+                        )
+
+        if "OREMP CORRELATION ENERGY" in calc["data"]:
+            if calc["data"]["OREMP CORRELATION ENERGY"] == _knownmissing:
+                calc["data"]["OREMP TOTAL ENERGY"] = _knownmissing
+                calc["data"]["OREMP OPPOSITE-SPIN CORRELATION ENERGY"] = _knownmissing
+            else:
+                calc["data"]["OREMP TOTAL ENERGY"] = (
+                    calc["data"]["OREMP CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
+                )
+                if "OREMP SAME-SPIN CORRELATION ENERGY" in calc["data"]:
+                    if calc["data"]["OREMP SAME-SPIN CORRELATION ENERGY"] == _knownmissing:
+                        calc["data"]["OREMP OPPOSITE-SPIN CORRELATION ENERGY"] = _knownmissing
+                    else:
+                        calc["data"]["OREMP OPPOSITE-SPIN CORRELATION ENERGY"] = (
+                            calc["data"]["OREMP CORRELATION ENERGY"]
+                            - calc["data"]["OREMP REFERENCE CORRECTION ENERGY"]
+                            - calc["data"]["OREMP SAME-SPIN CORRELATION ENERGY"]
+                        )
 
         if "OLCCD CORRELATION ENERGY" in calc["data"]:
             calc["data"]["OLCCD TOTAL ENERGY"] = (

--- a/qcengine/programs/tests/standard_suite_ref.py
+++ b/qcengine/programs/tests/standard_suite_ref.py
@@ -458,10 +458,10 @@ _hess_scf_nh2_adz_cd_rohf = np.zeros(81).reshape((9, 9))
 #       * "OLCCD TOTAL GRADIENT" in CONV-FC-CONV
 #       * "O(T) CORRECTION ENERGY in CONV-AE-CONV and CONV-FC-CONV
 #       * "A-O(T) CORRECTION ENERGY" in CONV-AE-CONV and CONV-FC-CONV
-#       * "OMP2/OMP2.5/OMP3/OREMP REFERENCE CORRECTION ENERGY" in CONV-FC-CONV for rhf/uhf/rohf
-#       * "OMP2/OMP2.5/OMP3/OREMP CORRELATION ENERGY" in CONV-FC-CONV for rhf/uhf/rohf
-#       * "OMP2/OMP2.5/OMP3/OREMP TOTAL GRADIENT" in CONV-FC-CONV for rhf/uhf/rohf
-#       * "OMP2/OMP2.5/OMP3/OREMP SAME-SPIN CORRELATION ENERGY" in CONV-FC-CONV for uhf/rohf
+#       * "OMP2/OMP2.5/OMP3/OREMP2 REFERENCE CORRECTION ENERGY" in CONV-FC-CONV for rhf/uhf/rohf
+#       * "OMP2/OMP2.5/OMP3/OREMP2 CORRELATION ENERGY" in CONV-FC-CONV for rhf/uhf/rohf
+#       * "OMP2/OMP2.5/OMP3/OREMP2 TOTAL GRADIENT" in CONV-FC-CONV for rhf/uhf/rohf
+#       * "OMP2/OMP2.5/OMP3/OREMP2 SAME-SPIN CORRELATION ENERGY" in CONV-FC-CONV for uhf/rohf
 _knownmissing = "KnownMissing"
 
 _std_suite = [
@@ -512,9 +512,9 @@ _std_suite = [
             "QCISD CORRELATION ENERGY": -0.20892771089382,  # vcc
             "QCISD(T) CORRECTION ENERGY": -0.00182210,  # vcc
             "FCI CORRELATION ENERGY": -0.21117389325,  # detci
-            "REMP CORRELATION ENERGY": -0.20840575987435,  # occ, tight
-            "REMP SINGLES ENERGY": 0.0,
-            "REMP SAME-SPIN CORRELATION ENERGY": -0.04954400816816,  # occ, tight
+            "REMP2 CORRELATION ENERGY": -0.20840575987435,  # occ, tight
+            "REMP2 SINGLES ENERGY": 0.0,
+            "REMP2 SAME-SPIN CORRELATION ENERGY": -0.04954400816816,  # occ, tight
             "LCCD CORRELATION ENERGY": -0.2099060277,  # p4n
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.048339903547,  # fnocc
@@ -700,10 +700,10 @@ _std_suite = [
                 [   0., 0., -0.000007413433,
                     0., 0.,  0.000007413433]
             ).reshape((-1, 3)),
-            "OREMP REFERENCE CORRECTION ENERGY": 0.000553304064,  # occ, tight
-            "OREMP CORRELATION ENERGY": -0.208942935871,  # occ, tight
-            "OREMP SAME-SPIN CORRELATION ENERGY": -0.049683397802,  # occ, tight
-            "OREMP TOTAL GRADIENT": np.array(  # occ, tight
+            "OREMP2 REFERENCE CORRECTION ENERGY": 0.000553304064,  # occ, tight
+            "OREMP2 CORRELATION ENERGY": -0.208942935871,  # occ, tight
+            "OREMP2 SAME-SPIN CORRELATION ENERGY": -0.049683397802,  # occ, tight
+            "OREMP2 TOTAL GRADIENT": np.array(  # occ, tight
               [ 0.,  0.000000000000,     0.002830089047,
                 0.,  0.000000000000,    -0.002830089047]
             ).reshape((-1, 3)),
@@ -878,9 +878,9 @@ _std_suite = [
             "CISD CORRELATION ENERGY": -0.21978965712829,  # vcc
             "QCISD CORRELATION ENERGY": -0.22998871354660,  # vcc
             "QCISD(T) CORRECTION ENERGY": -0.0048836279,  # vcc
-            "REMP CORRELATION ENERGY": -0.229445317607,  # occ, tight
-            "REMP SINGLES ENERGY": 0.0,
-            "REMP SAME-SPIN CORRELATION ENERGY": -0.051382139941,  # occ, tight
+            "REMP2 CORRELATION ENERGY": -0.229445317607,  # occ, tight
+            "REMP2 SINGLES ENERGY": 0.0,
+            "REMP2 SAME-SPIN CORRELATION ENERGY": -0.051382139941,  # occ, tight
             "LCCD CORRELATION ENERGY": -0.2318870702,  # p4n
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.049937236558,  # fnocc
@@ -1549,10 +1549,10 @@ _std_suite = [
                     0.,  0.002953922342,    -0.002401925128,
                     0., -0.002953922342,    -0.002401925128]
             ).reshape((-1, 3)),
-            "OREMP REFERENCE CORRECTION ENERGY": 0.00128167136578,  # occ, tight
-            "OREMP CORRELATION ENERGY": -0.23069139385821,  # occ, tight
-            "OREMP SAME-SPIN CORRELATION ENERGY": -0.05189818473696,  # occ, tight
-            "OREMP TOTAL GRADIENT": np.array(  # occ, tight
+            "OREMP2 REFERENCE CORRECTION ENERGY": 0.00128167136578,  # occ, tight
+            "OREMP2 CORRELATION ENERGY": -0.23069139385821,  # occ, tight
+            "OREMP2 SAME-SPIN CORRELATION ENERGY": -0.05189818473696,  # occ, tight
+            "OREMP2 TOTAL GRADIENT": np.array(  # occ, tight
                [    0., -0.000000000000,     0.009103029917,
                     0.,  0.005405690204,    -0.004551514958,
                     0., -0.005405690204,    -0.004551514958]
@@ -1743,9 +1743,9 @@ _std_suite = [
             "CISD CORRELATION ENERGY": -0.26425382513286,  # vcc
             "QCISD CORRELATION ENERGY": -0.27614913924585,  # vcc
             "QCISD(T) CORRECTION ENERGY": -0.00704158,  # vcc
-            "REMP CORRELATION ENERGY": -0.276444865873,  # occ, tight
-            "REMP SINGLES ENERGY": 0.0,
-            "REMP SAME-SPIN CORRELATION ENERGY": -0.059323770883,  # occ, tight
+            "REMP2 CORRELATION ENERGY": -0.276444865873,  # occ, tight
+            "REMP2 SINGLES ENERGY": 0.0,
+            "REMP2 SAME-SPIN CORRELATION ENERGY": -0.059323770883,  # occ, tight
             "LCCD CORRELATION ENERGY": -0.2786913134,  # p4n
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.057792990490,  # fnocc
@@ -2584,10 +2584,10 @@ _std_suite = [
                     0., -0.004066707268,     0.003074076107,
                     0.,  0.004066707268,     0.003074076107]
             ).reshape((-1, 3)),
-            "OREMP REFERENCE CORRECTION ENERGY": 0.001444328268,  # occ, tight
-            "OREMP CORRELATION ENERGY": -0.277848169449,  # occ, tight
-            "OREMP SAME-SPIN CORRELATION ENERGY": -0.059932090515,  # occ, tight
-            "OREMP TOTAL GRADIENT": np.array(  # occ, tight
+            "OREMP2 REFERENCE CORRECTION ENERGY": 0.001444328268,  # occ, tight
+            "OREMP2 CORRELATION ENERGY": -0.277848169449,  # occ, tight
+            "OREMP2 SAME-SPIN CORRELATION ENERGY": -0.059932090515,  # occ, tight
+            "OREMP2 TOTAL GRADIENT": np.array(  # occ, tight
               [ 0.,  0.000000000000,    -0.001616411571,
                 0., -0.001508635375,     0.000808205786,
                 0.,  0.001508635375,     0.000808205786]
@@ -2863,9 +2863,9 @@ _std_suite = [
             "CISD CORRELATION ENERGY": -0.08014448073265,  # vcc
             "QCISD CORRELATION ENERGY": -0.08218197897917,  # vcc
             "QCISD(T) CORRECTION ENERGY": -0.00062359,  # vcc only
-            "REMP CORRELATION ENERGY": -0.07803997531851,  # occ, tight
-            "REMP SINGLES ENERGY": 0.0,
-            "REMP SAME-SPIN CORRELATION ENERGY": -0.00233934205346,  # occ, tight
+            "REMP2 CORRELATION ENERGY": -0.07803997531851,  # occ, tight
+            "REMP2 SINGLES ENERGY": 0.0,
+            "REMP2 SAME-SPIN CORRELATION ENERGY": -0.00233934205346,  # occ, tight
             "LCCD CORRELATION ENERGY": -0.0834347185,  # p4n
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0024003297,  # occ
@@ -3477,10 +3477,10 @@ _std_suite = [
                     0.,  0.013097750811,    -0.000082223065,
                     0., -0.013097750811,    -0.000082223065]
             ).reshape((-1, 3)),
-            "OREMP REFERENCE CORRECTION ENERGY": 0.001061018532,  # occ, tight
-            "OREMP CORRELATION ENERGY": -0.078996001732,  # occ, tight
-            "OREMP SAME-SPIN CORRELATION ENERGY": -0.002398210306,  # occ, tight
-            "OREMP TOTAL GRADIENT": np.array(  # occ, tight
+            "OREMP2 REFERENCE CORRECTION ENERGY": 0.001061018532,  # occ, tight
+            "OREMP2 CORRELATION ENERGY": -0.078996001732,  # occ, tight
+            "OREMP2 SAME-SPIN CORRELATION ENERGY": -0.002398210306,  # occ, tight
+            "OREMP2 TOTAL GRADIENT": np.array(  # occ, tight
               [ 0.,  0.000000000000,     0.005898073051,
                 0.,  0.000000000000,    -0.005790147152,
                 0.,  0.014384641403,    -0.000053962950,
@@ -3586,9 +3586,9 @@ _std_suite = [
             "CISD CORRELATION ENERGY": -0.16787805277043,  # vcc
             "QCISD CORRELATION ENERGY": -0.17409647936869,  # vcc
             "QCISD(T) CORRECTION ENERGY": -0.00371845,  # vcc only
-            "REMP CORRELATION ENERGY": -0.172501515758,  # occ, tight
-            "REMP SINGLES ENERGY": 0.0,
-            "REMP SAME-SPIN CORRELATION ENERGY": -0.034548274152,  # occ, tight
+            "REMP2 CORRELATION ENERGY": -0.172501515758,  # occ, tight
+            "REMP2 SINGLES ENERGY": 0.0,
+            "REMP2 SAME-SPIN CORRELATION ENERGY": -0.034548274152,  # occ, tight
             "LCCD CORRELATION ENERGY": -0.1770086091,  # p4n
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0341268118,  # occ
@@ -3767,10 +3767,10 @@ _std_suite = [
                     0.,  0.014956911575,    -0.014060103748,
                     0., -0.014956911575,    -0.014060103748]
             ).reshape((-1, 3)),
-            "OREMP REFERENCE CORRECTION ENERGY": 0.00111233720168,  # occ, tight
-            "OREMP CORRELATION ENERGY": -0.17359939909712,  # occ, tight
-            "OREMP SAME-SPIN CORRELATION ENERGY": -0.03496212583967,  # occ, tight
-            "OREMP TOTAL GRADIENT": np.array(  # occ, tight
+            "OREMP2 REFERENCE CORRECTION ENERGY": 0.00111233720168,  # occ, tight
+            "OREMP2 CORRELATION ENERGY": -0.17359939909712,  # occ, tight
+            "OREMP2 SAME-SPIN CORRELATION ENERGY": -0.03496212583967,  # occ, tight
+            "OREMP2 TOTAL GRADIENT": np.array(  # occ, tight
                 [   0.,  0.000000000000,     0.030225286483,
                     0.,  0.016238459426,    -0.015112643242,
                     0., -0.016238459426,    -0.015112643242]
@@ -3871,9 +3871,9 @@ _std_suite = [
             "CISD CORRELATION ENERGY": -0.20576009250440,  # vcc
             "QCISD CORRELATION ENERGY": -0.21351003301667,  # vcc
             "QCISD(T) CORRECTION ENERGY": -0.00505349,  # vcc only
-            "REMP CORRELATION ENERGY": -0.212452538490,  # occ, tight
-            "REMP SINGLES ENERGY": 0.0,
-            "REMP SAME-SPIN CORRELATION ENERGY": -0.040608279810,  # occ, tight
+            "REMP2 CORRELATION ENERGY": -0.212452538490,  # occ, tight
+            "REMP2 SINGLES ENERGY": 0.0,
+            "REMP2 SAME-SPIN CORRELATION ENERGY": -0.040608279810,  # occ, tight
             "LCCD CORRELATION ENERGY": -0.2167878305,  # p4n
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0401306050,  # occ
@@ -4043,10 +4043,10 @@ _std_suite = [
                     0.,  0.006203313670,    -0.007784934417,
                     0., -0.006203313670,    -0.007784934417]
             ).reshape((-1, 3)),
-            "OREMP REFERENCE CORRECTION ENERGY": 0.001287772670,  # occ, tight
-            "OREMP CORRELATION ENERGY": -0.213723933328,  # occ, tight
-            "OREMP SAME-SPIN CORRELATION ENERGY": -0.041063372010,  # occ, tight
-            "OREMP TOTAL GRADIENT": np.array(  # occ, tight
+            "OREMP2 REFERENCE CORRECTION ENERGY": 0.001287772670,  # occ, tight
+            "OREMP2 CORRELATION ENERGY": -0.213723933328,  # occ, tight
+            "OREMP2 SAME-SPIN CORRELATION ENERGY": -0.041063372010,  # occ, tight
+            "OREMP2 TOTAL GRADIENT": np.array(  # occ, tight
               [ 0.,  0.000000000000,     0.017901979677,
                 0.,  0.007592988824,    -0.008950989839,
                 0., -0.007592988824,    -0.008950989839]
@@ -4373,10 +4373,10 @@ _std_suite = [
                     0.,  0.013097750617,    -0.000082223115,
                     0., -0.013097750617,    -0.000082223115]
             ).reshape((-1, 3)),
-            "OREMP REFERENCE CORRECTION ENERGY": -0.000463092111,  # occ, tight
-            "OREMP CORRELATION ENERGY": -0.080520111623,  # occ, tight
-            "OREMP SAME-SPIN CORRELATION ENERGY": -0.002398210414,  # occ, tight
-            "OREMP TOTAL GRADIENT": np.array(  # occ, tight
+            "OREMP2 REFERENCE CORRECTION ENERGY": -0.000463092111,  # occ, tight
+            "OREMP2 CORRELATION ENERGY": -0.080520111623,  # occ, tight
+            "OREMP2 SAME-SPIN CORRELATION ENERGY": -0.002398210414,  # occ, tight
+            "OREMP2 TOTAL GRADIENT": np.array(  # occ, tight
               [ 0.,  0.000000000000,     0.005898074368,
                 0.,  0.000000000000,    -0.005790150595,
                 0.,  0.014384643442,    -0.000053961887,
@@ -4540,10 +4540,10 @@ _std_suite = [
                 0.,  0.014956911348,    -0.014060103648,
                 0., -0.014956911348,    -0.014060103648]
             ).reshape((-1, 3)),
-            "OREMP REFERENCE CORRECTION ENERGY": -0.003301366872,  # occ, tight
-            "OREMP CORRELATION ENERGY": -0.178013102573,  # occ, tight
-            "OREMP SAME-SPIN CORRELATION ENERGY": -0.034962125667,  # occ, tight
-            "OREMP TOTAL GRADIENT": np.array(  # occ, tight
+            "OREMP2 REFERENCE CORRECTION ENERGY": -0.003301366872,  # occ, tight
+            "OREMP2 CORRELATION ENERGY": -0.178013102573,  # occ, tight
+            "OREMP2 SAME-SPIN CORRELATION ENERGY": -0.034962125667,  # occ, tight
+            "OREMP2 TOTAL GRADIENT": np.array(  # occ, tight
               [ 0.,  0.000000000000,     0.030225286965,
                 0.,  0.016238460656,    -0.015112643483,
                 0., -0.016238460656,    -0.015112643483]
@@ -4701,10 +4701,10 @@ _std_suite = [
                     0.,  0.006203313291,    -0.007784933717,
                     0., -0.006203313291,    -0.007784933717]
             ).reshape((-1, 3)),
-            "OREMP REFERENCE CORRECTION ENERGY": -0.003321935448,  # occ, tight
-            "OREMP CORRELATION ENERGY": -0.218333639848,  # occ, tight
-            "OREMP SAME-SPIN CORRELATION ENERGY": -0.041063372384,  # occ, tight
-            "OREMP TOTAL GRADIENT": np.array(  # occ, tight
+            "OREMP2 REFERENCE CORRECTION ENERGY": -0.003321935448,  # occ, tight
+            "OREMP2 CORRELATION ENERGY": -0.218333639848,  # occ, tight
+            "OREMP2 SAME-SPIN CORRELATION ENERGY": -0.041063372384,  # occ, tight
+            "OREMP2 TOTAL GRADIENT": np.array(  # occ, tight
               [ 0.,  0.000000000000,     0.017901994172,
                 0.,  0.007592995571,    -0.008950997086,
                 0., -0.007592995571,    -0.008950997086]
@@ -4801,9 +4801,9 @@ _std_suite = [
             "QCISD CORRELATION ENERGY": -0.20699674383631,  # vcc
             "QCISD(T) CORRECTION ENERGY": -0.00180789,  # vcc
             "FCI CORRELATION ENERGY": -0.2092292951,  # detci
-            "REMP CORRELATION ENERGY": -0.20642733451785,  # occ, tight
-            "REMP SINGLES ENERGY": 0.0,
-            "REMP SAME-SPIN CORRELATION ENERGY": -0.04882718129882,  # occ, tight
+            "REMP2 CORRELATION ENERGY": -0.20642733451785,  # occ, tight
+            "REMP2 SINGLES ENERGY": 0.0,
+            "REMP2 SAME-SPIN CORRELATION ENERGY": -0.04882718129882,  # occ, tight
             "LCCD CORRELATION ENERGY": -0.2079585027,  # p4n
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.047635656759,  # fnocc
@@ -4924,9 +4924,9 @@ _std_suite = [
             "OMP3 REFERENCE CORRECTION ENERGY": _knownmissing,
             "OMP3 CORRELATION ENERGY": _knownmissing,
             "OMP3 TOTAL GRADIENT": _knownmissing,
-            "OREMP REFERENCE CORRECTION ENERGY": _knownmissing,
-            "OREMP CORRELATION ENERGY": _knownmissing,
-            "OREMP TOTAL GRADIENT": _knownmissing,
+            "OREMP2 REFERENCE CORRECTION ENERGY": _knownmissing,
+            "OREMP2 CORRELATION ENERGY": _knownmissing,
+            "OREMP2 TOTAL GRADIENT": _knownmissing,
             "OLCCD REFERENCE CORRECTION ENERGY": 0.0005535161,  # p4n (core-occ rotations neglected)
             "OLCCD CORRELATION ENERGY": -0.2086206237,  # p4n (core-occ rotations neglected)
             "OLCCD TOTAL GRADIENT": _knownmissing,
@@ -5084,9 +5084,9 @@ _std_suite = [
             "CISD CORRELATION ENERGY": -0.21764746560900,  # vcc
             "QCISD CORRELATION ENERGY": -0.22775040212176,  # vcc
             "QCISD(T) CORRECTION ENERGY": -0.00485806,  # vcc
-            "REMP CORRELATION ENERGY": -0.227138458433,  # occ, tight
-            "REMP SINGLES ENERGY": 0.0,
-            "REMP SAME-SPIN CORRELATION ENERGY": -0.050586597452,  # occ, tight
+            "REMP2 CORRELATION ENERGY": -0.227138458433,  # occ, tight
+            "REMP2 SINGLES ENERGY": 0.0,
+            "REMP2 SAME-SPIN CORRELATION ENERGY": -0.050586597452,  # occ, tight
             "LCCD CORRELATION ENERGY": -0.2296135965,  # p4n
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.049154543318,  # fnocc
@@ -5442,9 +5442,9 @@ _std_suite = [
             "OMP3 REFERENCE CORRECTION ENERGY": _knownmissing,
             "OMP3 CORRELATION ENERGY": _knownmissing,
             "OMP3 TOTAL GRADIENT": _knownmissing,
-            "OREMP REFERENCE CORRECTION ENERGY": _knownmissing,
-            "OREMP CORRELATION ENERGY": _knownmissing,
-            "OREMP TOTAL GRADIENT": _knownmissing,
+            "OREMP2 REFERENCE CORRECTION ENERGY": _knownmissing,
+            "OREMP2 CORRELATION ENERGY": _knownmissing,
+            "OREMP2 TOTAL GRADIENT": _knownmissing,
             "OLCCD REFERENCE CORRECTION ENERGY": 0.0011942797,  # p4n (core-occ rotations neglected)
             "OLCCD CORRELATION ENERGY": -0.2309009256,  # p4n (core-occ rotations neglected)
             "OLCCD TOTAL GRADIENT": _knownmissing,
@@ -5602,9 +5602,9 @@ _std_suite = [
             "CISD CORRELATION ENERGY": -0.24016600239402,  # vcc
             "QCISD CORRELATION ENERGY": -0.25077731041751,  # vcc
             "QCISD(T) CORRECTION ENERGY": -0.00687323,  # vcc
-            "REMP CORRELATION ENERGY": -0.251018009939,  # occ, tight
-            "REMP SINGLES ENERGY": 0.0,
-            "REMP SAME-SPIN CORRELATION ENERGY": -0.055360085349,  # occ, tight
+            "REMP2 CORRELATION ENERGY": -0.251018009939,  # occ, tight
+            "REMP2 SINGLES ENERGY": 0.0,
+            "REMP2 SAME-SPIN CORRELATION ENERGY": -0.055360085349,  # occ, tight
             "LCCD CORRELATION ENERGY": -0.2531942099,  # p4n
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.053842594884,  # fnocc
@@ -6196,9 +6196,9 @@ _std_suite = [
             "OMP3 REFERENCE CORRECTION ENERGY": _knownmissing,
             "OMP3 CORRELATION ENERGY": _knownmissing,
             "OMP3 TOTAL GRADIENT": _knownmissing,
-            "OREMP REFERENCE CORRECTION ENERGY": _knownmissing,
-            "OREMP CORRELATION ENERGY": _knownmissing,
-            "OREMP TOTAL GRADIENT": _knownmissing,
+            "OREMP2 REFERENCE CORRECTION ENERGY": _knownmissing,
+            "OREMP2 CORRELATION ENERGY": _knownmissing,
+            "OREMP2 TOTAL GRADIENT": _knownmissing,
             "OLCCD REFERENCE CORRECTION ENERGY": 0.0012982937,  # p4n (core-occ rotations neglected)
             "OLCCD CORRELATION ENERGY": -0.2544819317,  # p4n (core-occ rotations neglected)
             "OLCCD TOTAL GRADIENT": _knownmissing,
@@ -6442,9 +6442,9 @@ _std_suite = [
             "CISD CORRELATION ENERGY": -0.07917581082828,  # vcc
             "QCISD CORRELATION ENERGY": -0.08117897504733,  # vcc
             "QCISD(T) CORRECTION ENERGY": -0.00060269,  # vcc only
-            "REMP CORRELATION ENERGY": -0.07701467620060,  # occ, tight
-            "REMP SINGLES ENERGY": 0.0,
-            "REMP SAME-SPIN CORRELATION ENERGY": -0.00219044944957,  # occ. tight
+            "REMP2 CORRELATION ENERGY": -0.07701467620060,  # occ, tight
+            "REMP2 SINGLES ENERGY": 0.0,
+            "REMP2 SAME-SPIN CORRELATION ENERGY": -0.00219044944957,  # occ. tight
             "LCCD CORRELATION ENERGY": -0.0824313452,  # p4n
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0022532590,  # occ
@@ -6869,10 +6869,10 @@ _std_suite = [
             "OMP3 CORRELATION ENERGY": _knownmissing,
             "OMP3 SAME-SPIN CORRELATION ENERGY": _knownmissing,
             "OMP3 TOTAL GRADIENT": _knownmissing,
-            "OREMP REFERENCE CORRECTION ENERGY": _knownmissing,
-            "OREMP CORRELATION ENERGY": _knownmissing,
-            "OREMP SAME-SPIN CORRELATION ENERGY": _knownmissing,
-            "OREMP TOTAL GRADIENT": _knownmissing,
+            "OREMP2 REFERENCE CORRECTION ENERGY": _knownmissing,
+            "OREMP2 CORRELATION ENERGY": _knownmissing,
+            "OREMP2 SAME-SPIN CORRELATION ENERGY": _knownmissing,
+            "OREMP2 TOTAL GRADIENT": _knownmissing,
             "OLCCD REFERENCE CORRECTION ENERGY": 0.0014923056,  # p4n (core-occ rotations neglected)
             "OLCCD CORRELATION ENERGY": -0.0839163095,  # p4n (core-occ rotations neglected)
             "OLCCD SAME-SPIN CORRELATION ENERGY": _knownmissing,
@@ -6941,9 +6941,9 @@ _std_suite = [
             "CISD CORRELATION ENERGY": -0.16574719763576,  # vcc
             "QCISD CORRELATION ENERGY": -0.17187325792329,  # vcc
             "QCISD(T) CORRECTION ENERGY": -0.00368626,  # vcc only
-            "REMP CORRELATION ENERGY": -0.170214503998,  # occ, tight
-            "REMP SINGLES ENERGY": 0.0,
-            "REMP SAME-SPIN CORRELATION ENERGY": -0.033849141454,  # occ, tight
+            "REMP2 CORRELATION ENERGY": -0.170214503998,  # occ, tight
+            "REMP2 SINGLES ENERGY": 0.0,
+            "REMP2 SAME-SPIN CORRELATION ENERGY": -0.033849141454,  # occ, tight
             "LCCD CORRELATION ENERGY": -0.1747537294,  # p4n
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0334378864,  # occ
@@ -7127,10 +7127,10 @@ _std_suite = [
             "OMP3 CORRELATION ENERGY": _knownmissing,
             "OMP3 SAME-SPIN CORRELATION ENERGY": _knownmissing,
             "OMP3 TOTAL GRADIENT": _knownmissing,
-            "OREMP REFERENCE CORRECTION ENERGY": _knownmissing,
-            "OREMP CORRELATION ENERGY": _knownmissing,
-            "OREMP SAME-SPIN CORRELATION ENERGY": _knownmissing,
-            "OREMP TOTAL GRADIENT": _knownmissing,
+            "OREMP2 REFERENCE CORRECTION ENERGY": _knownmissing,
+            "OREMP2 CORRELATION ENERGY": _knownmissing,
+            "OREMP2 SAME-SPIN CORRELATION ENERGY": _knownmissing,
+            "OREMP2 TOTAL GRADIENT": _knownmissing,
             "OLCCD REFERENCE CORRECTION ENERGY": 0.0011137749,  # p4n (core-occ rotations neglected)
             "OLCCD CORRELATION ENERGY": -0.1759973931,  # p4n (core-occ rotations neglected)
             "OLCCD SAME-SPIN CORRELATION ENERGY": _knownmissing,
@@ -7199,9 +7199,9 @@ _std_suite = [
             "CISD CORRELATION ENERGY": -0.18202095532782,  # vcc
             "QCISD CORRELATION ENERGY": -0.18852342173162,  # vcc
             "QCISD(T) CORRECTION ENERGY": -0.00487511,  # vcc only
-            "REMP CORRELATION ENERGY": -0.187474026696,  # occ, tight
-            "REMP SINGLES ENERGY": 0.0,
-            "REMP SAME-SPIN CORRELATION ENERGY": -0.037232180981,  # occ, tight
+            "REMP2 CORRELATION ENERGY": -0.187474026696,  # occ, tight
+            "REMP2 SINGLES ENERGY": 0.0,
+            "REMP2 SAME-SPIN CORRELATION ENERGY": -0.037232180981,  # occ, tight
             "LCCD CORRELATION ENERGY": -0.1917024115,  # p4n
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0367596656,  # occ
@@ -7346,10 +7346,10 @@ _std_suite = [
             "OMP3 CORRELATION ENERGY": _knownmissing,
             "OMP3 SAME-SPIN CORRELATION ENERGY": _knownmissing,
             "OMP3 TOTAL GRADIENT": _knownmissing,
-            "OREMP REFERENCE CORRECTION ENERGY": _knownmissing,
-            "OREMP CORRELATION ENERGY": _knownmissing,
-            "OREMP SAME-SPIN CORRELATION ENERGY": _knownmissing,
-            "OREMP TOTAL GRADIENT": _knownmissing,
+            "OREMP2 REFERENCE CORRECTION ENERGY": _knownmissing,
+            "OREMP2 CORRELATION ENERGY": _knownmissing,
+            "OREMP2 SAME-SPIN CORRELATION ENERGY": _knownmissing,
+            "OREMP2 TOTAL GRADIENT": _knownmissing,
             "OLCCD REFERENCE CORRECTION ENERGY": 0.0012186690,  # p4n (core-occ rotations neglected)
             "OLCCD CORRELATION ENERGY": -0.1929863522,  # p4n (core-occ rotations neglected)
             "OLCCD SAME-SPIN CORRELATION ENERGY": _knownmissing,
@@ -7620,10 +7620,10 @@ _std_suite = [
             "OMP3 CORRELATION ENERGY": _knownmissing,
             "OMP3 SAME-SPIN CORRELATION ENERGY": _knownmissing,
             "OMP3 TOTAL GRADIENT": _knownmissing,
-            "OREMP REFERENCE CORRECTION ENERGY": _knownmissing,
-            "OREMP CORRELATION ENERGY": _knownmissing,
-            "OREMP SAME-SPIN CORRELATION ENERGY": _knownmissing,
-            "OREMP TOTAL GRADIENT": _knownmissing,
+            "OREMP2 REFERENCE CORRECTION ENERGY": _knownmissing,
+            "OREMP2 CORRELATION ENERGY": _knownmissing,
+            "OREMP2 SAME-SPIN CORRELATION ENERGY": _knownmissing,
+            "OREMP2 TOTAL GRADIENT": _knownmissing,
             "OLCCD REFERENCE CORRECTION ENERGY": -0.0000318047,  # p4n (core-occ rotations neglected)
             "OLCCD CORRELATION ENERGY": -0.0854404197,  # p4n (core-occ rotations neglected)
             "OLCCD SAME-SPIN CORRELATION ENERGY": _knownmissing,
@@ -7726,10 +7726,10 @@ _std_suite = [
             "OMP3 CORRELATION ENERGY": _knownmissing,
             "OMP3 SAME-SPIN CORRELATION ENERGY": _knownmissing,
             "OMP3 TOTAL GRADIENT": _knownmissing,
-            "OREMP REFERENCE CORRECTION ENERGY": _knownmissing,
-            "OREMP CORRELATION ENERGY": _knownmissing,
-            "OREMP SAME-SPIN CORRELATION ENERGY": _knownmissing,
-            "OREMP TOTAL GRADIENT": _knownmissing,
+            "OREMP2 REFERENCE CORRECTION ENERGY": _knownmissing,
+            "OREMP2 CORRELATION ENERGY": _knownmissing,
+            "OREMP2 SAME-SPIN CORRELATION ENERGY": _knownmissing,
+            "OREMP2 TOTAL GRADIENT": _knownmissing,
             "OLCCD REFERENCE CORRECTION ENERGY": -0.0032999290,  # p4n (core-occ rotations neglected)
             "OLCCD CORRELATION ENERGY": -0.1804110970,  # p4n (core-occ rotations neglected)
             "OLCCD SAME-SPIN CORRELATION ENERGY": _knownmissing,
@@ -7835,10 +7835,10 @@ _std_suite = [
             "OMP3 CORRELATION ENERGY": _knownmissing,
             "OMP3 SAME-SPIN CORRELATION ENERGY": _knownmissing,
             "OMP3 TOTAL GRADIENT": _knownmissing,
-            "OREMP REFERENCE CORRECTION ENERGY": _knownmissing,
-            "OREMP CORRELATION ENERGY": _knownmissing,
-            "OREMP SAME-SPIN CORRELATION ENERGY": _knownmissing,
-            "OREMP TOTAL GRADIENT": _knownmissing,
+            "OREMP2 REFERENCE CORRECTION ENERGY": _knownmissing,
+            "OREMP2 CORRELATION ENERGY": _knownmissing,
+            "OREMP2 SAME-SPIN CORRELATION ENERGY": _knownmissing,
+            "OREMP2 TOTAL GRADIENT": _knownmissing,
             "OLCCD REFERENCE CORRECTION ENERGY": -0.0033910391,  # p4n (core-occ rotations neglected)
             "OLCCD CORRELATION ENERGY": -0.1975960603,  # p4n (core-occ rotations neglected)
             "OLCCD SAME-SPIN CORRELATION ENERGY": _knownmissing,
@@ -8830,8 +8830,8 @@ _std_suite = [
                 # dfocc findif-5
                 [ 0., 0., -0.000926981449, 0., 0., 0.000926981449]
             ).reshape((-1, 3)),
-            "REMP CORRELATION ENERGY": -0.208401248910,  # dfocc, tight
-            "REMP SINGLES ENERGY": 0.0,
+            "REMP2 CORRELATION ENERGY": -0.208401248910,  # dfocc, tight
+            "REMP2 SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.20990226,  # dfocc
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD TOTAL GRADIENT": np.array(
@@ -8849,8 +8849,8 @@ _std_suite = [
             "OMP2.5 CORRELATION ENERGY": -0.205680612213,  # dfocc, tight
             "OMP3 REFERENCE CORRECTION ENERGY": 0.000467209128,  # dfocc, tight
             "OMP3 CORRELATION ENERGY": -0.206931341471,  # dfocc, tight
-            "OREMP REFERENCE CORRECTION ENERGY": 0.000553277131,  # dfocc, tight
-            "OREMP CORRELATION ENERGY": -0.208938401219,  # dfocc, tight
+            "OREMP2 REFERENCE CORRECTION ENERGY": 0.000553277131,  # dfocc, tight
+            "OREMP2 CORRELATION ENERGY": -0.208938401219,  # dfocc, tight
             "OLCCD REFERENCE CORRECTION ENERGY": 0.000552265186,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.210437984945,  # dfocc, tight
             "OCCD REFERENCE CORRECTION ENERGY": 0.000511278480,  # dfocc, tight
@@ -8892,8 +8892,8 @@ _std_suite = [
             ).reshape((-1, 3)),
             "MP3 CORRELATION ENERGY": -0.22643303,  # dfocc
             "MP3 SINGLES ENERGY": 0.0,
-            "REMP CORRELATION ENERGY": -0.229445833755,  # dfocc, tight
-            "REMP SINGLES ENERGY": 0.0,
+            "REMP2 CORRELATION ENERGY": -0.229445833755,  # dfocc, tight
+            "REMP2 SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.23188949,  # dfocc
             "LCCD SINGLES ENERGY": 0.0000000000,
             "CCSD CORRELATION ENERGY": -0.22941289840818,  # dfocc, tight
@@ -8907,8 +8907,8 @@ _std_suite = [
             "OMP2.5 CORRELATION ENERGY": -0.225648131745,  # dfocc, tight
             "OMP3 REFERENCE CORRECTION ENERGY": 0.000953721118,  # dfocc, tight
             "OMP3 CORRELATION ENERGY": -0.227374133013,  # dfocc, tight
-            "OREMP REFERENCE CORRECTION ENERGY": 0.00128180471179,  # dfocc, tight
-            "OREMP CORRELATION ENERGY": -0.23069205056701,  # dfocc, right
+            "OREMP2 REFERENCE CORRECTION ENERGY": 0.00128180471179,  # dfocc, tight
+            "OREMP2 CORRELATION ENERGY": -0.23069205056701,  # dfocc, right
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001189623873,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.233047836839,  # dfocc, tight
             "OCCD REFERENCE CORRECTION ENERGY": 0.001124461842,  # dfocc, tight
@@ -8950,8 +8950,8 @@ _std_suite = [
             ).reshape((-1, 3)),
             "MP3 CORRELATION ENERGY": -0.27294416,  # dfocc
             "MP3 SINGLES ENERGY": 0.0,
-            "REMP CORRELATION ENERGY": -0.276442808601,  # dfocc, tight
-            "REMP SINGLES ENERGY": 0.0,
+            "REMP2 CORRELATION ENERGY": -0.276442808601,  # dfocc, tight
+            "REMP2 SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.27869015,  # dfocc
             "LCCD SINGLES ENERGY": 0.0000000000,
             "CCSD CORRELATION ENERGY": -0.27570421327166,  # dfocc, tight
@@ -8965,8 +8965,8 @@ _std_suite = [
             "OMP2.5 CORRELATION ENERGY": -0.273207190194,  # dfocc, tight
             "OMP3 REFERENCE CORRECTION ENERGY": 0.001090092456,  # dfocc, tight
             "OMP3 CORRELATION ENERGY": -0.274014744975,  # dfocc, tight
-            "OREMP REFERENCE CORRECTION ENERGY": 0.001444318022,  # dfocc, tight
-            "OREMP CORRELATION ENERGY": -0.277846110170,  # dfocc, tight
+            "OREMP2 REFERENCE CORRECTION ENERGY": 0.001444318022,  # dfocc, tight
+            "OREMP2 CORRELATION ENERGY": -0.277846110170,  # dfocc, tight
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001352168423,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.280004165823,  # dfocc, tight
             "OCCD REFERENCE CORRECTION ENERGY": 0.001279252698,  # dfocc, tight
@@ -9028,9 +9028,9 @@ _std_suite = [
                     -0.00011515114,
                 ]
             ).reshape((-1, 3)),
-            "REMP CORRELATION ENERGY": -0.078034068730,  # dfocc, tight
-            "REMP SINGLES ENERGY": 0.0,
-            "REMP SAME-SPIN CORRELATION ENERGY": -0.002339588819,  # dfocc, tight
+            "REMP2 CORRELATION ENERGY": -0.078034068730,  # dfocc, tight
+            "REMP2 SINGLES ENERGY": 0.0,
+            "REMP2 SAME-SPIN CORRELATION ENERGY": -0.002339588819,  # dfocc, tight
             "LCCD CORRELATION ENERGY": -0.08343038,  # dfocc
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.00240059,  # dfocc
@@ -9063,8 +9063,8 @@ _std_suite = [
             "OMP3 REFERENCE CORRECTION ENERGY": 0.000777636403,  # dfocc, tight
             "OMP3 CORRELATION ENERGY": -0.075525183445,  # dfocc, tight
             "OMP3 SAME-SPIN CORRELATION ENERGY": -0.002426255771,  # dfocc, tight
-            "OREMP REFERENCE CORRECTION ENERGY": 0.001061022340,  # dfocc, tight
-            "OREMP CORRELATION ENERGY": -0.078990084532,  # dfocc, tight
+            "OREMP2 REFERENCE CORRECTION ENERGY": 0.001061022340,  # dfocc, tight
+            "OREMP2 CORRELATION ENERGY": -0.078990084532,  # dfocc, tight
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001484257667,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.084737023607,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.002448903277,  # dfocc, tight
@@ -9107,9 +9107,9 @@ _std_suite = [
             "MP3 CORRELATION ENERGY": -0.17091879,  # dfocc
             "MP3 SINGLES ENERGY": 0.0,
             "MP3 SAME-SPIN CORRELATION ENERGY": -0.03533750,  # dfocc
-            "REMP CORRELATION ENERGY": -0.172502759037,  # dfocc, tight
-            "REMP SINGLES ENERGY": 0.0,
-            "REMP SAME-SPIN CORRELATION ENERGY": -0.034552222422,  # dfocc, tight
+            "REMP2 CORRELATION ENERGY": -0.172502759037,  # dfocc, tight
+            "REMP2 SINGLES ENERGY": 0.0,
+            "REMP2 SAME-SPIN CORRELATION ENERGY": -0.034552222422,  # dfocc, tight
             "LCCD CORRELATION ENERGY": -0.17701192,  # dfocc
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.03413070,  # dfocc
@@ -9126,8 +9126,8 @@ _std_suite = [
             "OMP3 REFERENCE CORRECTION ENERGY": 0.001024364167,  # dfocc, tight
             "OMP3 CORRELATION ENERGY": -0.171935686596,  # dfocc, tight
             "OMP3 SAME-SPIN CORRELATION ENERGY": -0.035751323781,  # dfocc, tight
-            "OREMP REFERENCE CORRECTION ENERGY": 0.00111244830766,  # dfocc, tight
-            "OREMP CORRELATION ENERGY": -0.17360075617488,  # dfocc, tight
+            "OREMP2 REFERENCE CORRECTION ENERGY": 0.00111244830766,  # dfocc, tight
+            "OREMP2 CORRELATION ENERGY": -0.17360075617488,  # dfocc, tight
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001111961826,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.178109192111,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.034472712167,  # dfocc, tight
@@ -9170,9 +9170,9 @@ _std_suite = [
             "MP3 CORRELATION ENERGY": -0.21084618,  # dfocc
             "MP3 SINGLES ENERGY": 0.0,
             "MP3 SAME-SPIN CORRELATION ENERGY": -0.04130830,  # dfocc
-            "REMP CORRELATION ENERGY": -0.212450972170,  # dfocc, tight
-            "REMP SINGLES ENERGY": 0.0,
-            "REMP SAME-SPIN CORRELATION ENERGY": -0.040612908150,  # dfocc, tight
+            "REMP2 CORRELATION ENERGY": -0.212450972170,  # dfocc, tight
+            "REMP2 SINGLES ENERGY": 0.0,
+            "REMP2 SAME-SPIN CORRELATION ENERGY": -0.040612908150,  # dfocc, tight
             "LCCD CORRELATION ENERGY": -0.21678706,  # dfocc
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.04013515,  # dfocc
@@ -9189,8 +9189,8 @@ _std_suite = [
             "OMP3 REFERENCE CORRECTION ENERGY": 0.001177850332,  # dfocc, tight
             "OMP3 CORRELATION ENERGY": -0.212014665319,  # dfocc, tight
             "OMP3 SAME-SPIN CORRELATION ENERGY": -0.041748214104,  # dfocc, tight
-            "OREMP REFERENCE CORRECTION ENERGY": 0.001287828667,  # dfocc, tight
-            "OREMP CORRELATION ENERGY": -0.213722428382,  # dfocc, tight
+            "OREMP2 REFERENCE CORRECTION ENERGY": 0.001287828667,  # dfocc, tight
+            "OREMP2 CORRELATION ENERGY": -0.213722428382,  # dfocc, tight
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001285760689,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.218055380962,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.040516816950,  # dfocc, tight
@@ -9230,8 +9230,8 @@ _std_suite = [
             "OMP3 REFERENCE CORRECTION ENERGY": -0.000746026622,  # dfocc, tight
             "OMP3 CORRELATION ENERGY": -0.077048846889,  # dfocc, tight
             "OMP3 SAME-SPIN CORRELATION ENERGY": -0.002426255644,  # dfocc, tight
-            "OREMP REFERENCE CORRECTION ENERGY": -0.000462639536,  # dfocc, tight
-            "OREMP CORRELATION ENERGY": -0.080513747976,  # dfocc, tight
+            "OREMP2 REFERENCE CORRECTION ENERGY": -0.000462639536,  # dfocc, tight
+            "OREMP2 CORRELATION ENERGY": -0.080513747976,  # dfocc, tight
             "OLCCD REFERENCE CORRECTION ENERGY": -0.000039411002,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.086260687051,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.002448904007,  # dfocc, tight
@@ -9280,8 +9280,8 @@ _std_suite = [
             "OMP3 REFERENCE CORRECTION ENERGY": -0.003389139644,  # dfocc, tight
             "OMP3 CORRELATION ENERGY": -0.176349187568,  # dfocc, tight
             "OMP3 SAME-SPIN CORRELATION ENERGY": -0.035751323194,  # dfocc, tight
-            "OREMP REFERENCE CORRECTION ENERGY": -0.003301052810,  # dfocc, tight
-            "OREMP CORRELATION ENERGY": -0.178014257147,  # dfocc, tight
+            "OREMP2 REFERENCE CORRECTION ENERGY": -0.003301052810,  # dfocc, tight
+            "OREMP2 CORRELATION ENERGY": -0.178014257147,  # dfocc, tight
             "OLCCD REFERENCE CORRECTION ENERGY": -0.003301541633,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.182522693083,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.034472708888,  # dfocc, tight
@@ -9330,8 +9330,8 @@ _std_suite = [
             "OMP3 REFERENCE CORRECTION ENERGY": -0.003431885897,  # dfocc, tight
             "OMP3 CORRELATION ENERGY": -0.216624397975,  # dfocc, tight
             "OMP3 SAME-SPIN CORRELATION ENERGY": -0.041748214168,  # dfocc, tight
-            "OREMP REFERENCE CORRECTION ENERGY": -0.003321905366,  # dfocc, tight
-            "OREMP CORRELATION ENERGY": -0.218332161038,  # dfocc, tight
+            "OREMP2 REFERENCE CORRECTION ENERGY": -0.003321905366,  # dfocc, tight
+            "OREMP2 CORRELATION ENERGY": -0.218332161038,  # dfocc, tight
             "OLCCD REFERENCE CORRECTION ENERGY": -0.003323981369,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.222665113625,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.040516826809,  # dfocc, tight
@@ -9369,8 +9369,8 @@ _std_suite = [
                 # dfocc findif-5 fc cd+cd
                 [ 0., 0., -0.000588974421, 0., 0., 0.000588974421]
             ).reshape((-1, 3)),
-            "REMP CORRELATION ENERGY": -0.206423120122,  # dfocc, tight
-            "REMP SINGLES ENERGY": 0.0,
+            "REMP2 CORRELATION ENERGY": -0.206423120122,  # dfocc, tight
+            "REMP2 SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.20795503,  # dfocc
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD TOTAL GRADIENT": np.array(
@@ -9388,8 +9388,8 @@ _std_suite = [
             "OMP2.5 CORRELATION ENERGY": -0.203698037577,  # dfocc, tight
             "OMP3 REFERENCE CORRECTION ENERGY": 0.000468982166,  # dfocc, tight
             "OMP3 CORRELATION ENERGY": -0.205112639670,  # dfocc, tight
-            "OREMP REFERENCE CORRECTION ENERGY": 0.000554016472,  # dfocc, tight
-            "OREMP CORRELATION ENERGY": -0.207066289816,  # dfocc, tight
+            "OREMP2 REFERENCE CORRECTION ENERGY": 0.000554016472,  # dfocc, tight
+            "OREMP2 CORRELATION ENERGY": -0.207066289816,  # dfocc, tight
             "OLCCD REFERENCE CORRECTION ENERGY": 0.000553491444,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.208617145287,  # dfocc, tight
             "OCCD REFERENCE CORRECTION ENERGY": 0.000511777936,  # dfocc, tight
@@ -9431,8 +9431,8 @@ _std_suite = [
             ).reshape((-1, 3)),
             "MP3 CORRELATION ENERGY": -0.22415794,  # dfocc
             "MP3 SINGLES ENERGY": 0.0,
-            "REMP CORRELATION ENERGY": -0.227139386881,  # dfocc, tight
-            "REMP SINGLES ENERGY": 0.0,
+            "REMP2 CORRELATION ENERGY": -0.227139386881,  # dfocc, tight
+            "REMP2 SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.22961642,  # dfocc
             "LCCD SINGLES ENERGY": 0.0000000000,
             "CCSD CORRELATION ENERGY": -0.22717606848165,  # dfocc, tight
@@ -9446,8 +9446,8 @@ _std_suite = [
             "OMP2.5 CORRELATION ENERGY": -0.223336430535,  # dfocc, tight
             "OMP3 REFERENCE CORRECTION ENERGY": 0.000960343766,  # dfocc, tight
             "OMP3 CORRELATION ENERGY": -0.225227488953,  # dfocc, tight
-            "OREMP REFERENCE CORRECTION ENERGY": 0.00128588799768,  # dfocc, tight
-            "OREMP CORRELATION ENERGY": -0.22849477192663,  # dfocc, tight
+            "OREMP2 REFERENCE CORRECTION ENERGY": 0.00128588799768,  # dfocc, tight
+            "OREMP2 CORRELATION ENERGY": -0.22849477192663,  # dfocc, tight
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001194389384,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.230903883683,  # dfocc, tight
             "OCCD REFERENCE CORRECTION ENERGY": 0.001127721989,  # dfocc, tight
@@ -9489,8 +9489,8 @@ _std_suite = [
             ).reshape((-1, 3)),
             "MP3 CORRELATION ENERGY": -0.24747710,  # dfocc
             "MP3 SINGLES ENERGY": 0.0,
-            "REMP CORRELATION ENERGY": -0.251016068140,  # dfocc, tight
-            "REMP SINGLES ENERGY": 0.0,
+            "REMP2 CORRELATION ENERGY": -0.251016068140,  # dfocc, tight
+            "REMP2 SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.25319315,  # dfocc
             "LCCD SINGLES ENERGY": 0.0000000000,
             "CCSD CORRELATION ENERGY": -0.25032938698805,  # dfocc, tight
@@ -9504,8 +9504,8 @@ _std_suite = [
             "OMP2.5 CORRELATION ENERGY": -0.247905627376,  # dfocc, tight
             "OMP3 REFERENCE CORRECTION ENERGY": 0.001042085727,  # dfocc, tight
             "OMP3 CORRELATION ENERGY": -0.248525576959,  # dfocc, tight
-            "OREMP REFERENCE CORRECTION ENERGY": 0.001387317415,  # dfocc, tight
-            "OREMP CORRELATION ENERGY": -0.252381884524,  # dfocc, tight
+            "OREMP2 REFERENCE CORRECTION ENERGY": 0.001387317415,  # dfocc, tight
+            "OREMP2 CORRELATION ENERGY": -0.252381884524,  # dfocc, tight
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001298302400,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.254480886451,  # dfocc, tight
             "OCCD REFERENCE CORRECTION ENERGY": 0.001226900919,  # dfocc, tight
@@ -9567,9 +9567,9 @@ _std_suite = [
                     -0.000121632922,
                 ]
             ).reshape((-1, 3)),
-            "REMP CORRELATION ENERGY": -0.077009033372,  # dfocc, tight
-            "REMP SINGLES ENERGY": 0.0,
-            "REMP SAME-SPIN CORRELATION ENERGY": -0.002190684009,  # dfocc, tight
+            "REMP2 CORRELATION ENERGY": -0.077009033372,  # dfocc, tight
+            "REMP2 SINGLES ENERGY": 0.0,
+            "REMP2 SAME-SPIN CORRELATION ENERGY": -0.002190684009,  # dfocc, tight
             "LCCD CORRELATION ENERGY": -0.08242726,  # dfocc
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.00225350,  # dfocc
@@ -9602,8 +9602,8 @@ _std_suite = [
             "OMP3 REFERENCE CORRECTION ENERGY": 0.000780607023,  # dfocc, tight
             "OMP3 CORRELATION ENERGY": -0.074661038269,  # dfocc, tight
             "OMP3 SAME-SPIN CORRELATION ENERGY": -0.002276029266,  # dfocc, tight
-            "OREMP REFERENCE CORRECTION ENERGY": 0.001065407270,  # dfocc, tight
-            "OREMP CORRELATION ENERGY": -0.078143718483,  # dfocc, tight
+            "OREMP2 REFERENCE CORRECTION ENERGY": 0.001065407270,  # dfocc, tight
+            "OREMP2 CORRELATION ENERGY": -0.078143718483,  # dfocc, tight
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001492355224,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.083912298766,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.002307760137,  # dfocc, tight
@@ -9646,9 +9646,9 @@ _std_suite = [
             "MP3 CORRELATION ENERGY": -0.16863165,  # dfocc
             "MP3 SINGLES ENERGY": 0.0,
             "MP3 SAME-SPIN CORRELATION ENERGY": -0.03464009,  # dfocc
-            "REMP CORRELATION ENERGY": -0.170216188333,  # dfocc, tight
-            "REMP SINGLES ENERGY": 0.0,
-            "REMP SAME-SPIN CORRELATION ENERGY": -0.033852995535,  # dfocc, tight
+            "REMP2 CORRELATION ENERGY": -0.170216188333,  # dfocc, tight
+            "REMP2 SINGLES ENERGY": 0.0,
+            "REMP2 SAME-SPIN CORRELATION ENERGY": -0.033852995535,  # dfocc, tight
             "LCCD CORRELATION ENERGY": -0.17475747,  # dfocc
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0334416820,  # dfocc
@@ -9665,8 +9665,8 @@ _std_suite = [
             "OMP3 REFERENCE CORRECTION ENERGY": 0.001026576887,  # dfocc, tight
             "OMP3 CORRELATION ENERGY": -0.169784888805,  # dfocc, tight
             "OMP3 SAME-SPIN CORRELATION ENERGY": -0.035012011899,  # dfocc, tight
-            "OREMP REFERENCE CORRECTION ENERGY": 0.00111325834527,  # dfocc, tight
-            "OREMP CORRELATION ENERGY": -0.17144631168723,  # dfocc, tight
+            "OREMP2 REFERENCE CORRECTION ENERGY": 0.00111325834527,  # dfocc, tight
+            "OREMP2 CORRELATION ENERGY": -0.17144631168723,  # dfocc, tight
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001113861889,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.176001256953,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.033743742943,  # dfocc, tight
@@ -9709,9 +9709,9 @@ _std_suite = [
             "MP3 CORRELATION ENERGY": -0.18575577,  # dfocc
             "MP3 SINGLES ENERGY": 0.0,
             "MP3 SAME-SPIN CORRELATION ENERGY": -0.03792717,  # dfocc
-            "REMP CORRELATION ENERGY": -0.187472566719,  # dfocc, tight
-            "REMP SINGLES ENERGY": 0.0,
-            "REMP SAME-SPIN CORRELATION ENERGY": -0.037236809266,  # dfocc, tight
+            "REMP2 CORRELATION ENERGY": -0.187472566719,  # dfocc, tight
+            "REMP2 SINGLES ENERGY": 0.0,
+            "REMP2 SAME-SPIN CORRELATION ENERGY": -0.037236809266,  # dfocc, tight
             "LCCD CORRELATION ENERGY": -0.19170174,  # dfocc
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.03676422,  # dfocc
@@ -9728,8 +9728,8 @@ _std_suite = [
             "OMP3 REFERENCE CORRECTION ENERGY": 0.001112904383,  # dfocc, tight
             "OMP3 CORRELATION ENERGY": -0.186933561283,  # dfocc, tight
             "OMP3 SAME-SPIN CORRELATION ENERGY": -0.038275663827,  # dfocc, tight
-            "OREMP REFERENCE CORRECTION ENERGY": 0.001217841569,  # dfocc, tight
-            "OREMP CORRELATION ENERGY": -0.188746049630,  # dfocc, tight
+            "OREMP2 REFERENCE CORRECTION ENERGY": 0.001217841569,  # dfocc, tight
+            "OREMP2 CORRELATION ENERGY": -0.188746049630,  # dfocc, tight
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001218721333,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.192985744725,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.037047752001,  # dfocc, tight
@@ -9782,8 +9782,8 @@ _std_suite = [
             "OMP3 REFERENCE CORRECTION ENERGY": -0.000743052999,  # dfocc, tight
             "OMP3 CORRELATION ENERGY": -0.076184701712,  # dfocc, tight
             "OMP3 SAME-SPIN CORRELATION ENERGY": -0.002276029277,  # dfocc, tight
-            "OREMP REFERENCE CORRECTION ENERGY": -0.000458253707,  # dfocc, tight
-            "OREMP CORRELATION ENERGY": -0.079667381927,  # dfocc, tight
+            "OREMP2 REFERENCE CORRECTION ENERGY": -0.000458253707,  # dfocc, tight
+            "OREMP2 CORRELATION ENERGY": -0.079667381927,  # dfocc, tight
             "OLCCD REFERENCE CORRECTION ENERGY": -0.000031311396,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.085435962210,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.002307761175,  # dfocc, tight
@@ -9832,8 +9832,8 @@ _std_suite = [
             "OMP3 REFERENCE CORRECTION ENERGY": -0.003386926686,  # dfocc, tight
             "OMP3 CORRELATION ENERGY": -0.174198389777,  # dfocc, tight
             "OMP3 SAME-SPIN CORRELATION ENERGY": -0.035012012647,  # dfocc, tight
-            "OREMP REFERENCE CORRECTION ENERGY": -0.00330024259293,  # dfocc, tight
-            "OREMP CORRELATION ENERGY": -0.17585981265919,  # dfocc, tight
+            "OREMP2 REFERENCE CORRECTION ENERGY": -0.00330024259293,  # dfocc, tight
+            "OREMP2 CORRELATION ENERGY": -0.17585981265919,  # dfocc, tight
             "OLCCD REFERENCE CORRECTION ENERGY": -0.003299640039,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.180414757924,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.033743734902,  # dfocc, tight
@@ -9882,8 +9882,8 @@ _std_suite = [
             "OMP3 REFERENCE CORRECTION ENERGY": -0.003496834047,  # dfocc, tight
             "OMP3 CORRELATION ENERGY": -0.191543293940,  # dfocc, tight
             "OMP3 SAME-SPIN CORRELATION ENERGY": -0.038275664440,  # dfocc, tight
-            "OREMP REFERENCE CORRECTION ENERGY": -0.003391896462,  # dfocc, tight
-            "OREMP CORRELATION ENERGY": -0.193355782287,  # dfocc, tight
+            "OREMP2 REFERENCE CORRECTION ENERGY": -0.003391896462,  # dfocc, tight
+            "OREMP2 CORRELATION ENERGY": -0.193355782287,  # dfocc, tight
             "OLCCD REFERENCE CORRECTION ENERGY": -0.003391009701,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.197595477381,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.037047749578,  # dfocc, tight
@@ -10399,8 +10399,8 @@ _std_suite = [
             "MP3 CORRELATION ENERGY": -0.20656153,  # dfocc
             "MP3 SINGLES ENERGY": 0.0,
             "MP3 TOTAL GRADIENT": np.array([0.0, 0.0, -0.000933466293, 0.0, 0.0, 0.000933466293]).reshape((-1, 3)),
-            "REMP CORRELATION ENERGY": -0.208504245426,  # dfocc, tight
-            "REMP SINGLES ENERGY": 0.0,
+            "REMP2 CORRELATION ENERGY": -0.208504245426,  # dfocc, tight
+            "REMP2 SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.2100337333,  # p4n
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD TOTAL GRADIENT": np.array([0.0, 0.0, 0.002183232102, 0.0, 0.0, -0.002183232102]).reshape((-1, 3)),
@@ -10441,9 +10441,9 @@ _std_suite = [
                   [ 0.,  0.000000000000,    -0.000022521780,
                     0., -0.000000000000,     0.000022521780]
             ).reshape((-1, 3)),
-            "OREMP REFERENCE CORRECTION ENERGY": 0.000553781427,  # dfocc, tight
-            "OREMP CORRELATION ENERGY": -0.209041900252,  # dfocc, tight
-            "OREMP TOTAL GRADIENT": np.array(  # dfocc, tight
+            "OREMP2 REFERENCE CORRECTION ENERGY": 0.000553781427,  # dfocc, tight
+            "OREMP2 CORRELATION ENERGY": -0.209041900252,  # dfocc, tight
+            "OREMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
                  [  0.,  0.000000000000,     0.002809444261,
                     0., -0.000000000000,    -0.002809444261]
             ).reshape((-1, 3)),
@@ -10499,8 +10499,8 @@ _std_suite = [
             "MP3 TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.004009128141, 0.0, 0.002552803039, -0.00200456407, 0.0, -0.002552803039, -0.00200456407]
             ).reshape((-1, 3)),
-            "REMP CORRELATION ENERGY": -0.22954466014956,  # dfocc, tight
-            "REMP SINGLES ENERGY": 0.0,
+            "REMP2 CORRELATION ENERGY": -0.22954466014956,  # dfocc, tight
+            "REMP2 SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.2320149229,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD TOTAL GRADIENT": np.array(
@@ -10550,9 +10550,9 @@ _std_suite = [
                     0.,  0.002952173310,    -0.002407616826,
                     0., -0.002952173310,    -0.002407616826]
             ).reshape((-1, 3)),
-            "OREMP REFERENCE CORRECTION ENERGY": 0.001281722402,  # dfocc, tight
-            "OREMP CORRELATION ENERGY": -0.23079090375495,  # dfocc, tight
-            "OREMP TOTAL GRADIENT": np.array(  # dfocc, tight
+            "OREMP2 REFERENCE CORRECTION ENERGY": 0.001281722402,  # dfocc, tight
+            "OREMP2 CORRELATION ENERGY": -0.23079090375495,  # dfocc, tight
+            "OREMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
               [ 0.,  0.000000000000,     0.009108870642,
                 0.,  0.005403366342,    -0.004554435321,
                 0., -0.005403366342,    -0.004554435321]
@@ -10611,8 +10611,8 @@ _std_suite = [
             "MP3 TOTAL GRADIENT": np.array(
                 [0.0, 0.0, -0.007037747646, 0.0, -0.004494031919, 0.003518873823, 0.0, 0.004494031919, 0.003518873823]
             ).reshape((-1, 3)),
-            "REMP CORRELATION ENERGY": -0.276419945808,  # dfocc, tight
-            "REMP SINGLES ENERGY": 0.0,
+            "REMP2 CORRELATION ENERGY": -0.276419945808,  # dfocc, tight
+            "REMP2 SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.2786671617,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD TOTAL GRADIENT": np.array(
@@ -10652,9 +10652,9 @@ _std_suite = [
                     0., -0.004075383127,     0.003091300132,
                     0.,  0.004075383127,     0.003091300132]
             ).reshape((-1, 3)),
-            "OREMP REFERENCE CORRECTION ENERGY": 0.001444459285,  # dfocc, tight
-            "OREMP CORRELATION ENERGY": -0.277823416296,  # dfocc, tight
-            "OREMP TOTAL GRADIENT": np.array(  # dfocc, tight
+            "OREMP2 REFERENCE CORRECTION ENERGY": 0.001444459285,  # dfocc, tight
+            "OREMP2 CORRELATION ENERGY": -0.277823416296,  # dfocc, tight
+            "OREMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
                  [  0., -0.000000000000,    -0.001651592566,
                     0., -0.001517469318,     0.000825796283,
                     0.,  0.001517469318,     0.000825796283]
@@ -10730,9 +10730,9 @@ _std_suite = [
                     -0.00011437482,
                 ]
             ).reshape((-1, 3)),
-            "REMP CORRELATION ENERGY": -0.078090599375,  # dfocc, tight
-            "REMP SINGLES ENERGY": 0.0,
-            "REMP SAME-SPIN CORRELATION ENERGY": -0.002340709678,  # dfocc, tight
+            "REMP2 CORRELATION ENERGY": -0.078090599375,  # dfocc, tight
+            "REMP2 SINGLES ENERGY": 0.0,
+            "REMP2 SAME-SPIN CORRELATION ENERGY": -0.002340709678,  # dfocc, tight
             "LCCD CORRELATION ENERGY": -0.0835030877,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0024016379,  # dfocc
@@ -10795,9 +10795,9 @@ _std_suite = [
                     0.,  0.013097326629,    -0.000083099766,
                     0., -0.013097326629,    -0.000083099766]
             ).reshape((-1, 3)),
-            "OREMP REFERENCE CORRECTION ENERGY": 0.001063189693,  # dfocc, tight
-            "OREMP CORRELATION ENERGY": -0.079048591655,  # dfocc, tight
-            "OREMP TOTAL GRADIENT": np.array(  # dfocc, tight
+            "OREMP2 REFERENCE CORRECTION ENERGY": 0.001063189693,  # dfocc, tight
+            "OREMP2 CORRELATION ENERGY": -0.079048591655,  # dfocc, tight
+            "OREMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
                  [  0.,  0.000000000000,     0.005890513253,
                     0., -0.000000000000,    -0.005780178036,
                     0.,  0.014386023476,    -0.000055167609,
@@ -10861,9 +10861,9 @@ _std_suite = [
             "MP3 TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.027082665714, 0.0, 0.014406579724, -0.013541332857, 0.0, -0.014406579724, -0.013541332857]
             ).reshape((-1, 3)),
-            "REMP CORRELATION ENERGY": -0.17256998862940,  # dfocc, tight
-            "REMP SINGLES ENERGY": 0.0,
-            "REMP SAME-SPIN CORRELATION ENERGY": -0.03451443433327,  # dfocc, tight
+            "REMP2 CORRELATION ENERGY": -0.17256998862940,  # dfocc, tight
+            "REMP2 SINGLES ENERGY": 0.0,
+            "REMP2 SAME-SPIN CORRELATION ENERGY": -0.03451443433327,  # dfocc, tight
             "LCCD CORRELATION ENERGY": -0.1770997033,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0340788149,  # dfocc
@@ -10908,9 +10908,9 @@ _std_suite = [
                     0.,  0.014949633980,    -0.014056074099,
                     0., -0.014949633980,    -0.014056074099]
             ).reshape((-1, 3)),
-            "OREMP REFERENCE CORRECTION ENERGY": 0.0011125246764,  # dfocc, tight
-            "OREMP CORRELATION ENERGY": -0.17366812020990,  # dfocc, tight
-            "OREMP TOTAL GRADIENT": np.array(  # dfocc, tight)
+            "OREMP2 REFERENCE CORRECTION ENERGY": 0.0011125246764,  # dfocc, tight
+            "OREMP2 CORRELATION ENERGY": -0.17366812020990,  # dfocc, tight
+            "OREMP2 TOTAL GRADIENT": np.array(  # dfocc, tight)
               [ 0., -0.000000000000,     0.030213597936,
                 0.,  0.016231443797,    -0.015106798968,
                 0., -0.016231443797,    -0.015106798968]
@@ -10971,9 +10971,9 @@ _std_suite = [
             "MP3 TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.014412459072, 0.0, 0.005610368822, -0.007206229536, 0.0, -0.005610368822, -0.007206229536]
             ).reshape((-1, 3)),
-            "REMP CORRELATION ENERGY": -0.212434650458,  # dfocc, tight
-            "REMP SINGLES ENERGY": 0.0,
-            "REMP SAME-SPIN CORRELATION ENERGY": -0.040606132872,  # dfocc, tight
+            "REMP2 CORRELATION ENERGY": -0.212434650458,  # dfocc, tight
+            "REMP2 SINGLES ENERGY": 0.0,
+            "REMP2 SAME-SPIN CORRELATION ENERGY": -0.040606132872,  # dfocc, tight
             "LCCD CORRELATION ENERGY": -0.2167706529,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0401283617,  # dfocc
@@ -11018,9 +11018,9 @@ _std_suite = [
                     0.,  0.006191167357,    -0.007773071375,
                     0., -0.006191167357,    -0.007773071375]
             ).reshape((-1, 3)),
-            "OREMP REFERENCE CORRECTION ENERGY": 0.001287786460,  # dfocc, tight
-            "OREMP CORRELATION ENERGY": -0.213706080780,  # dfocc, tight
-            "OREMP TOTAL GRADIENT": np.array(  # dfocc, tight
+            "OREMP2 REFERENCE CORRECTION ENERGY": 0.001287786460,  # dfocc, tight
+            "OREMP2 CORRELATION ENERGY": -0.213706080780,  # dfocc, tight
+            "OREMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
                  [  0., -0.000000000000,     0.017877890596,
                     0.,  0.007580722221,    -0.008938945298,
                     0., -0.007580722221,    -0.008938945298]
@@ -11107,9 +11107,9 @@ _std_suite = [
                     0.,  0.013097326563,    -0.000083100613,
                     0., -0.013097326563,    -0.000083100613]
             ).reshape((-1, 3)),
-            "OREMP REFERENCE CORRECTION ENERGY": -0.000460845361,  # dfocc, tight
-            "OREMP CORRELATION ENERGY": -0.080572628744,  # dfocc, tight
-            "OREMP TOTAL GRADIENT": np.array(  # dfocc, tight
+            "OREMP2 REFERENCE CORRECTION ENERGY": -0.000460845361,  # dfocc, tight
+            "OREMP2 CORRELATION ENERGY": -0.080572628744,  # dfocc, tight
+            "OREMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
                  [  0.,  0.000000000000,     0.005890487280,
                     0., -0.000000000000,    -0.005780144920,
                     0.,  0.014386015714,    -0.000055171180,
@@ -11192,9 +11192,9 @@ _std_suite = [
                     0.,  0.014949636932,    -0.014056071530,
                     0., -0.014949636932,    -0.014056071530]
             ).reshape((-1, 3)),
-            "OREMP REFERENCE CORRECTION ENERGY": -0.003301435451,  # dfocc, tight
-            "OREMP CORRELATION ENERGY": -0.178082080418,  # dfocc, tight
-            "OREMP TOTAL GRADIENT": np.array(  # dfocc, tight
+            "OREMP2 REFERENCE CORRECTION ENERGY": -0.003301435451,  # dfocc, tight
+            "OREMP2 CORRELATION ENERGY": -0.178082080418,  # dfocc, tight
+            "OREMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
                  [  0., -0.000000000000,     0.030213608364,
                     0.,  0.016231443474,    -0.015106804182,
                     0., -0.016231443474,    -0.015106804182]
@@ -11274,9 +11274,9 @@ _std_suite = [
                     0.,  0.006191172928,    -0.007773069564,
                     0., -0.006191172928,    -0.007773069564]
             ).reshape((-1, 3)),
-            "OREMP REFERENCE CORRECTION ENERGY": -0.003322256873,  # dfocc, tight
-            "OREMP CORRELATION ENERGY": -0.218316122726,  # dfocc, tight
-            "OREMP TOTAL GRADIENT": np.array(  # dfocc, tight
+            "OREMP2 REFERENCE CORRECTION ENERGY": -0.003322256873,  # dfocc, tight
+            "OREMP2 CORRELATION ENERGY": -0.218316122726,  # dfocc, tight
+            "OREMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
                  [  0., -0.000000000000,     0.017877876813,
                     0.,  0.007580722265,    -0.008938938407,
                     0., -0.007580722265,    -0.008938938407]
@@ -11332,8 +11332,8 @@ _std_suite = [
             "MP3 CORRELATION ENERGY": -0.20461763,  # dfocc
             "MP3 SINGLES ENERGY": 0.0,
             "MP3 TOTAL GRADIENT": np.array([0.0, 0.0, -0.000595617648, 0.0, 0.0, 0.000595617648]).reshape((-1, 3)),
-            "REMP CORRELATION ENERGY": -0.206525739571,  # dfocc, tight
-            "REMP SINGLES ENERGY": 0.0,
+            "REMP2 CORRELATION ENERGY": -0.206525739571,  # dfocc, tight
+            "REMP2 SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.2080860831,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD TOTAL GRADIENT": np.array([0.0, 0.0, 0.002514968877, 0.0, 0.0, -0.002514968877]).reshape((-1, 3)),
@@ -11374,9 +11374,9 @@ _std_suite = [
                   [ 0.,  0.000000000000,     0.000413292087,
                     0., -0.000000000000,    -0.000413292087]
             ).reshape((-1, 3)),
-            "OREMP REFERENCE CORRECTION ENERGY": 0.000554531047,  # dfocc, tight
-            "OREMP CORRELATION ENERGY": -0.207169559461,  # dfocc, tight
-            "OREMP TOTAL GRADIENT": np.array(  # dfocc, tight
+            "OREMP2 REFERENCE CORRECTION ENERGY": 0.000554531047,  # dfocc, tight
+            "OREMP2 CORRELATION ENERGY": -0.207169559461,  # dfocc, tight
+            "OREMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
               [ 0.,  0.000000000000,     0.003224769580,
                 0., -0.000000000000,    -0.003224769580]
             ).reshape((-1, 3)),
@@ -11432,8 +11432,8 @@ _std_suite = [
             "MP3 TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.004605219936, 0.0, 0.002923029606, -0.002302609968, 0.0, -0.002923029606, -0.002302609968]
             ).reshape((-1, 3)),
-            "REMP CORRELATION ENERGY": -0.22723769214209,  # dfocc, tight
-            "REMP SINGLES ENERGY": 0.0,
+            "REMP2 CORRELATION ENERGY": -0.22723769214209,  # dfocc, tight
+            "REMP2 SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.2297412879,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD TOTAL GRADIENT": np.array(
@@ -11483,9 +11483,9 @@ _std_suite = [
                     0.,  0.003375822885,    -0.002782046393,
                     0., -0.003375822885,    -0.002782046393]
             ).reshape((-1, 3)),
-            "OREMP REFERENCE CORRECTION ENERGY": 0.001285806012,  # dfocc, tight
-            "OREMP CORRELATION ENERGY": -0.228593144538,  # dfocc, tight
-            "OREMP TOTAL GRADIENT": np.array(  # dfocc, tight
+            "OREMP2 REFERENCE CORRECTION ENERGY": 0.001285806012,  # dfocc, tight
+            "OREMP2 CORRELATION ENERGY": -0.228593144538,  # dfocc, tight
+            "OREMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
              [ 0.0,  0.000000000000,     0.009830485254,
                0.0,  0.005814222254,    -0.004915242627,
                0.0, -0.005814222254,    -0.004915242627]
@@ -11544,8 +11544,8 @@ _std_suite = [
             "MP3 TOTAL GRADIENT": np.array(
                 [0.0, 0.0, -0.006198368687, 0.0, -0.004115138427, 0.003099184344, 0.0, 0.004115138427, 0.003099184344]
             ).reshape((-1, 3)),
-            "REMP CORRELATION ENERGY": -0.251000783874,  # dfocc, tight
-            "REMP SINGLES ENERGY": 0.0,
+            "REMP2 CORRELATION ENERGY": -0.251000783874,  # dfocc, tight
+            "REMP2 SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.2531777549,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD TOTAL GRADIENT": np.array(
@@ -11595,9 +11595,9 @@ _std_suite = [
                     0., -0.003679381392,     0.002637385622,
                     0.,  0.003679381392,     0.002637385622]
             ).reshape((-1, 3)),
-            "OREMP REFERENCE CORRECTION ENERGY": 0.001387432536,  # dfocc, tight
-            "OREMP CORRELATION ENERGY": -0.252366737687,  # dfocc, tight
-            "OREMP TOTAL GRADIENT": np.array(  # dfocc, tight
+            "OREMP2 REFERENCE CORRECTION ENERGY": 0.001387432536,  # dfocc, tight
+            "OREMP2 CORRELATION ENERGY": -0.252366737687,  # dfocc, tight
+            "OREMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
               [ 0.,  0.000000000000,    -0.000767533552,
                 0., -0.001128632785,     0.000383766776,
                 0.,  0.001128632785,     0.000383766776]
@@ -11673,9 +11673,9 @@ _std_suite = [
                     -0.000120861314,
                 ]
             ).reshape((-1, 3)),
-            "REMP CORRELATION ENERGY": -0.077065229797,  # dfocc, tight
-            "REMP SINGLES ENERGY": 0.0,
-            "REMP SAME-SPIN CORRELATION ENERGY": -0.002191757201,  # dfocc, tight
+            "REMP2 CORRELATION ENERGY": -0.077065229797,  # dfocc, tight
+            "REMP2 SINGLES ENERGY": 0.0,
+            "REMP2 SAME-SPIN CORRELATION ENERGY": -0.002191757201,  # dfocc, tight
             "LCCD CORRELATION ENERGY": -0.0824996438,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0022545103,  # dfocc
@@ -11738,9 +11738,9 @@ _std_suite = [
                     0.,  0.013091494156,    -0.000089730216,
                     0., -0.013091494156,    -0.000089730216]
             ).reshape((-1, 3)),
-            "OREMP REFERENCE CORRECTION ENERGY": 0.001067566021,  # dfocc, tight
-            "OREMP CORRELATION ENERGY": -0.078201861999,  # dfocc, tight
-            "OREMP TOTAL GRADIENT": np.array(  # dfocc, tight
+            "OREMP2 REFERENCE CORRECTION ENERGY": 0.001067566021,  # dfocc, tight
+            "OREMP2 CORRELATION ENERGY": -0.078201861999,  # dfocc, tight
+            "OREMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
               [ 0.,  0.000000000000,     0.005652301943,
                 0., -0.000000000000,    -0.005529627660,
                 0.,  0.014380946092,    -0.000061337141,
@@ -11804,9 +11804,9 @@ _std_suite = [
             "MP3 TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.027853586058, 0.0, 0.014898421791, -0.013926793029, 0.0, -0.014898421791, -0.013926793029]
             ).reshape((-1, 3)),
-            "REMP CORRELATION ENERGY": -0.17028287893561,  # dfocc, tight
-            "REMP SINGLES ENERGY": 0.0,
-            "REMP SAME-SPIN CORRELATION ENERGY": -0.03381515362353,  # dfocc, tight
+            "REMP2 CORRELATION ENERGY": -0.17028287893561,  # dfocc, tight
+            "REMP2 SINGLES ENERGY": 0.0,
+            "REMP2 SAME-SPIN CORRELATION ENERGY": -0.03381515362353,  # dfocc, tight
             "LCCD CORRELATION ENERGY": -0.1748446809,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0333897039,  # dfocc
@@ -11851,9 +11851,9 @@ _std_suite = [
                     0.,  0.015477270320,    -0.014501011752,
                     0., -0.015477270319,    -0.014501011752]
             ).reshape((-1, 3)),
-            "OREMP REFERENCE CORRECTION ENERGY": 0.001113332083,  # dfocc, tight
-            "OREMP CORRELATION ENERGY": -0.171513122196,  # dfocc, tight
-            "OREMP TOTAL GRADIENT": np.array(  # dfocc, tight
+            "OREMP2 REFERENCE CORRECTION ENERGY": 0.001113332083,  # dfocc, tight
+            "OREMP2 CORRELATION ENERGY": -0.171513122196,  # dfocc, tight
+            "OREMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
               [ 0., -0.000000000000,     0.031096217899,
                 0.,  0.016756071833,    -0.015548108949,
                 0., -0.016756071832,    -0.015548108949]
@@ -11914,9 +11914,9 @@ _std_suite = [
             "MP3 TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.015407701186, 0.0, 0.006091123422, -0.007703850593, 0.0, -0.006091123422, -0.007703850593]
             ).reshape((-1, 3)),
-            "REMP CORRELATION ENERGY": -0.187461784316,  # dfocc, tight
-            "REMP SINGLES ENERGY": 0.0,
-            "REMP SAME-SPIN CORRELATION ENERGY": -0.037230047131,  # dfocc, tight
+            "REMP2 CORRELATION ENERGY": -0.187461784316,  # dfocc, tight
+            "REMP2 SINGLES ENERGY": 0.0,
+            "REMP2 SAME-SPIN CORRELATION ENERGY": -0.037230047131,  # dfocc, tight
             "LCCD CORRELATION ENERGY": -0.1916908596,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0367574293,
@@ -11961,9 +11961,9 @@ _std_suite = [
                     0.,  0.006684117862,    -0.008304469164,
                     0., -0.006684117862,    -0.008304469164]
             ).reshape((-1, 3)),
-            "OREMP REFERENCE CORRECTION ENERGY": 0.001217776401,  # dfocc, tight
-            "OREMP CORRELATION ENERGY": -0.188735219689,  # dfocc, tight
-            "OREMP TOTAL GRADIENT": np.array(  # dfocc, tight
+            "OREMP2 REFERENCE CORRECTION ENERGY": 0.001217776401,  # dfocc, tight
+            "OREMP2 CORRELATION ENERGY": -0.188735219689,  # dfocc, tight
+            "OREMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
               [ 0.,  0.000000000000,     0.018940660731,
                 0.,  0.008076822926,    -0.009470330365,
                 0., -0.008076822926,    -0.009470330365]
@@ -12049,9 +12049,9 @@ _std_suite = [
                     0.,  0.013091495437,    -0.000089727790,
                     0., -0.013091495437,    -0.000089727790]
             ).reshape((-1, 3)),
-            "OREMP REFERENCE CORRECTION ENERGY": -0.000456469124,  # dfocc, tight
-            "OREMP CORRELATION ENERGY": -0.079725899088,  # dfocc, tight
-            "OREMP TOTAL GRADIENT": np.array(  # dfocc, tight
+            "OREMP2 REFERENCE CORRECTION ENERGY": -0.000456469124,  # dfocc, tight
+            "OREMP2 CORRELATION ENERGY": -0.079725899088,  # dfocc, tight
+            "OREMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
               [ 0.,  0.000000000000,     0.005652293263,
                 0., -0.000000000000,    -0.005529605660,
                 0.,  0.014380930007,    -0.000061343802,
@@ -12134,9 +12134,9 @@ _std_suite = [
                     0.,  0.015477263061,    -0.014501016090,
                     0., -0.015477263061,    -0.014501016090]
             ).reshape((-1, 3)),
-            "OREMP REFERENCE CORRECTION ENERGY": -0.003300628093,  # dfocc, tight
-            "OREMP CORRELATION ENERGY": -0.175927082404,  # dfocc, tight
-            "OREMP TOTAL GRADIENT": np.array(  # dfocc, tight
+            "OREMP2 REFERENCE CORRECTION ENERGY": -0.003300628093,  # dfocc, tight
+            "OREMP2 CORRELATION ENERGY": -0.175927082404,  # dfocc, tight
+            "OREMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
               [ 0., -0.000000000000,     0.031096218276,
                 0.,  0.016756071943,    -0.015548109138,
                 0., -0.016756071943,    -0.015548109138]
@@ -12216,9 +12216,9 @@ _std_suite = [
                     0.,  0.006684114421,    -0.008304473257,
                     0., -0.006684114421,    -0.008304473257]
             ).reshape((-1, 3)),
-            "OREMP REFERENCE CORRECTION ENERGY": -0.003392270931,  # dfocc, tight
-            "OREMP CORRELATION ENERGY": -0.193345261634,  # dfocc, tight
-            "OREMP TOTAL GRADIENT": np.array(  # dfocc, tight
+            "OREMP2 REFERENCE CORRECTION ENERGY": -0.003392270931,  # dfocc, tight
+            "OREMP2 CORRELATION ENERGY": -0.193345261634,  # dfocc, tight
+            "OREMP2 TOTAL GRADIENT": np.array(  # dfocc, tight
               [ 0.,  0.000000000000,     0.018940651737,
                 0.,  0.008076829692,    -0.009470325868,
                 0., -0.008076829692,    -0.009470325868]
@@ -12648,19 +12648,19 @@ def compute_derived_qcvars(std_suite_list):
         if "FCI CORRELATION ENERGY" in calc["data"]:
             calc["data"]["FCI TOTAL ENERGY"] = calc["data"]["FCI CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
 
-        if "REMP CORRELATION ENERGY" in calc["data"]:
-            calc["data"]["REMP TOTAL ENERGY"] = (
-                calc["data"]["REMP CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
+        if "REMP2 CORRELATION ENERGY" in calc["data"]:
+            calc["data"]["REMP2 TOTAL ENERGY"] = (
+                calc["data"]["REMP2 CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
             )
-            if "REMP SINGLES ENERGY" in calc["data"]:
-                calc["data"]["REMP DOUBLES ENERGY"] = (
-                    calc["data"]["REMP CORRELATION ENERGY"] - calc["data"]["REMP SINGLES ENERGY"]
+            if "REMP2 SINGLES ENERGY" in calc["data"]:
+                calc["data"]["REMP2 DOUBLES ENERGY"] = (
+                    calc["data"]["REMP2 CORRELATION ENERGY"] - calc["data"]["REMP2 SINGLES ENERGY"]
                 )
-                if "REMP SAME-SPIN CORRELATION ENERGY" in calc["data"]:
-                    calc["data"]["REMP OPPOSITE-SPIN CORRELATION ENERGY"] = (
-                        calc["data"]["REMP CORRELATION ENERGY"]
-                        - calc["data"]["REMP SAME-SPIN CORRELATION ENERGY"]
-                        - calc["data"]["REMP SINGLES ENERGY"]
+                if "REMP2 SAME-SPIN CORRELATION ENERGY" in calc["data"]:
+                    calc["data"]["REMP2 OPPOSITE-SPIN CORRELATION ENERGY"] = (
+                        calc["data"]["REMP2 CORRELATION ENERGY"]
+                        - calc["data"]["REMP2 SAME-SPIN CORRELATION ENERGY"]
+                        - calc["data"]["REMP2 SINGLES ENERGY"]
                     )
 
         if "LCCD CORRELATION ENERGY" in calc["data"]:
@@ -12837,22 +12837,22 @@ def compute_derived_qcvars(std_suite_list):
                             - calc["data"]["OMP3 SAME-SPIN CORRELATION ENERGY"]
                         )
 
-        if "OREMP CORRELATION ENERGY" in calc["data"]:
-            if calc["data"]["OREMP CORRELATION ENERGY"] == _knownmissing:
-                calc["data"]["OREMP TOTAL ENERGY"] = _knownmissing
-                calc["data"]["OREMP OPPOSITE-SPIN CORRELATION ENERGY"] = _knownmissing
+        if "OREMP2 CORRELATION ENERGY" in calc["data"]:
+            if calc["data"]["OREMP2 CORRELATION ENERGY"] == _knownmissing:
+                calc["data"]["OREMP2 TOTAL ENERGY"] = _knownmissing
+                calc["data"]["OREMP2 OPPOSITE-SPIN CORRELATION ENERGY"] = _knownmissing
             else:
-                calc["data"]["OREMP TOTAL ENERGY"] = (
-                    calc["data"]["OREMP CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
+                calc["data"]["OREMP2 TOTAL ENERGY"] = (
+                    calc["data"]["OREMP2 CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
                 )
-                if "OREMP SAME-SPIN CORRELATION ENERGY" in calc["data"]:
-                    if calc["data"]["OREMP SAME-SPIN CORRELATION ENERGY"] == _knownmissing:
-                        calc["data"]["OREMP OPPOSITE-SPIN CORRELATION ENERGY"] = _knownmissing
+                if "OREMP2 SAME-SPIN CORRELATION ENERGY" in calc["data"]:
+                    if calc["data"]["OREMP2 SAME-SPIN CORRELATION ENERGY"] == _knownmissing:
+                        calc["data"]["OREMP2 OPPOSITE-SPIN CORRELATION ENERGY"] = _knownmissing
                     else:
-                        calc["data"]["OREMP OPPOSITE-SPIN CORRELATION ENERGY"] = (
-                            calc["data"]["OREMP CORRELATION ENERGY"]
-                            - calc["data"]["OREMP REFERENCE CORRECTION ENERGY"]
-                            - calc["data"]["OREMP SAME-SPIN CORRELATION ENERGY"]
+                        calc["data"]["OREMP2 OPPOSITE-SPIN CORRELATION ENERGY"] = (
+                            calc["data"]["OREMP2 CORRELATION ENERGY"]
+                            - calc["data"]["OREMP2 REFERENCE CORRECTION ENERGY"]
+                            - calc["data"]["OREMP2 SAME-SPIN CORRELATION ENERGY"]
                         )
 
         if "OLCCD CORRELATION ENERGY" in calc["data"]:

--- a/qcengine/programs/tests/standard_suite_ref.py
+++ b/qcengine/programs/tests/standard_suite_ref.py
@@ -3331,6 +3331,9 @@ _std_suite = [
             ).reshape((-1, 3)),
             "OCCD REFERENCE CORRECTION ENERGY": 0.001165795,  # qchem
             "OCCD CORRELATION ENERGY": -0.082188930,  # qchem
+            "OCCD TOTAL GRADIENT": np.array(  # qchem, rearranged
+              [0, 0, 0.00520110, 0, 0, -0.00505850, 0., 0.01487527, -0.00007130, 0., -0.01487527, -0.00007130]
+            ).reshape((-1, 3)),
             "PBE TOTAL ENERGY": -26.04681636799003,  # psi 99,590
             "PBE TOTAL GRADIENT": np.array(  # psi 99,590
                 [
@@ -3579,6 +3582,9 @@ _std_suite = [
             ).reshape((-1, 3)),
             "OCCD REFERENCE CORRECTION ENERGY": 0.000987794,  # qchem
             "OCCD CORRELATION ENERGY": -0.173720242,  # qchem
+            "OCCD TOTAL GRADIENT":  np.array(  # qchem, rearranged
+                [0., 0., 0.02915872, 0., 0.01575094, -0.01457936, 0., -0.01575094, -0.01457936]
+            ).reshape((-1, 3)),
             "PBE TOTAL ENERGY": -55.81473169701641,  # psi 99,590
             "PBE TOTAL GRADIENT": np.array(  # psi 99,590
                 [
@@ -3815,6 +3821,9 @@ _std_suite = [
             ).reshape((-1, 3)),
             "OCCD REFERENCE CORRECTION ENERGY": 0.001155093,  # qchem
             "OCCD CORRELATION ENERGY": -0.213139955,  # qchem
+            "OCCD TOTAL GRADIENT": np.array(  # qchem, rearranged
+                [0, 0, 0.01669862, 0,  0.00707632 , -0.00834931, 0, -0.00707632, -0.00834931],
+            ).reshape((-1, 3)),
             "PBE TOTAL ENERGY": -55.83097248811423,  # psi 99,590
             "PBE TOTAL GRADIENT": np.array(  # psi 99,590
                 [
@@ -4106,6 +4115,12 @@ _std_suite = [
             ).reshape((-1, 3)),
             "OCCD REFERENCE CORRECTION ENERGY": -0.000358562,  # qchem
             "OCCD CORRELATION ENERGY": -0.083713042,  # qchem
+            "OCCD TOTAL GRADIENT": np.array(  # qchem 3-pt findif
+              [ 0.,  0.,    5.200665059079133e-03,
+                0.,  0.,   -5.057359056039087e-03,
+                0.,  1.487654179061328e-02,  -7.165259590676168e-05,
+                0., -1.487654176147304e-02,  -7.165259308673899e-05]
+            ).reshape((-1, 3)),
             "PBE TOTAL ENERGY": -26.046275584237,  # nwc 99,590
             "PBE TOTAL GRADIENT": np.array(  # nwc 99,590
                 [
@@ -4231,6 +4246,11 @@ _std_suite = [
             ).reshape((-1, 3)),
             "OCCD REFERENCE CORRECTION ENERGY": -0.003426081,  # qchem
             "OCCD CORRELATION ENERGY": -0.178133946,  # qchem
+            "OCCD TOTAL GRADIENT": np.array(  # qchem 3-pt findif
+              [ 0.,    2.629008122312371e-10,   2.915992176610871e-02,
+                0.,    1.575113356366842e-02,  -1.457995768916476e-02,
+                0.,   -1.575113354590485e-02,  -1.457995755771435e-02]
+            ).reshape((-1, 3)),
             "PBE TOTAL ENERGY": -55.813318056978,  # nwc 99,590
             "PBE TOTAL GRADIENT": np.array(  # nwc 99,590
                 [
@@ -4353,6 +4373,11 @@ _std_suite = [
             ).reshape((-1, 3)),
             "OCCD REFERENCE CORRECTION ENERGY": -0.00345534,  # qchem
             "OCCD CORRELATION ENERGY": -0.217749658,  # qchem
+            "OCCD TOTAL GRADIENT": np.array(  # qchem 3-pt findif
+              [ 0.,   2.948752353404416e-10,   1.669883480914791e-02,
+                0.,   7.076450128096212e-03,  -8.349414756025908e-03,
+                0.,  -7.076449627163584e-03,  -8.349414585495651e-03]
+            ).reshape((-1, 3)),
             "PBE TOTAL ENERGY": -55.829414170216,  # nwc 99,590
             "PBE TOTAL GRADIENT": np.array(  # nwc 99,590
                 [
@@ -5039,7 +5064,7 @@ _std_suite = [
             "CCSDTQ CORRELATION ENERGY": -0.233074721244323,  # ncc
             "OCCD REFERENCE CORRECTION ENERGY": 0.001125755,  # qchem
             "OCCD CORRELATION ENERGY": -0.226880992,  # qchem
-            "OCCD TOTAL GRADIENT": np.array(  # dfocc, rearranged
+            "OCCD TOTAL GRADIENT": np.array(  # qchem, rearranged
                 [ 0, 0, 0.00797428, 0, 0.00488548, -0.00398714, 0, -0.00488548, -0.00398714]
             ).reshape((-1, 3)),
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
@@ -6423,6 +6448,9 @@ _std_suite = [
             "CCSDT CORRELATION ENERGY": -0.08208821205578,  # vcc
             "OCCD REFERENCE CORRECTION ENERGY": 0.001154566,  # qchem
             "OCCD CORRELATION ENERGY": -0.081188108,  # qchem
+            "OCCD TOTAL GRADIENT": np.array(  # qchem, rearranged
+                [0, 0, 0.00494989, 0, 0,  -0.00479521, 0, 0.01487079, -0.00007734, 0, -0.01487079, -0.00007734]
+            ).reshape((-1, 3)),
             # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(144).reshape((12, 12)),
         },
@@ -6653,6 +6681,9 @@ _std_suite = [
             "CCSDT CORRELATION ENERGY": -0.17591978591647,  # vcc
             "OCCD REFERENCE CORRECTION ENERGY": 0.000986681,  # qchem
             "OCCD CORRELATION ENERGY": -0.171498252,  # qchem
+            "OCCD TOTAL GRADIENT": np.array(  # qchem, rearranged
+                [0, 0, 0.03004030, 0, 0.01627564, -0.01502015, 0, -0.01627564, -0.01502015]
+            ).reshape((-1, 3)),
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -6844,6 +6875,9 @@ _std_suite = [
             "CCSDT CORRELATION ENERGY": -0.19368177447948,  # vcc
             "OCCD REFERENCE CORRECTION ENERGY": 0.001089195,  # qchem
             "OCCD CORRELATION ENERGY": -0.188164420,  # qchem
+            "OCCD TOTAL GRADIENT": np.array(  # qchem, rearranged
+                [0, 0, 0.01780351, 0,  0.00760260, -0.00890176 , 0, -0.00760260, -0.00890176]
+            ).reshape((-1, 3)),
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -7093,6 +7127,12 @@ _std_suite = [
             "CCSDT CORRELATION ENERGY": -0.08361110233142,  # vcc
             "OCCD REFERENCE CORRECTION ENERGY": -0.000362931,  # qchem
             "OCCD CORRELATION ENERGY": -0.082712571,  # qchem
+            "OCCD TOTAL GRADIENT": np.array(  # qchem 3-pt findif
+              [  0.,    8.460068018933954e-12,   4.950754755080671e-03,
+                 0.,   -1.880015115318656e-12,  -4.795829218979597e-03,
+                 0.,    1.487359483495976e-02,  -7.746235397720769e-05,
+                 0.,   -1.487359480111949e-02,  -7.746237653738908e-05]
+            ).reshape((-1, 3)),
             # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(144).reshape((12, 12)),
         },
@@ -7171,6 +7211,11 @@ _std_suite = [
             "CCSDT CORRELATION ENERGY": -0.18030677104047,  # vcc (different orbs: -0.18031166502580)
             "OCCD REFERENCE CORRECTION ENERGY": -0.003402152,  # qchem
             "OCCD CORRELATION ENERGY": -0.175891240,  # qchem
+            "OCCD TOTAL GRADIENT": np.array(  # qchem 3-pt findif
+             [ 0.,   -2.131628207280301e-11,   2.994042840143152e-02,
+               0.,    1.624512323772365e-02,  -1.497021096596995e-02,
+               0.,   -1.624512344378104e-02,  -1.497021098018081e-02]
+            ).reshape((-1, 3)),
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -7253,6 +7298,11 @@ _std_suite = [
             "CCSDT CORRELATION ENERGY": -0.19824510672649,  # vcc
             "OCCD REFERENCE CORRECTION ENERGY": -0.003478949,  # qchem
             "OCCD CORRELATION ENERGY": -0.192732814,  # qchem
+            "OCCD TOTAL GRADIENT": np.array(  # qchem 3-pt findif
+              [  0.,   1.705302565824240e-10,   1.774538645804569e-02,
+                 0.,   7.588575865469238e-03,  -8.872690465011601e-03,
+                 0.,  -7.588575776651396e-03,  -8.872690337113909e-03]
+            ).reshape((-1, 3)),
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -8246,7 +8296,7 @@ _std_suite = [
             "OLCCD CORRELATION ENERGY": -0.21043798,  # dfocc
             "OLCCD SAME-SPIN CORRELATION ENERGY": 41,  # dfocc
             "OCCD REFERENCE CORRECTION ENERGY": 0.00051128,  # dfocc
-            "OCCD CORRELATION ENERGY": -0.20864567,  # dfocc
+            "OCCD CORRELATION ENERGY": -0.20864566636,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(6).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(36).reshape((6, 6)),
         },
@@ -8422,8 +8472,8 @@ _std_suite = [
             "OLCCD REFERENCE CORRECTION ENERGY": 0.00148385,  # dfocc
             "OLCCD CORRELATION ENERGY": -0.08473702,  # dfocc
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.00244894,  # dfocc
-            "OCCD REFERENCE CORRECTION ENERGY": 0.00116602,  # dfocc
-            "OCCD CORRELATION ENERGY": -0.08218460,  # dfocc
+            "OCCD REFERENCE CORRECTION ENERGY": 0.00116602,  # dfocc, tight
+            "OCCD CORRELATION ENERGY": -0.08218459647,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(144).reshape((12, 12)),
         },
@@ -8469,8 +8519,8 @@ _std_suite = [
             "OLCCD REFERENCE CORRECTION ENERGY": 0.00111173,  # dfocc
             "OLCCD CORRELATION ENERGY": -0.17810919,  # dfocc
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.03447266,  # dfocc
-            "OCCD REFERENCE CORRECTION ENERGY": 0.00098769,  # dfocc
-            "OCCD CORRELATION ENERGY": -0.17372338,  # dfocc
+            "OCCD REFERENCE CORRECTION ENERGY": 0.0009877675,  # dfocc, tight
+            "OCCD CORRELATION ENERGY": -0.17372337478,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -8516,7 +8566,7 @@ _std_suite = [
             "OLCCD REFERENCE CORRECTION ENERGY": 0.00128557,  # dfocc
             "OLCCD CORRELATION ENERGY": -0.21805538,  # dfocc
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.04051681,  # dfocc
-            "OCCD REFERENCE CORRECTION ENERGY": 0.00115506,  # dfocc
+            "OCCD REFERENCE CORRECTION ENERGY": 0.0011550930,  # dfocc, tight
             "OCCD CORRELATION ENERGY": -0.21313921,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
@@ -8661,7 +8711,7 @@ _std_suite = [
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.04787083,
             "(T) CORRECTION ENERGY": -0.0019204203743072874,
             "A-(T) CORRECTION ENERGY": -0.00194413,  # dfocc
-            "OCCD REFERENCE CORRECTION ENERGY": 0.00051178,  # dfocc
+            "OCCD REFERENCE CORRECTION ENERGY": 0.00051177794,  # dfocc, tight
             "OCCD CORRELATION ENERGY": -0.20682760,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(6).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(36).reshape((6, 6)),
@@ -8829,8 +8879,8 @@ _std_suite = [
             "CCSD SINGLES ENERGY": 0.0,
             "(T) CORRECTION ENERGY": -0.00060403,  # dfocc
             "A-(T) CORRECTION ENERGY": -0.00058790,  # dfocc
-            "OCCD REFERENCE CORRECTION ENERGY": 0.00117357,  # dfocc
-            "OCCD CORRELATION ENERGY": -0.08136638,  # dfocc
+            "OCCD REFERENCE CORRECTION ENERGY": 0.0011735859,  # dfocc, tight
+            "OCCD CORRELATION ENERGY": -0.08136638214,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(144).reshape((12, 12)),
         },
@@ -8873,7 +8923,7 @@ _std_suite = [
             "CCSD SINGLES ENERGY": 0.0,
             "(T) CORRECTION ENERGY": -0.00381140,  # dfocc
             "A-(T) CORRECTION ENERGY": -0.00373215,  # dfocc
-            "OCCD REFERENCE CORRECTION ENERGY": 0.00098847,  # dfocc
+            "OCCD REFERENCE CORRECTION ENERGY": 0.0009886431,  # dfocc, tight
             "OCCD CORRELATION ENERGY": -0.17163549,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
@@ -8917,7 +8967,7 @@ _std_suite = [
             "CCSD SINGLES ENERGY": 0.0,
             "(T) CORRECTION ENERGY": -0.00498288,  # dfocc
             "A-(T) CORRECTION ENERGY": -0.00488266,  # dfocc
-            "OCCD REFERENCE CORRECTION ENERGY": 0.00109104,  # dfocc
+            "OCCD REFERENCE CORRECTION ENERGY": 0.0010911198,  # dfocc, tight
             "OCCD CORRELATION ENERGY": -0.18823687,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
@@ -8955,8 +9005,8 @@ _std_suite = [
                     -0.00024246,
                 ]
             ).reshape((-1, 3)),
-            "OCCD REFERENCE CORRECTION ENERGY": -0.00035009,  # dfocc
-            "OCCD CORRELATION ENERGY": -0.08289004,  # dfocc
+            "OCCD REFERENCE CORRECTION ENERGY": -0.0003500776,  # dfocc, tight
+            "OCCD CORRELATION ENERGY": -0.08289004548,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(144).reshape((12, 12)),
         },
@@ -8989,7 +9039,7 @@ _std_suite = [
                     -0.01318846179,
                 ]
             ).reshape((-1, 3)),
-            "OCCD REFERENCE CORRECTION ENERGY": -0.00342489,  # dfocc
+            "OCCD REFERENCE CORRECTION ENERGY": -0.0034248578,  # dfocc, tight
             "OCCD CORRELATION ENERGY": -0.17604899,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
@@ -9023,7 +9073,7 @@ _std_suite = [
                     -0.007444881162,
                 ]
             ).reshape((-1, 3)),
-            "OCCD REFERENCE CORRECTION ENERGY": -0.00351863,  # dfocc
+            "OCCD REFERENCE CORRECTION ENERGY": -0.0035186129,  # dfocc, tight
             "OCCD CORRELATION ENERGY": -0.19284661,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
@@ -9558,11 +9608,11 @@ _std_suite = [
             "OLCCD REFERENCE CORRECTION ENERGY": 0.00055271,  # dfocc
             "OLCCD CORRELATION ENERGY": -0.21056994,  # dfocc
             "OLCCD TOTAL GRADIENT": np.zeros(6).reshape((-1, 3)),
-            "OCCD REFERENCE CORRECTION ENERGY": 0.00051171,  # dfocc
-            "OCCD CORRELATION ENERGY": -0.20877456,  # dfocc
-            "OCCD TOTAL GRADIENT": np.array(  # dfocc
-                       [ 0.,              0.,              0.001829701274,
-                        -0.,             -0.,             -0.001829701274]
+            "OCCD REFERENCE CORRECTION ENERGY": 0.00051171478318,  # dfocc, tight
+            "OCCD CORRELATION ENERGY": -0.20877455867384,  # dfocc, tight
+            "OCCD TOTAL GRADIENT": np.array(  # dfocc, tight
+              [ 0., 0.,    0.001829701353,
+                0., 0.,   -0.001829701353]
             ).reshape((-1, 3)),
             # "XXX TOTAL GRADIENT": np.zeros(6).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(36).reshape((6, 6)),
@@ -9637,12 +9687,12 @@ _std_suite = [
                         -0.,              0.005852719747, -0.004880162207,
                         -0.,             -0.005852719747, -0.004880162207]
             ).reshape((-1, 3)),
-            "OCCD REFERENCE CORRECTION ENERGY": 0.00112410,  # dfocc
-            "OCCD CORRELATION ENERGY": -0.22924045,  # dfocc
-            "OCCD TOTAL GRADIENT": np.array(  # dfocc
-                       [ 0.,              0.,              0.007259061848,
-                        -0.,              0.00447396049,  -0.003629530924,
-                        -0.,             -0.00447396049,  -0.003629530924]
+            "OCCD REFERENCE CORRECTION ENERGY": 0.0011241002379,  # dfocc, tight
+            "OCCD CORRELATION ENERGY": -0.22924045334096,  # dfocc, tight
+            "OCCD TOTAL GRADIENT": np.array(  # dfocc, tight
+             [  0., -0.000000000000,     0.007259063497,
+               -0.,  0.004473960460,    -0.003629531749,
+               -0., -0.004473960460,    -0.003629531749]
             ).reshape((-1, 3)),
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
@@ -9703,12 +9753,12 @@ _std_suite = [
             "OLCCD REFERENCE CORRECTION ENERGY": 0.00135231,  # dfocc
             "OLCCD CORRELATION ENERGY": -0.27998133,  # dfocc
             "OLCCD TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
-            "OCCD REFERENCE CORRECTION ENERGY": 0.00127939,  # dfocc
-            "OCCD CORRELATION ENERGY": -0.27539517,  # dfocc
-            "OCCD TOTAL GRADIENT": np.array(  # dfocc
-                       [ 0.,             -0.,             -0.003670657573,
-                        -0.,             -0.002477953535,  0.001835328787,
-                         0.,              0.002477953535,  0.001835328786]
+            "OCCD REFERENCE CORRECTION ENERGY": 0.00127938819983,  # dfocc, tight
+            "OCCD CORRELATION ENERGY": -0.27539517277894,  # dfocc, tight
+            "OCCD TOTAL GRADIENT": np.array(  # dfocc, tight
+             [  0.,  0.000000000000,    -0.003670656144,
+               -0., -0.002477953103,     0.001835328072,
+                0.,  0.002477953103,     0.001835328072]
             ).reshape((-1, 3)),
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
@@ -9803,13 +9853,13 @@ _std_suite = [
             "OLCCD REFERENCE CORRECTION ENERGY": 0.00148572,  # dfocc
             "OLCCD CORRELATION ENERGY": -0.08481145,  # dfocc
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.00245014,  # dfocc
-            "OCCD REFERENCE CORRECTION ENERGY": 0.00116757,  # dfocc
-            "OCCD CORRELATION ENERGY": -0.08225498,  # dfocc
-            "OCCD TOTAL GRADIENT": np.array(  # dfocc
-                       [-0.,              0.,              0.005192785742,
-                         0.,             -0.,             -0.005046571537,
-                        -0.,              0.014877326081, -0.000073107103,
-                         0.,             -0.014877326081, -0.000073107103]
+            "OCCD REFERENCE CORRECTION ENERGY": 0.00116757931849,  # dfocc, tight
+            "OCCD CORRELATION ENERGY": -0.08225497590846,  # dfocc, tight
+            "OCCD TOTAL GRADIENT": np.array(  # dfocc, tight
+                       [-0.,  0.,                0.005192742269,
+                         0., -0.,               -0.005046526613,
+                        -0.,  0.014877327584,   -0.000073107828,
+                         0., -0.014877327584,   -0.000073107828]
             ).reshape((-1, 3)),
             # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(144).reshape((12, 12)),
@@ -9878,12 +9928,12 @@ _std_suite = [
                          0.,              0.01725870275,  -0.015931015497,
                         -0.,             -0.01725870275,  -0.015931015497]
             ).reshape((-1, 3)),
-            "OCCD REFERENCE CORRECTION ENERGY": 0.00098759,  # dfocc
-            "OCCD CORRELATION ENERGY": -0.17380640,  # dfocc
-            "OCCD TOTAL GRADIENT": np.array(  # dfocc
-                       [-0.,             -0.,              0.02914585699 ,
-                         0.,              0.015744650608, -0.014572928495,
-                        -0.,             -0.015744650608, -0.014572928496]
+            "OCCD REFERENCE CORRECTION ENERGY": 0.00098766230788,  # dfocc, tight
+            "OCCD CORRELATION ENERGY": -0.17380639841079,  # dfocc, tight
+            "OCCD TOTAL GRADIENT": np.array(  # dfocc, tight
+                       [-0.,             -0.,              0.029147626743,
+                         0.,              0.01574493194,  -0.014573813372,
+                        -0.,             -0.01574493194,  -0.014573813372]
             ).reshape((-1, 3)),
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
@@ -9947,12 +9997,12 @@ _std_suite = [
             "OLCCD REFERENCE CORRECTION ENERGY": 0.00128551,  # dfocc
             "OLCCD CORRELATION ENERGY": -0.21803893,  # dfocc
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.04051003,  # dfocc
-            "OCCD REFERENCE CORRECTION ENERGY": 0.00115503,  # dfocc
-            "OCCD CORRELATION ENERGY": -0.21312358,  # dfocc
-            "OCCD TOTAL GRADIENT": np.array(  # dfocc
-                       [ 0.,              0.,              0.016674719968,
-                        -0.,              0.007064080694, -0.008337359984,
-                         0.,             -0.007064080694, -0.008337359984]
+            "OCCD REFERENCE CORRECTION ENERGY": 0.00115506325268,  # dfocc, tight
+            "OCCD CORRELATION ENERGY": -0.21312358096054,  # dfocc, tight
+            "OCCD TOTAL GRADIENT": np.array(  # dfocc, tight
+             [  0.,  0.,                0.016675154934,
+               -0.,  0.007064234315,   -0.008337577467,
+                0., -0.007064234315,   -0.008337577467]
             ).reshape((-1, 3)),
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
@@ -9995,13 +10045,13 @@ _std_suite = [
             "OLCCD REFERENCE CORRECTION ENERGY": -0.00003862,  # dfocc
             "OLCCD CORRELATION ENERGY": -0.08633549,  # dfocc
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.00245012,  # dfocc
-            "OCCD REFERENCE CORRECTION ENERGY": -0.00035646,  # dfocc
-            "OCCD CORRELATION ENERGY": -0.08377901,  # dfocc
-            "OCCD TOTAL GRADIENT": np.array(  # dfocc
-                       [-0.,              0.,              0.005192980829,
-                         0.,             -0.,             -0.005046758888,
-                        -0.,              0.014877324353, -0.00007311097 ,
-                         0.,             -0.014877324353, -0.00007311097 ]
+            "OCCD REFERENCE CORRECTION ENERGY": -0.00035645775738,  # dfocc, tight
+            "OCCD CORRELATION ENERGY": -0.08377901300913,  # dfocc, tight
+            "OCCD TOTAL GRADIENT": np.array(  # dfocc, tight
+            [ -0.,  0.000000000000,     0.005192742183,
+               0., -0.000000000000,    -0.005046526527,
+              -0.,  0.014877327583,    -0.000073107828,
+               0., -0.014877327583,    -0.000073107828]
             ).reshape((-1, 3)),
             # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(144).reshape((12, 12)),
@@ -10045,12 +10095,12 @@ _std_suite = [
                          0.,              0.017258564742, -0.0159323715  ,
                         -0.,             -0.017258564742, -0.0159323715  ]
             ).reshape((-1, 3)),
-            "OCCD REFERENCE CORRECTION ENERGY": -0.00342630,  # dfocc
-            "OCCD CORRELATION ENERGY": -0.17822036,  # dfocc
-            "OCCD TOTAL GRADIENT": np.array(  # dfocc
-                       [-0.,             -0.,              0.029147612271,
-                         0.,              0.015744923333, -0.014573806135,
-                        -0.,             -0.015744923333, -0.014573806135]
+            "OCCD REFERENCE CORRECTION ENERGY": -0.00342629789193,  # dfocc, tight
+            "OCCD CORRELATION ENERGY": -0.17822035862112,  # dfocc, tight
+            "OCCD TOTAL GRADIENT": np.array(  # dfocc, tight
+             [-0., -0.000000000000,     0.029147627070,
+               0.,  0.015744932006,    -0.014573813535,
+              -0., -0.015744932006,    -0.014573813535]
             ).reshape((-1, 3)),
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
@@ -10089,12 +10139,12 @@ _std_suite = [
             "OLCCD REFERENCE CORRECTION ENERGY": -0.00332461,  # dfocc
             "OLCCD CORRELATION ENERGY": -0.22264897,  # dfocc
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.04051002,  # dfocc
-            "OCCD REFERENCE CORRECTION ENERGY": -0.00345497,  # dfocc
-            "OCCD CORRELATION ENERGY": -0.21773362,  # dfocc
-            "OCCD TOTAL GRADIENT": np.array(  # dfocc
-                       [ 0.,              0.,              0.016673805473,
-                        -0.,              0.00706348269,  -0.008336902738,
-                         0.,             -0.00706348269,  -0.008336902735]
+            "OCCD REFERENCE CORRECTION ENERGY": -0.00345497869314,  # dfocc, tight
+            "OCCD CORRELATION ENERGY": -0.21773362291808,  # dfocc, tight
+            "OCCD TOTAL GRADIENT": np.array(  # dfocc, tight
+            [  0., -0.000000000000,     0.016675155033,
+              -0.,  0.007064234369,    -0.008337577516,
+               0., -0.007064234369,    -0.008337577516]
             ).reshape((-1, 3)),
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
@@ -10152,11 +10202,11 @@ _std_suite = [
                         -0.,             -0.,             -0.003412477814]
             ).reshape((-1, 3)),
             "A-(T) CORRECTION ENERGY": -0.00194585,  # dfocc
-            "OCCD REFERENCE CORRECTION ENERGY": 0.00051223,  # dfocc
-            "OCCD CORRELATION ENERGY": -0.20695630,  # dfocc
-            "OCCD TOTAL GRADIENT": np.array(  # dfocc
-                       [ 0.,              0.,              0.002245649472,
-                        -0.,             -0.,             -0.002245649472]
+            "OCCD REFERENCE CORRECTION ENERGY": 0.00051222526754,  # dfocc, tight
+            "OCCD CORRELATION ENERGY": -0.20695630522582,  # dfocc, tight
+            "OCCD TOTAL GRADIENT": np.array(  # dfocc, tight
+             [  0.,  0.,   0.002245645626,
+               -0., -0.,  -0.002245645626]
             ).reshape((-1, 3)),
             # "XXX TOTAL GRADIENT": np.zeros(6).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(36).reshape((6, 6)),
@@ -10224,12 +10274,12 @@ _std_suite = [
                         -0.,             -0.006421774051, -0.005400604283]
             ).reshape((-1, 3)),
             "A-(T) CORRECTION ENERGY": -0.00521446,  # dfocc
-            "OCCD REFERENCE CORRECTION ENERGY": 0.00112736,  # dfocc
-            "OCCD CORRELATION ENERGY": -0.22711014,  # dfocc
-            "OCCD TOTAL GRADIENT": np.array(  # dfocc
-                       [ 0.,             -0.,              0.007977308047,
-                        -0.,              0.004884097985, -0.003988654024,
-                        -0.,             -0.004884097985, -0.003988654024]
+            "OCCD REFERENCE CORRECTION ENERGY": 0.00112736114914,  # dfocc, tight
+            "OCCD CORRELATION ENERGY":  -0.22711013815896,  # dfocc, tight
+            "OCCD TOTAL GRADIENT": np.array(  # dfocc, tight
+            [  0., -0.000000000000,     0.007977310114,
+              -0.,  0.004884098446,    -0.003988655057,
+              -0., -0.004884098446,    -0.003988655057]
             ).reshape((-1, 3)),
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
@@ -10297,12 +10347,12 @@ _std_suite = [
                          0.,              0.000361314051, -0.000308753262]
             ).reshape((-1, 3)),
             "A-(T) CORRECTION ENERGY": -0.00701651,  # dfocc
-            "OCCD REFERENCE CORRECTION ENERGY": 0.00122701,  # dfocc
-            "OCCD CORRELATION ENERGY": -0.25004962,  # dfocc
-            "OCCD TOTAL GRADIENT": np.array(  # dfocc
-                       [ 0.,             -0.,             -0.002738848137,
-                        -0.,             -0.00205614215,   0.001369424069,
-                         0.,              0.00205614215,   0.001369424068]
+            "OCCD REFERENCE CORRECTION ENERGY": 0.00122701106154,  # dfocc, tight
+            "OCCD CORRELATION ENERGY": -0.25004962087804,  # dfocc, tight
+            "OCCD TOTAL GRADIENT": np.array(  # dfocc, tight
+            [  0., -0.000000000000,    -0.002738846535,
+              -0., -0.002056141369,     0.001369423268,
+               0.,  0.002056141369,     0.001369423268]
             ).reshape((-1, 3)),
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
@@ -10394,13 +10444,13 @@ _std_suite = [
                          0.,             -0.014958703713, -0.000035200787]
             ).reshape((-1, 3)),
             "A-(T) CORRECTION ENERGY": -0.00058825,  # dfocc
-            "OCCD REFERENCE CORRECTION ENERGY": 0.00117508,  # dfocc
-            "OCCD CORRELATION ENERGY": -0.08143642,  # dfocc
-            "OCCD TOTAL GRADIENT": np.array(  # dfocc
-                       [-0.,              0.,              0.004941864874,
-                         0.,             -0.,             -0.004784287208,
-                        -0.,              0.014873119825, -0.000078788833,
-                         0.,             -0.014873119825, -0.000078788833]
+            "OCCD REFERENCE CORRECTION ENERGY": 0.00117513618887,  # dfocc, tight
+            "OCCD CORRELATION ENERGY": -0.08143642271488,  # dfocc, tight
+            "OCCD TOTAL GRADIENT": np.array(  # dfocc, tight
+            [ -0.,  0.000000000000,     0.004941329452,
+               0., -0.000000000000,    -0.004783766728,
+              -0.,  0.014873123435,    -0.000078781362,
+               0., -0.014873123435,    -0.000078781362]
             ).reshape((-1, 3)),
             # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(144).reshape((12, 12)),
@@ -10461,12 +10511,12 @@ _std_suite = [
                         -0.,             -0.017296807836, -0.015961537154]
             ).reshape((-1, 3)),
             "A-(T) CORRECTION ENERGY": -0.00373604,  # dfocc
-            "OCCD REFERENCE CORRECTION ENERGY": 0.00098836,  # dfocc
-            "OCCD CORRELATION ENERGY": -0.17171798,  # dfocc
-            "OCCD TOTAL GRADIENT": np.array(  # dfocc
-                       [-0.,             -0.,              0.030026015485,
-                         0.,              0.016268136174, -0.015013007742,
-                        -0.,             -0.016268136173, -0.015013007743]
+            "OCCD REFERENCE CORRECTION ENERGY": 0.00098853594635,  # dfocc, tight
+            "OCCD CORRELATION ENERGY": -0.17171797869288,  # dfocc, tight
+            "OCCD TOTAL GRADIENT": np.array(  # dfocc, tight
+            [ -0., -0.000000000000,     0.030027361324,
+               0.,  0.016268352543,    -0.015013680662,
+              -0., -0.016268352543,    -0.015013680662]
             ).reshape((-1, 3)),
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
@@ -10527,12 +10577,12 @@ _std_suite = [
                          0.,             -0.008716203188, -0.010003589367]
             ).reshape((-1, 3)),
             "A-(T) CORRECTION ENERGY": -0.00488153,  # dfocc
-            "OCCD REFERENCE CORRECTION ENERGY": 0.00109104,  # dfocc
-            "OCCD CORRELATION ENERGY": -0.18822673,  # dfocc
-            "OCCD TOTAL GRADIENT": np.array(  # dfocc
-                       [ 0.,              0.,              0.017782847456,
-                        -0.,              0.007591037208, -0.008891423727,
-                         0.,             -0.007591037209, -0.008891423729]
+            "OCCD REFERENCE CORRECTION ENERGY": 0.0010910673835,  # dfocc, tight
+            "OCCD CORRELATION ENERGY": -0.18822673037030,  # dfocc, tight
+            "OCCD TOTAL GRADIENT": np.array(  # dfocc, tight
+            [  0.,  0.000000000000,     0.017781686076,
+              -0.,  0.007590501254,    -0.008890843038,
+               0., -0.007590501254,    -0.008890843038]
             ).reshape((-1, 3)),
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
@@ -10571,13 +10621,13 @@ _std_suite = [
                 ]
             ).reshape((-1, 3)),
             "LCCD CORRELATION ENERGY": -0.0824737155,  # p4n
-            "OCCD REFERENCE CORRECTION ENERGY": -0.00034891,  # dfocc
-            "OCCD CORRELATION ENERGY": -0.08296046,  # dfocc
-            "OCCD TOTAL GRADIENT": np.array(  # dfocc
-                       [-0.,              0.,              0.00494137578 ,
-                         0.,             -0.,             -0.004783814597,
-                        -0.,              0.014873122524, -0.000078780591,
-                         0.,             -0.014873122524, -0.000078780591]
+            "OCCD REFERENCE CORRECTION ENERGY": -0.00034890091894,  # dfocc, tight
+            "OCCD CORRELATION ENERGY": -0.08296045969717,  # dfocc, tight
+            "OCCD TOTAL GRADIENT": np.array(  # dfocc, tight
+            [ -0.,  0.000000000000,     0.004941329268,
+               0., -0.000000000000,    -0.004783766592,
+              -0.,  0.014873123401,    -0.000078781338,
+               0., -0.014873123401,    -0.000078781338]
             ).reshape((-1, 3)),
             # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(144).reshape((12, 12)),
@@ -10613,12 +10663,12 @@ _std_suite = [
                 ]
             ).reshape((-1, 3)),
             "LCCD CORRELATION ENERGY": -0.1769909051,  # p4n
-            "OCCD REFERENCE CORRECTION ENERGY": -0.00342546,  # dfocc
-            "OCCD CORRELATION ENERGY": -0.17613194,  # dfocc
-            "OCCD TOTAL GRADIENT": np.array(  # dfocc
-                       [-0.,              0.,              0.030027564344,
-                         0.,              0.016268433623, -0.015013782162,
-                        -0.,             -0.016268433623, -0.015013782182]
+            "OCCD REFERENCE CORRECTION ENERGY": -0.00342542420012,  # dfocc, tight
+            "OCCD CORRELATION ENERGY": -0.17613193885178,  # dfocc, tight
+            "OCCD TOTAL GRADIENT": np.array(  # dfocc, tight
+            [ -0., -0.000000000000,     0.030027364470,
+               0.,  0.016268353265,    -0.015013682235,
+              -0., -0.016268353265,    -0.015013682235]
             ).reshape((-1, 3)),
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
@@ -10654,12 +10704,12 @@ _std_suite = [
                 ]
             ).reshape((-1, 3)),
             "LCCD CORRELATION ENERGY": -0.1939804718,  # p4n
-            "OCCD REFERENCE CORRECTION ENERGY": -0.00351899,  # dfocc
-            "OCCD CORRELATION ENERGY": -0.19283677,  # dfocc
-            "OCCD TOTAL GRADIENT": np.array(
-                       [ 0.,              0.,              0.017781529683,
-                        -0.,              0.007590440485, -0.008890764841,
-                         0.,             -0.007590440485, -0.008890764842]
+            "OCCD REFERENCE CORRECTION ENERGY": -0.00351897455648,  # dfocc, tight
+            "OCCD CORRELATION ENERGY": -0.19283677235188,  # dfocc
+            "OCCD TOTAL GRADIENT": np.array(  # dfocc, tight
+            [  0.,  0.000000000000,     0.017781687051,
+              -0.,  0.007590501825,    -0.008890843526,
+               0., -0.007590501825,    -0.008890843526]
             ).reshape((-1, 3)),
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
@@ -11193,11 +11243,12 @@ def compute_derived_qcvars(std_suite_list):
             calc["data"]["OLCCD TOTAL ENERGY"] = (
                 calc["data"]["OLCCD CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
             )
-            calc["data"]["OLCCD OPPOSITE-SPIN CORRELATION ENERGY"] = (
-                calc["data"]["OLCCD CORRELATION ENERGY"]
-                - calc["data"]["OLCCD REFERENCE CORRECTION ENERGY"]
-                - calc["data"]["OLCCD SAME-SPIN CORRELATION ENERGY"]
-            )
+            if "OLCCD SAME-SPIN CORRELATION ENERGY" in calc["data"]:
+                calc["data"]["OLCCD OPPOSITE-SPIN CORRELATION ENERGY"] = (
+                    calc["data"]["OLCCD CORRELATION ENERGY"]
+                    - calc["data"]["OLCCD REFERENCE CORRECTION ENERGY"]
+                    - calc["data"]["OLCCD SAME-SPIN CORRELATION ENERGY"]
+                )
 
         if "OCCD CORRELATION ENERGY" in calc["data"]:
             calc["data"]["OCCD TOTAL ENERGY"] = (

--- a/qcengine/programs/tests/standard_suite_ref.py
+++ b/qcengine/programs/tests/standard_suite_ref.py
@@ -659,6 +659,15 @@ _std_suite = [
             "OLCCD REFERENCE CORRECTION ENERGY": 0.0005522939,  # p4n
             "OLCCD CORRELATION ENERGY": -0.2104417743,  # p4n
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.0484443079,  # occ
+            "OLCCD TOTAL GRADIENT": np.array(  # occ
+                       [ 0.,             0.,             0.00339205449,
+                         0.,             0.,            -0.00339205449]
+            ).reshape((-1, 3)),
+            "OCCD REFERENCE CORRECTION ENERGY": 0.000511277,  # qchem
+            "OCCD CORRELATION ENERGY": -0.208649453,  # qchem
+            "OCCD TOTAL GRADIENT": np.array(  # qchem, rearranged
+                [    0.00000000,    0.00000000, 0.00184797, 0, 0, -0.00184797]
+            ).reshape((-1, 3)),
             "PBE TOTAL ENERGY": -100.33517315116806,  # psi 99,590
             "PBE TOTAL GRADIENT": np.array([[0.0, 0.0, 0.020107103338], [0.0, 0.0, -0.020107128125]]),  # psi 99,590
             "B3LYP TOTAL ENERGY": -100.43544624005466,  # psi 99,590
@@ -1463,6 +1472,16 @@ _std_suite = [
             "OLCCD REFERENCE CORRECTION ENERGY": 0.0011895155,  # p4n
             "OLCCD CORRELATION ENERGY": -0.2330452995,  # p4n
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.0503175223,  # occ
+            "OLCCD TOTAL GRADIENT": np.array(  # occ
+                       [ 0.,              0.,              0.009755099696,
+                        -0.,              0.005854889163, -0.004877549848,
+                         0.,             -0.005854889163, -0.004877549848]
+            ).reshape((-1, 3)),
+            "OCCD REFERENCE CORRECTION ENERGY": 0.001123344,  # qchem
+            "OCCD CORRELATION ENERGY": -0.229118050,  # qchem
+            "OCCD TOTAL GRADIENT": np.array(  # qchem, rearranged
+                [ 0., 0., 0.00727331, 0., 0.00447444, -0.00363665, 0., -0.00447444, -0.00363665]
+            ).reshape((-1, 3)),
             "PBE TOTAL ENERGY": -76.35896461348528,  # psi 99,590
             "PBE TOTAL GRADIENT": np.array(  # psi 99,590
                 [
@@ -2451,6 +2470,16 @@ _std_suite = [
             "OLCCD REFERENCE CORRECTION ENERGY": 0.0013521561,  # p4n
             "OLCCD CORRELATION ENERGY": -0.2800053174,  # p4n
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.0582676514,  # occ
+            "OLCCD TOTAL GRADIENT": np.array(  # occ
+                       [ 0.,              0.,             -0.001040099489,
+                         0.,             -0.001127979233,  0.000520049745,
+                        -0.,              0.001127979233,  0.000520049745]
+            ).reshape((-1, 3)),
+            "OCCD REFERENCE CORRECTION ENERGY": 0.001279242,  # qchem
+            "OCCD CORRELATION ENERGY": -0.275418269,  # qchem
+            "OCCD TOTAL GRADIENT": np.array(  # qchem, rearranged
+                [0, 0, -0.00363692, 0, -0.00246929, 0.00181846, 0, 0.00246929, 0.00181846]
+            ).reshape((-1, 3)),
             "PBE TOTAL ENERGY": -76.38209089347507,  # psi 99,590
             "PBE TOTAL GRADIENT": np.array(  # psi 99,590
                 [
@@ -3285,6 +3314,7 @@ _std_suite = [
                     ],
                 ]
             ),
+            "A-(T) CORRECTION ENERGY": -0.000609324,  # mrcc
             "CCSDT-1A CORRELATION ENERGY": -0.082798380297,  # ecc
             "CCSDT-1B CORRELATION ENERGY": -0.082796300732,  # ecc
             "CCSDT-2 CORRELATION ENERGY": -0.082795702684,  # ecc
@@ -3293,6 +3323,14 @@ _std_suite = [
             "OLCCD REFERENCE CORRECTION ENERGY": 0.0014842084,  # p4n
             "OLCCD CORRELATION ENERGY": -0.0847413506,  # p4n
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.0024486744,  # occ
+            "OLCCD TOTAL GRADIENT": np.array(  # occ
+                       [ 0.,              0.,              0.002952428656,
+                         0.,              0.,             -0.002937832654,
+                        -0.,              0.015746258127, -0.000007298001,
+                         0.,             -0.015746258127, -0.000007298001]
+            ).reshape((-1, 3)),
+            "OCCD REFERENCE CORRECTION ENERGY": 0.001165795,  # qchem
+            "OCCD CORRELATION ENERGY": -0.082188930,  # qchem
             "PBE TOTAL ENERGY": -26.04681636799003,  # psi 99,590
             "PBE TOTAL GRADIENT": np.array(  # psi 99,590
                 [
@@ -3534,6 +3572,13 @@ _std_suite = [
             "OLCCD REFERENCE CORRECTION ENERGY": 0.0011118724,  # p4n
             "OLCCD CORRELATION ENERGY": -0.1781057943,  # p4n
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.0344689234,  # occ
+            "OLCCD TOTAL GRADIENT": np.array(  # occ
+                       [ 0.,              0.,              0.031877236853,
+                        -0.,              0.017265501329, -0.015938618427,
+                         0.,             -0.017265501329, -0.015938618427]
+            ).reshape((-1, 3)),
+            "OCCD REFERENCE CORRECTION ENERGY": 0.000987794,  # qchem
+            "OCCD CORRELATION ENERGY": -0.173720242,  # qchem
             "PBE TOTAL ENERGY": -55.81473169701641,  # psi 99,590
             "PBE TOTAL GRADIENT": np.array(  # psi 99,590
                 [
@@ -3754,6 +3799,7 @@ _std_suite = [
                     ],
                 ]
             ),
+            "A-(T) CORRECTION ENERGY": -0.0050643207,  # mrcc
             "CCSDT-1A CORRELATION ENERGY": -0.218598725534,  # ecc
             "CCSDT-1B CORRELATION ENERGY": -0.218597572977,  # ecc
             "CCSDT-2 CORRELATION ENERGY": -0.218253889761,  # ecc
@@ -3762,6 +3808,13 @@ _std_suite = [
             "OLCCD REFERENCE CORRECTION ENERGY": 0.0012856903,  # p4n
             "OLCCD CORRELATION ENERGY": -0.2180560836,  # p4n
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.0405122800,  # occ
+            "OLCCD TOTAL GRADIENT": np.array(  # occ
+                       [-0.,              0.,              0.019472272298,
+                        -0.,              0.008522161738, -0.009736136149,
+                         0.,             -0.008522161738, -0.009736136149]
+            ).reshape((-1, 3)),
+            "OCCD REFERENCE CORRECTION ENERGY": 0.001155093,  # qchem
+            "OCCD CORRELATION ENERGY": -0.213139955,  # qchem
             "PBE TOTAL ENERGY": -55.83097248811423,  # psi 99,590
             "PBE TOTAL GRADIENT": np.array(  # psi 99,590
                 [
@@ -4045,6 +4098,14 @@ _std_suite = [
             "OLCCD REFERENCE CORRECTION ENERGY": -0.0000399018,  # p4n
             "OLCCD CORRELATION ENERGY": -0.0862654609,  # p4n
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.0024486744,  # occ
+            "OLCCD TOTAL GRADIENT": np.array(  # occ
+                       [-0.,              0.,              0.002952428137,
+                         0.,              0.,             -0.002937832352,
+                        -0.,              0.015746258328, -0.000007297893,
+                         0.,             -0.015746258328, -0.000007297893]
+            ).reshape((-1, 3)),
+            "OCCD REFERENCE CORRECTION ENERGY": -0.000358562,  # qchem
+            "OCCD CORRELATION ENERGY": -0.083713042,  # qchem
             "PBE TOTAL ENERGY": -26.046275584237,  # nwc 99,590
             "PBE TOTAL GRADIENT": np.array(  # nwc 99,590
                 [
@@ -4163,6 +4224,13 @@ _std_suite = [
             "OLCCD REFERENCE CORRECTION ENERGY": -0.0033018315,  # p4n
             "OLCCD CORRELATION ENERGY": -0.1825194982,  # p4n
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.0344689234,  # occ
+            "OLCCD TOTAL GRADIENT": np.array(  # occ
+                       [-0.,              0.,              0.031877236593,
+                        -0.,              0.017265501452, -0.015938618296,
+                         0.,             -0.017265501452, -0.015938618296]
+            ).reshape((-1, 3)),
+            "OCCD REFERENCE CORRECTION ENERGY": -0.003426081,  # qchem
+            "OCCD CORRELATION ENERGY": -0.178133946,  # qchem
             "PBE TOTAL ENERGY": -55.813318056978,  # nwc 99,590
             "PBE TOTAL GRADIENT": np.array(  # nwc 99,590
                 [
@@ -4278,6 +4346,13 @@ _std_suite = [
             "OLCCD REFERENCE CORRECTION ENERGY": -0.0033240178,  # p4n
             "OLCCD CORRELATION ENERGY": -0.2226657917,  # p4n
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.0405122800,  # occ
+            "OLCCD TOTAL GRADIENT": np.array(  # occ
+                       [ 0.,              0.,              0.019472272302,
+                        -0.,              0.008522161726, -0.009736136151,
+                         0.,             -0.008522161726, -0.009736136151]
+            ).reshape((-1, 3)),
+            "OCCD REFERENCE CORRECTION ENERGY": -0.00345534,  # qchem
+            "OCCD CORRELATION ENERGY": -0.217749658,  # qchem
             "PBE TOTAL ENERGY": -55.829414170216,  # nwc 99,590
             "PBE TOTAL GRADIENT": np.array(  # nwc 99,590
                 [
@@ -4464,6 +4539,11 @@ _std_suite = [
             "[Q] CORRECTION ENERGY": -0.000379506649993,  # ncc
             "(Q) CORRECTION ENERGY": -0.000413051703749,  # ncc
             "CCSDTQ CORRELATION ENERGY": -0.209218171097884,  # ncc
+            "OCCD REFERENCE CORRECTION ENERGY": 0.000510311,  # qchem
+            "OCCD CORRELATION ENERGY": -0.206722125,  # qchem
+            "OCCD TOTAL GRADIENT": np.array(  # qchem, rearranged
+                [0, 0, 0.00227059, 0, 0, -0.00227059]
+            ).reshape((-1, 3)),
             # "XXX TOTAL GRADIENT": np.zeros(6).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(36).reshape((6, 6)),
         },
@@ -4957,6 +5037,11 @@ _std_suite = [
             "[Q] CORRECTION ENERGY": -0.000288788062660,  # ncc
             "(Q) CORRECTION ENERGY": -0.000503838444143,  # ncc
             "CCSDTQ CORRELATION ENERGY": -0.233074721244323,  # ncc
+            "OCCD REFERENCE CORRECTION ENERGY": 0.001125755,  # qchem
+            "OCCD CORRELATION ENERGY": -0.226880992,  # qchem
+            "OCCD TOTAL GRADIENT": np.array(  # dfocc, rearranged
+                [ 0, 0, 0.00797428, 0, 0.00488548, -0.00398714, 0, -0.00488548, -0.00398714]
+            ).reshape((-1, 3)),
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -5686,6 +5771,11 @@ _std_suite = [
             "[Q] CORRECTION ENERGY": -0.000151213601440,  # ncc
             "(Q) CORRECTION ENERGY": -0.000368016662584,  # ncc
             "CCSDTQ CORRELATION ENERGY": -0.257824320323573,  # ncc
+            "OCCD REFERENCE CORRECTION ENERGY": 0.001225751,  # qchem
+            "OCCD CORRELATION ENERGY": -0.250044802,  # qchem
+            "OCCD TOTAL GRADIENT": np.array(  # qchem, rearranged
+                [0, 0, -0.00269153 , 0, -0.00204152, 0.00134576, 0,  0.00204152, 0.00134576]
+            ).reshape((-1, 3)),
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -6325,11 +6415,14 @@ _std_suite = [
                     ],
                 ]
             ),
+            "A-(T) CORRECTION ENERGY": -0.000587873,  # mrcc
             "CCSDT-1A CORRELATION ENERGY": -0.081774257938,  # ecc
             "CCSDT-1B CORRELATION ENERGY": -0.081772270576,  # ecc
             "CCSDT-2 CORRELATION ENERGY": -0.081772292290,  # ecc
             "CCSDT-3 CORRELATION ENERGY": -0.08177701734273,  # vcc
             "CCSDT CORRELATION ENERGY": -0.08208821205578,  # vcc
+            "OCCD REFERENCE CORRECTION ENERGY": 0.001154566,  # qchem
+            "OCCD CORRELATION ENERGY": -0.081188108,  # qchem
             # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(144).reshape((12, 12)),
         },
@@ -6558,6 +6651,8 @@ _std_suite = [
                 [[0.0, 0.0, 0.03180282], [0.0, 0.01723825, -0.01590141], [0.0, -0.01723825, -0.01590141]]
             ),
             "CCSDT CORRELATION ENERGY": -0.17591978591647,  # vcc
+            "OCCD REFERENCE CORRECTION ENERGY": 0.000986681,  # qchem
+            "OCCD CORRELATION ENERGY": -0.171498252,  # qchem
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -6741,11 +6836,14 @@ _std_suite = [
                     ],
                 ]
             ),
+            "A-(T) CORRECTION ENERGY": -0.004882427,  # mrcc
             "CCSDT-1A CORRELATION ENERGY": -0.193424330972,  # ecc
             "CCSDT-1B CORRELATION ENERGY": -0.193423371134,  # ecc
             "CCSDT-2 CORRELATION ENERGY": -0.193087540038,  # vcc
             "CCSDT-3 CORRELATION ENERGY": -0.19310599643349,  # vcc
             "CCSDT CORRELATION ENERGY": -0.19368177447948,  # vcc
+            "OCCD REFERENCE CORRECTION ENERGY": 0.001089195,  # qchem
+            "OCCD CORRELATION ENERGY": -0.188164420,  # qchem
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -6993,6 +7091,8 @@ _std_suite = [
             ).reshape((-1, 3)),
             "(T) CORRECTION ENERGY": -0.00068823,  # cfour only
             "CCSDT CORRELATION ENERGY": -0.08361110233142,  # vcc
+            "OCCD REFERENCE CORRECTION ENERGY": -0.000362931,  # qchem
+            "OCCD CORRELATION ENERGY": -0.082712571,  # qchem
             # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(144).reshape((12, 12)),
         },
@@ -7069,6 +7169,8 @@ _std_suite = [
             ).reshape((-1, 3)),
             "(T) CORRECTION ENERGY": -0.003863167899,  # cfour only
             "CCSDT CORRELATION ENERGY": -0.18030677104047,  # vcc (different orbs: -0.18031166502580)
+            "OCCD REFERENCE CORRECTION ENERGY": -0.003402152,  # qchem
+            "OCCD CORRELATION ENERGY": -0.175891240,  # qchem
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -7149,6 +7251,8 @@ _std_suite = [
             ).reshape((-1, 3)),
             "(T) CORRECTION ENERGY": -0.00504351,  # cfour only
             "CCSDT CORRELATION ENERGY": -0.19824510672649,  # vcc
+            "OCCD REFERENCE CORRECTION ENERGY": -0.003478949,  # qchem
+            "OCCD CORRELATION ENERGY": -0.192732814,  # qchem
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -10072,6 +10176,7 @@ _std_suite = [
         },
     },
     # <<<  lopsided SCF/CORL algorithms  >>>
+    # <<<  lopsided DF-FC-CONV  >>>
     {
         "meta": {
             "system": "hf",
@@ -10098,6 +10203,7 @@ _std_suite = [
             # "XXX TOTAL HESSIAN": np.zeros(36).reshape((6, 6)),
         },
     },
+    # <<<  lopsided CD-FC-CONV  >>>
     {
         "meta": {
             "system": "hf",
@@ -10208,6 +10314,7 @@ _std_suite = [
     #            "MP2 SAME-SPIN CORRELATION ENERGY": -1.3,
     #        },
     #    },
+    # <<<  lopsided DF-AE-CONV  >>>
     {
         "meta": {
             "system": "hf",
@@ -10245,6 +10352,7 @@ _std_suite = [
             # "XXX TOTAL HESSIAN": np.zeros(36).reshape((6, 6)),
         },
     },
+    # <<<  lopsided CD-AE-CONV  >>>
     {
         "meta": {
             "system": "hf",
@@ -10364,7 +10472,8 @@ _std_suite = [
 ]
 
 
-for calc in _std_suite:
+def compute_derived_qcvars(std_suite_list):
+  for calc in std_suite_list:
     if calc["data"]:
         if "MP2 CORRELATION ENERGY" in calc["data"]:
             calc["data"]["MP2 TOTAL ENERGY"] = calc["data"]["MP2 CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
@@ -10600,6 +10709,17 @@ for calc in _std_suite:
                 - calc["data"]["OLCCD SAME-SPIN CORRELATION ENERGY"]
             )
 
+        if "OCCD CORRELATION ENERGY" in calc["data"]:
+            calc["data"]["OCCD TOTAL ENERGY"] = (
+                calc["data"]["OCCD CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
+            )
+            if "OCCD SAME-SPIN CORRELATION ENERGY" in calc["data"]:
+                calc["data"]["OCCD OPPOSITE-SPIN CORRELATION ENERGY"] = (
+                    calc["data"]["OCCD CORRELATION ENERGY"]
+                    - calc["data"]["OCCD REFERENCE CORRECTION ENERGY"]
+                    - calc["data"]["OCCD SAME-SPIN CORRELATION ENERGY"]
+                )
+
     calc["data"].update(_std_generics[f"{calc['meta']['system']}_{calc['meta']['basis']}_{calc['meta']['fcae']}"])
 
 
@@ -10614,4 +10734,5 @@ def answer_hash(**kwargs):
     return "_".join([system, basis, scf_type, reference, fcae, corl_type])
 
 
+compute_derived_qcvars(_std_suite)
 std_suite = {answer_hash(**calc["meta"]): calc["data"] for calc in _std_suite}

--- a/qcengine/programs/tests/standard_suite_ref.py
+++ b/qcengine/programs/tests/standard_suite_ref.py
@@ -7374,10 +7374,10 @@ _std_suite = [
             "MP3 SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.20990784,  # dfocc
             "LCCD SINGLES ENERGY": 0.0,
-            "CCSD CORRELATION ENERGY": -0.20874537,
+            "CCSD CORRELATION ENERGY": -0.20874537,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
-            "(T) CORRECTION ENERGY": -0.00193646,
-            "A-(T) CORRECTION ENERGY": -0.00196115,  # dfocc
+            "(T) CORRECTION ENERGY": -0.00193646,  # dfocc, tight
+            "A-(T) CORRECTION ENERGY": -0.00196115,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(6).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(36).reshape((6, 6)),
         },
@@ -7401,10 +7401,10 @@ _std_suite = [
             "MP3 SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.23188996,  # dfocc
             "LCCD SINGLES ENERGY": 0.0,
-            "CCSD CORRELATION ENERGY": -0.22941330,
+            "CCSD CORRELATION ENERGY": -0.22941330,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
-            "(T) CORRECTION ENERGY": -0.00523874,
-            "A-(T) CORRECTION ENERGY": -0.00523635,  # dfocc
+            "(T) CORRECTION ENERGY": -0.00523874,  # dfocc, tight
+            "A-(T) CORRECTION ENERGY": -0.00523635,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -7428,10 +7428,10 @@ _std_suite = [
             "MP3 SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.27869144,  # dfocc
             "LCCD SINGLES ENERGY": 0.0,
-            "CCSD CORRELATION ENERGY": -0.27570541,
+            "CCSD CORRELATION ENERGY": -0.27570541,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
-            "(T) CORRECTION ENERGY": -0.00726403,
-            "A-(T) CORRECTION ENERGY": -0.00718185,  # dfocc
+            "(T) CORRECTION ENERGY": -0.00726403,  # dfocc, tight
+            "A-(T) CORRECTION ENERGY": -0.00718185,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -7460,8 +7460,8 @@ _std_suite = [
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.00240067,  # dfocc
             "CCSD CORRELATION ENERGY": -0.08217068,  # dfocc
             "CCSD SINGLES ENERGY": 0.0,
-            "(T) CORRECTION ENERGY": -0.00062618,  # dfocc
-            "A-(T) CORRECTION ENERGY": -0.00060937,  # dfocc
+            "(T) CORRECTION ENERGY": -0.00062618,  # dfocc, tight
+            "A-(T) CORRECTION ENERGY": -0.00060937,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(144).reshape((12, 12)),
         },
@@ -7488,10 +7488,10 @@ _std_suite = [
             "LCCD CORRELATION ENERGY": -0.17701281,  # dfocc
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.03413088,  # dfocc
-            "CCSD CORRELATION ENERGY": -0.17387591,  # dfocc
+            "CCSD CORRELATION ENERGY": -0.17387591,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
-            "(T) CORRECTION ENERGY": -0.00384405,  # dfocc
-            "A-(T) CORRECTION ENERGY": -0.00376422,  # dfocc
+            "(T) CORRECTION ENERGY": -0.00384405,  # dfocc, tight
+            "A-(T) CORRECTION ENERGY": -0.00376422,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -7518,10 +7518,10 @@ _std_suite = [
             "LCCD CORRELATION ENERGY": -0.21678793,  # dfocc
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.04013550,  # dfocc
-            "CCSD CORRELATION ENERGY": -0.21329809,  # dfocc
+            "CCSD CORRELATION ENERGY": -0.21329809,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
-            "(T) CORRECTION ENERGY": -0.00516691,  # dfocc
-            "A-(T) CORRECTION ENERGY": -0.00506463,  # dfocc
+            "(T) CORRECTION ENERGY": -0.00516691,  # dfocc, tight
+            "A-(T) CORRECTION ENERGY": -0.00506463,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -7606,10 +7606,10 @@ _std_suite = [
             "MP3 SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.20796060,  # dfocc
             "LCCD SINGLES ENERGY": 0.0,
-            "CCSD CORRELATION ENERGY": -0.20681721,
+            "CCSD CORRELATION ENERGY": -0.20681721,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
-            "(T) CORRECTION ENERGY": -0.00192057,
-            "A-(T) CORRECTION ENERGY": -0.00194429,  # dfocc
+            "(T) CORRECTION ENERGY": -0.00192057,  # dfocc, tight
+            "A-(T) CORRECTION ENERGY": -0.00194429,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(6).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(36).reshape((6, 6)),
         },
@@ -7633,10 +7633,10 @@ _std_suite = [
             "MP3 SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.22961687,  # dfocc
             "LCCD SINGLES ENERGY": 0.0,
-            "CCSD CORRELATION ENERGY": -0.22717646,
+            "CCSD CORRELATION ENERGY": -0.22717646,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
-            "(T) CORRECTION ENERGY": -0.00521255,
-            "A-(T) CORRECTION ENERGY": -0.00520986,  # dfocc
+            "(T) CORRECTION ENERGY": -0.00521255,  # dfocc, tight
+            "A-(T) CORRECTION ENERGY": -0.00520986,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -7660,10 +7660,10 @@ _std_suite = [
             "MP3 SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.25319438,  # dfocc
             "LCCD SINGLES ENERGY": 0.0,
-            "CCSD CORRELATION ENERGY": -0.25033052,
+            "CCSD CORRELATION ENERGY": -0.25033052,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
-            "(T) CORRECTION ENERGY": -0.00709694,
-            "A-(T) CORRECTION ENERGY": -0.00701833,  # dfocc
+            "(T) CORRECTION ENERGY": -0.00709694,  # dfocc, tight
+            "A-(T) CORRECTION ENERGY": -0.00701833,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -7690,10 +7690,10 @@ _std_suite = [
             "LCCD CORRELATION ENERGY": -0.08242955,  # dfocc
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.00225358,  # dfocc
-            "CCSD CORRELATION ENERGY": -0.08116911,  # dfocc
+            "CCSD CORRELATION ENERGY": -0.08116911,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
-            "(T) CORRECTION ENERGY": -0.00060405,  # dfocc
-            "A-(T) CORRECTION ENERGY": -0.00058791,  # dfocc
+            "(T) CORRECTION ENERGY": -0.00060405,  # dfocc, tight
+            "A-(T) CORRECTION ENERGY": -0.00058791,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(144).reshape((12, 12)),
         },
@@ -7720,10 +7720,10 @@ _std_suite = [
             "LCCD CORRELATION ENERGY": -0.17475833,  # dfocc
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.03344184,  # dfocc
-            "CCSD CORRELATION ENERGY": -0.17165381,  # dfocc
+            "CCSD CORRELATION ENERGY": -0.17165381,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
-            "(T) CORRECTION ENERGY": -0.00381142,  # dfocc
-            "A-(T) CORRECTION ENERGY": -0.00373217,  # dfocc
+            "(T) CORRECTION ENERGY": -0.00381142,  # dfocc, tight
+            "A-(T) CORRECTION ENERGY": -0.00373217,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -7750,10 +7750,10 @@ _std_suite = [
             "LCCD CORRELATION ENERGY": -0.19170259,  # dfocc
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.03676455,  # dfocc
-            "CCSD CORRELATION ENERGY": -0.18831733,  # dfocc
+            "CCSD CORRELATION ENERGY": -0.18831733,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
-            "(T) CORRECTION ENERGY": -0.00498297,  # dfocc
-            "A-(T) CORRECTION ENERGY": -0.00488274,  # dfocc
+            "(T) CORRECTION ENERGY": -0.00498297,  # dfocc, tight
+            "A-(T) CORRECTION ENERGY": -0.00488274,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -7844,10 +7844,10 @@ _std_suite = [
             "LCCD CORRELATION ENERGY": -0.2100497124,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD TOTAL GRADIENT": np.array([0.0, 0.0, 0.002190589954, 0.0, 0.0, -0.002190589954]).reshape((-1, 3)),
-            "CCSD CORRELATION ENERGY": -0.20888438,
+            "CCSD CORRELATION ENERGY": -0.20888438,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
-            "(T) CORRECTION ENERGY": -0.00193859,
-            "A-(T) CORRECTION ENERGY": -0.00196333,  # dfocc
+            "(T) CORRECTION ENERGY": -0.00193859,  # dfocc, tight
+            "A-(T) CORRECTION ENERGY": -0.00196333,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(6).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(36).reshape((6, 6)),
         },
@@ -7872,10 +7872,10 @@ _std_suite = [
             "MP3 SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.2320261414,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
-            "CCSD CORRELATION ENERGY": -0.22954333,
+            "CCSD CORRELATION ENERGY": -0.22954333,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
-            "(T) CORRECTION ENERGY": -0.00524393,
-            "A-(T) CORRECTION ENERGY": -0.00524145,  # dfocc
+            "(T) CORRECTION ENERGY": -0.00524393,  # dfocc, tight
+            "A-(T) CORRECTION ENERGY": -0.00524145,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -7900,10 +7900,10 @@ _std_suite = [
             "MP3 SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.2786878429,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
-            "CCSD CORRELATION ENERGY": -0.27570207,
+            "CCSD CORRELATION ENERGY": -0.27570207,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
-            "(T) CORRECTION ENERGY": -0.00726375,
-            "A-(T) CORRECTION ENERGY": -0.00718158,  # dfocc
+            "(T) CORRECTION ENERGY": -0.00726375,  # dfocc, tight
+            "A-(T) CORRECTION ENERGY": -0.00718158,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -7930,10 +7930,10 @@ _std_suite = [
             "LCCD CORRELATION ENERGY": -0.0835080983,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0024018298,  # dfocc
-            "CCSD CORRELATION ENERGY": -0.08224363,  # dfocc
+            "CCSD CORRELATION ENERGY": -0.08224363,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
-            "(T) CORRECTION ENERGY": -0.00062669,  # dfocc
-            "A-(T) CORRECTION ENERGY": -0.00060985,  # dfocc
+            "(T) CORRECTION ENERGY": -0.00062669,  # dfocc, tight
+            "A-(T) CORRECTION ENERGY": -0.00060985,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(144).reshape((12, 12)),
         },
@@ -7960,10 +7960,10 @@ _std_suite = [
             "LCCD CORRELATION ENERGY": -0.1771107929,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0340809591,  # dfocc
-            "CCSD CORRELATION ENERGY": -0.17396848,  # dfocc
+            "CCSD CORRELATION ENERGY": -0.17396848,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
-            "(T) CORRECTION ENERGY": -0.00384851,  # dfocc
-            "A-(T) CORRECTION ENERGY": -0.00376850,  # dfocc
+            "(T) CORRECTION ENERGY": -0.00384851,  # dfocc, tight
+            "A-(T) CORRECTION ENERGY": -0.00376850,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -7990,10 +7990,10 @@ _std_suite = [
             "LCCD CORRELATION ENERGY": -0.2167841215,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0401306929,  # dfocc
-            "CCSD CORRELATION ENERGY": -0.21329436,  # dfocc
+            "CCSD CORRELATION ENERGY": -0.21329436,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
-            "(T) CORRECTION ENERGY": -0.00516666,  # dfocc
-            "A-(T) CORRECTION ENERGY": -0.00506439,  # dfocc
+            "(T) CORRECTION ENERGY": -0.00516666,  # dfocc, tight
+            "A-(T) CORRECTION ENERGY": -0.00506439,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -8085,10 +8085,10 @@ _std_suite = [
             "MP3 SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.2081020566,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
-            "CCSD CORRELATION ENERGY": -0.20695586,
+            "CCSD CORRELATION ENERGY": -0.20695586,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
-            "(T) CORRECTION ENERGY": -0.00192267,
-            "A-(T) CORRECTION ENERGY": -0.00194643,  # dfocc
+            "(T) CORRECTION ENERGY": -0.00192267,  # dfocc, tight
+            "A-(T) CORRECTION ENERGY": -0.00194643,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(6).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(36).reshape((6, 6)),
         },
@@ -8113,10 +8113,10 @@ _std_suite = [
             "MP3 SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.2297524911,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
-            "CCSD CORRELATION ENERGY": -0.22730597,
+            "CCSD CORRELATION ENERGY": -0.22730597,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
-            "(T) CORRECTION ENERGY": -0.00521769,
-            "A-(T) CORRECTION ENERGY": -0.00521491,  # dfocc
+            "(T) CORRECTION ENERGY": -0.00521769,  # dfocc, tight
+            "A-(T) CORRECTION ENERGY": -0.00521491,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -8141,10 +8141,10 @@ _std_suite = [
             "MP3 SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.2531939249,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
-            "CCSD CORRELATION ENERGY": -0.25033030,
+            "CCSD CORRELATION ENERGY": -0.25033030,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
-            "(T) CORRECTION ENERGY": -0.00709666,
-            "A-(T) CORRECTION ENERGY": -0.00701806,  # dfocc
+            "(T) CORRECTION ENERGY": -0.00709666,  # dfocc, tight
+            "A-(T) CORRECTION ENERGY": -0.00701806,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -8171,10 +8171,10 @@ _std_suite = [
             "LCCD CORRELATION ENERGY": -0.0825046579,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0022547041,  # dfocc
-            "CCSD CORRELATION ENERGY": -0.08124172,  # dfocc
+            "CCSD CORRELATION ENERGY": -0.08124172,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
-            "(T) CORRECTION ENERGY": -0.00060454,  # dfocc
-            "A-(T) CORRECTION ENERGY": -0.00058837,  # dfocc
+            "(T) CORRECTION ENERGY": -0.00060454,  # dfocc, tight
+            "A-(T) CORRECTION ENERGY": -0.00058837,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(144).reshape((12, 12)),
         },
@@ -8201,10 +8201,10 @@ _std_suite = [
             "LCCD CORRELATION ENERGY": -0.1748557523,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0333918420,  # dfocc
-            "CCSD CORRELATION ENERGY": -0.17174585,  # dfocc
+            "CCSD CORRELATION ENERGY": -0.17174585,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
-            "(T) CORRECTION ENERGY": -0.00381584,  # dfocc
-            "A-(T) CORRECTION ENERGY": -0.00373642,  # dfocc
+            "(T) CORRECTION ENERGY": -0.00381584,  # dfocc, tight
+            "A-(T) CORRECTION ENERGY": -0.00373642,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -8231,10 +8231,10 @@ _std_suite = [
             "LCCD CORRELATION ENERGY": -0.1917015960,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0367596684,  # dfocc
-            "CCSD CORRELATION ENERGY": -0.18831642,  # dfocc
+            "CCSD CORRELATION ENERGY": -0.18831642,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
-            "(T) CORRECTION ENERGY": -0.00498272,  # dfocc
-            "A-(T) CORRECTION ENERGY": -0.00488249,  # dfocc
+            "(T) CORRECTION ENERGY": -0.00498272,  # dfocc, tight
+            "A-(T) CORRECTION ENERGY": -0.00488249,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -8334,11 +8334,11 @@ _std_suite = [
                 # dfocc findif-5
                 [ 0., 0., 0.002193849073, 0., 0., -0.002193849073]
             ).reshape((-1, 3)),
-            "CCSD CORRELATION ENERGY": -0.20873986012771106,
+            "CCSD CORRELATION ENERGY": -0.20873986003026,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.04857381,
-            "(T) CORRECTION ENERGY": -0.0019363109218456449,
-            "A-(T) CORRECTION ENERGY": -0.00196099,  # dfocc
+            "(T) CORRECTION ENERGY": -0.00193631092143,  # dfocc, tight
+            "A-(T) CORRECTION ENERGY": -0.00196099396220,  # dfocc, tight
             "OLCCD REFERENCE CORRECTION ENERGY": 0.000552265186,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.210437984945,  # dfocc, tight
             "OCCD REFERENCE CORRECTION ENERGY": 0.00051128,  # dfocc
@@ -8380,11 +8380,11 @@ _std_suite = [
             "MP3 SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.23188949,  # dfocc
             "LCCD SINGLES ENERGY": 0.0000000000,
-            "CCSD CORRELATION ENERGY": -0.22941290,
+            "CCSD CORRELATION ENERGY": -0.22941289840818,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.05017955,
-            "(T) CORRECTION ENERGY": -0.00523867,
-            "A-(T) CORRECTION ENERGY": -0.00523629,  # dfocc
+            "(T) CORRECTION ENERGY": -0.00523866932915,  # dfocc, tight
+            "A-(T) CORRECTION ENERGY": -0.00523628844912,  # dfocc, tight
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001189623873,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.233047836839,  # dfocc, tight
             "OCCD REFERENCE CORRECTION ENERGY": 0.00112446,  # dfocc
@@ -8426,11 +8426,11 @@ _std_suite = [
             "MP3 SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.27869015,  # dfocc
             "LCCD SINGLES ENERGY": 0.0000000000,
-            "CCSD CORRELATION ENERGY": -0.27570421,
+            "CCSD CORRELATION ENERGY": -0.27570421327166,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.05801141,
-            "(T) CORRECTION ENERGY": -0.00726395,
-            "A-(T) CORRECTION ENERGY": -0.00718178,  # dfocc
+            "(T) CORRECTION ENERGY": -0.00726394807275,  # dfocc, tight
+            "A-(T) CORRECTION ENERGY": -0.00718177622315,  # dfocc, tight
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001352168423,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.280004165823,  # dfocc, tight
             "OCCD REFERENCE CORRECTION ENERGY": 0.00127925,  # dfocc
@@ -8509,10 +8509,10 @@ _std_suite = [
                     -0.000043034255,
                 ]
             ).reshape((-1, 3)),
-            "CCSD CORRELATION ENERGY": -0.08216852,  # dfocc
+            "CCSD CORRELATION ENERGY": -0.08216852322069,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
-            "(T) CORRECTION ENERGY": -0.00062617,  # dfocc
-            "A-(T) CORRECTION ENERGY": -0.00060935,  # dfocc
+            "(T) CORRECTION ENERGY": -0.00062616540400,  # dfocc, tight
+            "A-(T) CORRECTION ENERGY": -0.00060935179141,  # dfocc, tight
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001484257667,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.084737023607,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.002448903277,  # dfocc, tight
@@ -8556,10 +8556,10 @@ _std_suite = [
             "LCCD CORRELATION ENERGY": -0.17701192,  # dfocc
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.03413070,  # dfocc
-            "CCSD CORRELATION ENERGY": -0.17387519,  # dfocc
+            "CCSD CORRELATION ENERGY": -0.17387519037716,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
-            "(T) CORRECTION ENERGY": -0.00384403,  # dfocc
-            "A-(T) CORRECTION ENERGY": -0.00376420,  # dfocc
+            "(T) CORRECTION ENERGY": -0.00384402655927,  # dfocc, tight
+            "A-(T) CORRECTION ENERGY": -0.00376419871586,  # dfocc, tight
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001111961826,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.178109192111,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.034472712167,  # dfocc, tight
@@ -8603,10 +8603,10 @@ _std_suite = [
             "LCCD CORRELATION ENERGY": -0.21678706,  # dfocc
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.04013515,  # dfocc
-            "CCSD CORRELATION ENERGY": -0.21329731,  # dfocc
+            "CCSD CORRELATION ENERGY": -0.21329730737718,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
-            "(T) CORRECTION ENERGY": -0.00516682,  # dfocc
-            "A-(T) CORRECTION ENERGY": -0.00506455,  # dfocc
+            "(T) CORRECTION ENERGY": -0.00516682217061,  # dfocc, tight
+            "A-(T) CORRECTION ENERGY": -0.00506455138393,  # dfocc, tight
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001285760689,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.218055380962,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.040516816950,  # dfocc, tight
@@ -8750,11 +8750,11 @@ _std_suite = [
                 # dfocc findif-5 fc cd+cd
                 [ 0., 0., 0.002525704147, 0., 0., -0.002525704147]
             ).reshape((-1, 3)),
-            "CCSD CORRELATION ENERGY": -0.2068117080298787,
+            "CCSD CORRELATION ENERGY": -0.20681170792808,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.04787083,
-            "(T) CORRECTION ENERGY": -0.0019204203743072874,
-            "A-(T) CORRECTION ENERGY": -0.00194413,  # dfocc
+            "(T) CORRECTION ENERGY": -0.00192042037371,  # dfocc, tight
+            "A-(T) CORRECTION ENERGY": -0.00194413458399,  # dfocc, tight
             "OLCCD REFERENCE CORRECTION ENERGY": 0.000553491444,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.208617145287,  # dfocc, tight
             "OCCD REFERENCE CORRECTION ENERGY": 0.00051177794,  # dfocc, tight
@@ -8796,11 +8796,11 @@ _std_suite = [
             "MP3 SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.22961642,  # dfocc
             "LCCD SINGLES ENERGY": 0.0000000000,
-            "CCSD CORRELATION ENERGY": -0.22717607,
+            "CCSD CORRELATION ENERGY": -0.22717606848165,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.04939986,
-            "(T) CORRECTION ENERGY": -0.00521248,
-            "A-(T) CORRECTION ENERGY": -0.00520980,  # dfocc
+            "(T) CORRECTION ENERGY": -0.00521247873234,  # dfocc, tight
+            "A-(T) CORRECTION ENERGY": -0.00520979601465,  # dfocc, tight
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001194389384,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.230903883683,  # dfocc, tight
             "OCCD REFERENCE CORRECTION ENERGY": 0.00112772,  # dfocc
@@ -8842,11 +8842,11 @@ _std_suite = [
             "MP3 SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.25319315,  # dfocc
             "LCCD SINGLES ENERGY": 0.0000000000,
-            "CCSD CORRELATION ENERGY": -0.25032939,
+            "CCSD CORRELATION ENERGY": -0.25032938698805,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.05405638,
-            "(T) CORRECTION ENERGY": -0.00709686,
-            "A-(T) CORRECTION ENERGY": -0.00701826,  # dfocc
+            "(T) CORRECTION ENERGY": -0.00709685911318,  # dfocc, tight
+            "A-(T) CORRECTION ENERGY": -0.00701825978933,  # dfocc, tight
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001298302400,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.254480886451,  # dfocc, tight
             "OCCD REFERENCE CORRECTION ENERGY": 0.00122690,  # dfocc
@@ -8925,10 +8925,10 @@ _std_suite = [
                     -0.000048867243,
                 ]
             ).reshape((-1, 3)),
-            "CCSD CORRELATION ENERGY": -0.08116696,  # dfocc
+            "CCSD CORRELATION ENERGY": -0.08116696345172,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
-            "(T) CORRECTION ENERGY": -0.00060403,  # dfocc
-            "A-(T) CORRECTION ENERGY": -0.00058790,  # dfocc
+            "(T) CORRECTION ENERGY": -0.00060403476990,  # dfocc, tight
+            "A-(T) CORRECTION ENERGY": -0.00058789584036,  # dfocc, tight
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001492355224,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.083912298766,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.002307760137,  # dfocc, tight
@@ -8972,10 +8972,10 @@ _std_suite = [
             "LCCD CORRELATION ENERGY": -0.17475747,  # dfocc
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0334416820,  # dfocc
-            "CCSD CORRELATION ENERGY": -0.17165312,  # dfocc
+            "CCSD CORRELATION ENERGY": -0.17165311633501,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
-            "(T) CORRECTION ENERGY": -0.00381140,  # dfocc
-            "A-(T) CORRECTION ENERGY": -0.00373215,  # dfocc
+            "(T) CORRECTION ENERGY": -0.00381139581323,  # dfocc, tight
+            "A-(T) CORRECTION ENERGY": -0.00373214885816,  # dfocc, tight
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001113861889,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.176001256953,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.033743742943,  # dfocc, tight
@@ -9019,10 +9019,10 @@ _std_suite = [
             "LCCD CORRELATION ENERGY": -0.19170174,  # dfocc
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.03676422,  # dfocc
-            "CCSD CORRELATION ENERGY": -0.18831658,  # dfocc
+            "CCSD CORRELATION ENERGY": -0.18831657592466,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
-            "(T) CORRECTION ENERGY": -0.00498288,  # dfocc
-            "A-(T) CORRECTION ENERGY": -0.00488266,  # dfocc
+            "(T) CORRECTION ENERGY": -0.00498288386522,  # dfocc, tight
+            "A-(T) CORRECTION ENERGY": -0.00488265656152,  # dfocc, tight
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001218721333,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.192985744725,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.037047752001,  # dfocc, tight
@@ -9173,11 +9173,11 @@ _std_suite = [
             "LCCD CORRELATION ENERGY": -0.2100441271,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD TOTAL GRADIENT": np.array([0.0, 0.0, 0.00218256974, 0.0, 0.0, -0.00218256974]).reshape((-1, 3)),
-            "CCSD CORRELATION ENERGY": -0.20887885,
+            "CCSD CORRELATION ENERGY": -0.20887887,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.04845784,
-            "(T) CORRECTION ENERGY": -0.00193844,
-            "A-(T) CORRECTION ENERGY": -0.00196317,  # dfocc
+            "(T) CORRECTION ENERGY": -0.00193844,  # dfocc, tight
+            "A-(T) CORRECTION ENERGY": -0.00196317,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(6).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(36).reshape((6, 6)),
         },
@@ -9201,11 +9201,11 @@ _std_suite = [
             "MP3 SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.2320256729,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
-            "CCSD CORRELATION ENERGY": -0.22954292,
+            "CCSD CORRELATION ENERGY": -0.22954292,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.05010092,
-            "(T) CORRECTION ENERGY": -0.00524386,
-            "A-(T) CORRECTION ENERGY": -0.00524138,  # dfocc
+            "(T) CORRECTION ENERGY": -0.00524386,  # dfocc, tight
+            "A-(T) CORRECTION ENERGY": -0.00524138,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -9229,11 +9229,11 @@ _std_suite = [
             "MP3 SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.2786865554,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
-            "CCSD CORRELATION ENERGY": -0.27570087,
+            "CCSD CORRELATION ENERGY": -0.27570087,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.05800702,
-            "(T) CORRECTION ENERGY": -0.00726367,
-            "A-(T) CORRECTION ENERGY": -0.00718150,  # dfocc
+            "(T) CORRECTION ENERGY": -0.00726367,  # dfocc, tight
+            "A-(T) CORRECTION ENERGY": -0.00718150,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -9259,10 +9259,10 @@ _std_suite = [
             "LCCD CORRELATION ENERGY": -0.0835057932,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0024017496,  # dfocc
-            "CCSD CORRELATION ENERGY": -0.08224146,  # dfocc
+            "CCSD CORRELATION ENERGY": -0.08224146,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
-            "(T) CORRECTION ENERGY": -0.00062667,  # dfocc
-            "A-(T) CORRECTION ENERGY": -0.00060983,  # dfocc
+            "(T) CORRECTION ENERGY": -0.00062667,  # dfocc, tight
+            "A-(T) CORRECTION ENERGY": -0.00060983,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(144).reshape((12, 12)),
         },
@@ -9288,10 +9288,10 @@ _std_suite = [
             "LCCD CORRELATION ENERGY": -0.1771099018,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0340807883,  # dfocc
-            "CCSD CORRELATION ENERGY": -0.17396776,  # dfocc
+            "CCSD CORRELATION ENERGY": -0.17396776,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
-            "(T) CORRECTION ENERGY": -0.00384848,  # dfocc
-            "A-(T) CORRECTION ENERGY": -0.00376848,  # dfocc
+            "(T) CORRECTION ENERGY": -0.00384848,  # dfocc, tight
+            "A-(T) CORRECTION ENERGY": -0.00376848,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -9317,10 +9317,10 @@ _std_suite = [
             "LCCD CORRELATION ENERGY": -0.2167832515,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0401303480,  # dfocc
-            "CCSD CORRELATION ENERGY": -0.21329358,  # dfocc
+            "CCSD CORRELATION ENERGY": -0.21329358,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
-            "(T) CORRECTION ENERGY": -0.00516657,  # dfocc
-            "A-(T) CORRECTION ENERGY": -0.00506430,  # dfocc
+            "(T) CORRECTION ENERGY": -0.00516657,  # dfocc, tight
+            "A-(T) CORRECTION ENERGY": -0.00506430,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -9409,11 +9409,11 @@ _std_suite = [
             "MP3 SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.2080964757,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
-            "CCSD CORRELATION ENERGY": -0.20695033,
+            "CCSD CORRELATION ENERGY": -0.20695035,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.04775464,
-            "(T) CORRECTION ENERGY": -0.00192252,
-            "A-(T) CORRECTION ENERGY": -0.00194627,  # dfocc
+            "(T) CORRECTION ENERGY": -0.00192252,  # dfocc, tight
+            "A-(T) CORRECTION ENERGY": -0.00194627,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(6).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(36).reshape((6, 6)),
         },
@@ -9437,11 +9437,11 @@ _std_suite = [
             "MP3 SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.2297520405,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
-            "CCSD CORRELATION ENERGY": -0.22730558,
+            "CCSD CORRELATION ENERGY": -0.22730551,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.04932106,
-            "(T) CORRECTION ENERGY": -0.00521762,
-            "A-(T) CORRECTION ENERGY": -0.00521484,  # dfocc
+            "(T) CORRECTION ENERGY": -0.00521762,  # dfocc, tight
+            "A-(T) CORRECTION ENERGY": -0.00521484,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -9465,11 +9465,11 @@ _std_suite = [
             "MP3 SINGLES ENERGY": 0.0,
             "LCCD CORRELATION ENERGY": -0.2531926943,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
-            "CCSD CORRELATION ENERGY": -0.25032917,
+            "CCSD CORRELATION ENERGY": -0.25032917,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.05405189,
-            "(T) CORRECTION ENERGY": -0.00709658,
-            "A-(T) CORRECTION ENERGY": -0.00701799,  # dfocc
+            "(T) CORRECTION ENERGY": -0.00709658,  # dfocc, tight
+            "A-(T) CORRECTION ENERGY": -0.00701799,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -9495,10 +9495,10 @@ _std_suite = [
             "LCCD CORRELATION ENERGY": -0.0825023638,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0022546311,  # dfocc
-            "CCSD CORRELATION ENERGY": -0.08123956,  # dfocc
+            "CCSD CORRELATION ENERGY": -0.08123956,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
-            "(T) CORRECTION ENERGY": -0.00060452,  # dfocc
-            "A-(T) CORRECTION ENERGY": -0.00058836,  # dfocc
+            "(T) CORRECTION ENERGY": -0.00060452,  # dfocc, tight
+            "A-(T) CORRECTION ENERGY": -0.00058836,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(144).reshape((12, 12)),
         },
@@ -9524,10 +9524,10 @@ _std_suite = [
             "LCCD CORRELATION ENERGY": -0.1748548876,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0333916888,  # dfocc
-            "CCSD CORRELATION ENERGY": -0.17174515,  # dfocc
+            "CCSD CORRELATION ENERGY": -0.17174515,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
-            "(T) CORRECTION ENERGY": -0.00381581,  # dfocc
-            "A-(T) CORRECTION ENERGY": -0.00373640,  # dfocc
+            "(T) CORRECTION ENERGY": -0.00381581,  # dfocc, tight
+            "A-(T) CORRECTION ENERGY": -0.00373640,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -9553,10 +9553,10 @@ _std_suite = [
             "LCCD CORRELATION ENERGY": -0.1917007514,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0367593319,  # dfocc
-            "CCSD CORRELATION ENERGY": -0.18831566,  # dfocc
+            "CCSD CORRELATION ENERGY": -0.18831566,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
-            "(T) CORRECTION ENERGY": -0.00498264,  # dfocc
-            "A-(T) CORRECTION ENERGY": -0.00488241,  # dfocc
+            "(T) CORRECTION ENERGY": -0.00498264,  # dfocc, tight
+            "A-(T) CORRECTION ENERGY": -0.00488241,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -9654,25 +9654,25 @@ _std_suite = [
             "LCCD CORRELATION ENERGY": -0.2100337333,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD TOTAL GRADIENT": np.array([0.0, 0.0, 0.002183232102, 0.0, 0.0, -0.002183232102]).reshape((-1, 3)),
-            "CCSD CORRELATION ENERGY": -0.20886884012911314,
+            "CCSD CORRELATION ENERGY": -0.20886881949604,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.04845491,
-            "CCSD TOTAL GRADIENT": np.array(
+            "CCSD TOTAL GRADIENT": np.array(  # dfocc, tight
                 [
                     0.0,
                     0.0,
-                    0.001970675302,
+                    0.001970518943,
                     0.0,
                     0.0,
-                    -0.001970675302,
+                    -0.001970518943,
                 ]
             ).reshape((-1, 3)),
-            "(T) CORRECTION ENERGY": -0.0019380186429220421,
-            "CCSD(T) TOTAL GRADIENT": np.array(  # dfocc
+            "(T) CORRECTION ENERGY": -0.00193801686266,  # dfocc, tight
+            "CCSD(T) TOTAL GRADIENT": np.array(  # dfocc, tight
                        [ 0.,              0.,              0.003068357914,
                         -0.,             -0.,             -0.003068357914]
             ).reshape((-1, 3)),
-            "A-(T) CORRECTION ENERGY": -0.00196275,  # dfocc
+            "A-(T) CORRECTION ENERGY": -0.00196274645521,  # dfocc, tight
             "OLCCD REFERENCE CORRECTION ENERGY": 0.000552755815,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.210569944656,  # dfocc, tight
             "OLCCD TOTAL GRADIENT": np.array(  # dfocc, tight
@@ -9728,29 +9728,29 @@ _std_suite = [
             "LCCD TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.008561006838, 0.0, 0.005236802973, -0.004280503419, 0.0, -0.005236802973, -0.004280503419]
             ).reshape((-1, 3)),
-            "CCSD CORRELATION ENERGY": -0.22953289,
+            "CCSD CORRELATION ENERGY": -0.22953288030956,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.05009877,
-            "CCSD TOTAL GRADIENT": np.array(
+            "CCSD TOTAL GRADIENT": np.array(  # dfocc, tight
                 [
                     0.0,
                     0.0,
-                    0.007518759967,
+                    0.007518713989,
                     0.0,
-                    0.004613106602,
-                    -0.003759379983,
+                    0.004612996204,
+                    -0.003759356993,
                     0.0,
-                    -0.004613106602,
-                    -0.003759379983,
+                    -0.004612996204,
+                    -0.003759356995,
                 ]
             ).reshape((-1, 3)),
-            "(T) CORRECTION ENERGY": -0.00524345,
-            "CCSD(T) TOTAL GRADIENT": np.array(  # dfocc
-                       [ 0.,              0.,              0.01020000645,
+            "(T) CORRECTION ENERGY": -0.00524345048605,  # dfocc, tight
+            "CCSD(T) TOTAL GRADIENT": np.array(  # dfocc, tight
+                       [ 0.,              0.,              0.010200006450,
                         -0.,              0.00604923838,  -0.005100003223,
                         -0.,             -0.00604923838,  -0.005100003226]
             ).reshape((-1, 3)),
-            "A-(T) CORRECTION ENERGY": -0.00524100,  # dfocc
+            "A-(T) CORRECTION ENERGY": -0.00524100328791,  # dfocc, tight
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001189314489,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.233173062606,  # dfocc, tight
             "OLCCD TOTAL GRADIENT": np.array(  # dfocc, tight
@@ -9808,19 +9808,19 @@ _std_suite = [
             "LCCD TOTAL GRADIENT": np.array(
                 [0.0, 0.0, -0.002344345036, 0.0, -0.001783728285, 0.001172172518, 0.0, 0.001783728285, 0.001172172518]
             ).reshape((-1, 3)),
-            "CCSD CORRELATION ENERGY": -0.27568236,
+            "CCSD CORRELATION ENERGY": -0.27568224252782,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.05800380,
-            "CCSD TOTAL GRADIENT": np.array(
-                [0.0, 0.0, -0.003408844165, 0.0, -0.002343169064, 0.001704422083, 0.0, 0.002343169064, 0.001704422083]
+            "CCSD TOTAL GRADIENT": np.array(  # dfocc, tight
+                [0.0, 0.0, -0.003408923965, 0.0, -0.002343243985, 0.001704461980, 0.0, 0.002343243985, 0.001704461985]
             ).reshape((-1, 3)),
-            "(T) CORRECTION ENERGY": -0.00726213,
-            "CCSD(T) TOTAL GRADIENT": np.array(  # dfocc
+            "(T) CORRECTION ENERGY": -0.00726212675888,  # dfocc, tight
+            "CCSD(T) TOTAL GRADIENT": np.array(  # dfocc, tight
                        [ 0.,              0.,             -0.000217412659,
                         -0.,             -0.000742939442,  0.000108706327,
                          0.,              0.000742939441,  0.000108706333]
             ).reshape((-1, 3)),
-            "A-(T) CORRECTION ENERGY": -0.00718001,  # dfocc
+            "A-(T) CORRECTION ENERGY": -0.00718000875661,  # dfocc, tight
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001352291360,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.279981325469,  # dfocc, tight
             "OLCCD TOTAL GRADIENT": np.array(  # dfocc, tight
@@ -9909,22 +9909,22 @@ _std_suite = [
                     -0.00004272599,
                 ]
             ).reshape((-1, 3)),
-            "CCSD CORRELATION ENERGY": -0.08223901,  # dfocc
+            "CCSD CORRELATION ENERGY": -0.08223900985527,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
-            "CCSD TOTAL GRADIENT": np.array(  # dfocc
+            "CCSD TOTAL GRADIENT": np.array(  # dfocc, tight
                        [-0.,              0.,              0.005201169988,
                          0.,             -0.,             -0.005060084065,
                         -0.,              0.014882201275, -0.000070542962,
                          0.,             -0.014882201275, -0.000070542961]
             ).reshape((-1, 3)),
-            "(T) CORRECTION ENERGY": -0.00062656,  # dfocc
-            "CCSD(T) TOTAL GRADIENT": np.array(  # dfocc
+            "(T) CORRECTION ENERGY": -0.00062655599464,  # dfocc, tight
+            "CCSD(T) TOTAL GRADIENT": np.array(  # dfocc, tight
                        [-0.,              0.,              0.004689654727,
                          0.,             -0.,             -0.004631718438,
                         -0.,              0.014962374742, -0.000028968145,
                          0.,             -0.014962374742, -0.000028968144]
             ).reshape((-1, 3)),
-            "A-(T) CORRECTION ENERGY": -0.00060972,  # dfocc
+            "A-(T) CORRECTION ENERGY": -0.00060971952519,  # dfocc, tight
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001486131044,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.084811453110,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.002450103204,  # dfocc, tight
@@ -9987,20 +9987,20 @@ _std_suite = [
             "LCCD TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.030686886723, 0.0, 0.016619966665, -0.015343443362, 0.0, -0.016619966665, -0.015343443362]
             ).reshape((-1, 3)),
-            "CCSD CORRELATION ENERGY": -0.17395819,  # dfocc
+            "CCSD CORRELATION ENERGY": -0.17395818499234,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
-            "CCSD TOTAL GRADIENT": np.array(  # dfocc
-                [-0.,              0.,              0.029266386707,
+            "CCSD TOTAL GRADIENT": np.array(  # dfocc, tight
+                [-0.,             0.,              0.029266386707,
                  0.,              0.015807793582, -0.014633193357,
                 -0.,             -0.015807793582, -0.014633193351]
             ).reshape((-1, 3)),
-            "(T) CORRECTION ENERGY": -0.00384810,  # dfocc
-            "CCSD(T) TOTAL GRADIENT": np.array(  # dfocc
+            "(T) CORRECTION ENERGY": -0.00384810072338,  # dfocc, tight
+            "CCSD(T) TOTAL GRADIENT": np.array(  # dfocc, tight
                        [-0.,              0.,              0.031148775451,
                          0.,              0.016805034066, -0.015574387726,
                         -0.,             -0.016805034066, -0.015574387725]
             ).reshape((-1, 3)),
-            "A-(T) CORRECTION ENERGY": -0.00376812,  # dfocc
+            "A-(T) CORRECTION ENERGY": -0.00376812221828,  # dfocc, tight
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001111851483,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.178196933112,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.034422402711,  # dfocc, tight
@@ -10061,20 +10061,20 @@ _std_suite = [
             "LCCD TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.018122428755, 0.0, 0.007810952273, -0.009061214377, 0.0, -0.007810952273, -0.009061214377]
             ).reshape((-1, 3)),
-            "CCSD CORRELATION ENERGY": -0.21328159,  # dfocc
+            "CCSD CORRELATION ENERGY": -0.21328159274710,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
-            "CCSD TOTAL GRADIENT": np.array(  # dfocc
+            "CCSD TOTAL GRADIENT": np.array(  # dfocc, tight
                 [ 0.,             -0.,              0.016818391166,
                 -0.,              0.0071380193,   -0.008409195584,
                  0.,             -0.0071380193,   -0.008409195582]
             ).reshape((-1, 3)),
-            "(T) CORRECTION ENERGY": -0.00516564,  # dfocc
-            "CCSD(T) TOTAL GRADIENT": np.array(  # dfocc
+            "(T) CORRECTION ENERGY": -0.00516563729772,  # dfocc, tight
+            "CCSD(T) TOTAL GRADIENT": np.array(  # dfocc, tight
                        [ 0.,             -0.,              0.019018581448,
                         -0.,              0.008236968052, -0.009509290726,
                          0.,             -0.008236968052, -0.009509290722]
             ).reshape((-1, 3)),
-            "A-(T) CORRECTION ENERGY": -0.00506341,  # dfocc
+            "A-(T) CORRECTION ENERGY": -0.00506341197521,  # dfocc, tight
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001285702841,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.218038927594,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.040510034508,  # dfocc, tight
@@ -10280,25 +10280,25 @@ _std_suite = [
             "LCCD CORRELATION ENERGY": -0.2080860831,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD TOTAL GRADIENT": np.array([0.0, 0.0, 0.002514968877, 0.0, 0.0, -0.002514968877]).reshape((-1, 3)),
-            "CCSD CORRELATION ENERGY": -0.20694032546082639,
+            "CCSD CORRELATION ENERGY": -0.20694030442285,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.04775171,
-            "CCSD TOTAL GRADIENT": np.array(
+            "CCSD TOTAL GRADIENT": np.array(  # dfocc, tight
                 [
                     0.0,
                     0.0,
-                    0.002316563628,
+                    0.002316407407,
                     0.0,
                     0.0,
-                    -0.002316563628,
+                    -0.002316407407,
                 ]
             ).reshape((-1, 3)),
-            "(T) CORRECTION ENERGY": -0.001922093564526723,
-            "CCSD(T) TOTAL GRADIENT": np.array(
+            "(T) CORRECTION ENERGY": -0.00192209183545,  # dfocc, tight
+            "CCSD(T) TOTAL GRADIENT": np.array(  # dfocc, tight
                        [ 0.,              0.,              0.003412477814,
                         -0.,             -0.,             -0.003412477814]
             ).reshape((-1, 3)),
-            "A-(T) CORRECTION ENERGY": -0.00194585,  # dfocc
+            "A-(T) CORRECTION ENERGY": -0.00194585245550,  # dfocc, tight
             "OLCCD REFERENCE CORRECTION ENERGY": 0.000553992712,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.208748872411,  # dfocc, tight
             "OLCCD TOTAL GRADIENT": np.array(  # dfocc, tight
@@ -10354,29 +10354,29 @@ _std_suite = [
             "LCCD TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.009150916979, 0.0, 0.005603501036, -0.00457545849, 0.0, -0.005603501036, -0.00457545849]
             ).reshape((-1, 3)),
-            "CCSD CORRELATION ENERGY": -0.22729554,
+            "CCSD CORRELATION ENERGY": -0.22729553766998,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.04931891,
-            "CCSD TOTAL GRADIENT": np.array(
+            "CCSD TOTAL GRADIENT": np.array(  # dfocc, tight
                 [
                     0.0,
                     0.0,
-                    0.008124347934,
+                    0.008124306221,
                     0.0,
-                    0.004987676555,
-                    -0.004062173967,
+                    0.004987568157,
+                    -0.004062153110,
                     0.0,
-                    -0.004987676555,
-                    -0.004062173967,
+                    -0.004987568157,
+                    -0.004062153111,
                 ]
             ).reshape((-1, 3)),
-            "(T) CORRECTION ENERGY": -0.00521721,
-            "CCSD(T) TOTAL GRADIENT": np.array(  # dfocc
+            "(T) CORRECTION ENERGY": -0.00521721307613,  # dfocc, tight
+            "CCSD(T) TOTAL GRADIENT": np.array(  # dfocc, tight
                        [ 0.,              0.,              0.010801208563,
-                        -0.,              0.006421774051, -0.00540060428 ,
+                        -0.,              0.006421774051, -0.005400604280,
                         -0.,             -0.006421774051, -0.005400604283]
             ).reshape((-1, 3)),
-            "A-(T) CORRECTION ENERGY": -0.00521446,  # dfocc
+            "A-(T) CORRECTION ENERGY": -0.00521446434812,  # dfocc, tight
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001194079264,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.231028592985,  # dfocc, tight
             "OLCCD TOTAL GRADIENT": np.array(  # dfocc, tight
@@ -10434,29 +10434,29 @@ _std_suite = [
             "LCCD TOTAL GRADIENT": np.array(
                 [0.0, 0.0, -0.001506644114, 0.0, -0.001400658245, 0.000753322057, 0.0, 0.001400658245, 0.000753322057]
             ).reshape((-1, 3)),
-            "CCSD CORRELATION ENERGY": -0.25031508,
+            "CCSD CORRELATION ENERGY": -0.25031496729288,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.05404876,
-            "CCSD TOTAL GRADIENT": np.array(
+            "CCSD TOTAL GRADIENT": np.array(  # dfocc, tight
                 [
                     0.0,
                     0.0,
-                    -0.002520920562,
+                    -0.002520998723,
                     0.0,
-                    -0.001932133533,
-                    0.001260460281,
+                    -0.001932209248,
+                    0.001260499359,
                     0.0,
-                    0.001932133533,
-                    0.001260460281,
+                    0.001932209248,
+                    0.001260499363,
                 ]
             ).reshape((-1, 3)),
-            "(T) CORRECTION ENERGY": -0.00709505,
-            "CCSD(T) TOTAL GRADIENT": np.array(  # dfocc
-                       [ 0.,              0.,              0.00061750653 ,
+            "(T) CORRECTION ENERGY": -0.00709505459495,  # dfocc, tight
+            "CCSD(T) TOTAL GRADIENT": np.array(  # dfocc, tight
+                       [ 0.,              0.,              0.000617506530,
                         -0.,             -0.000361314051, -0.000308753267,
                          0.,              0.000361314051, -0.000308753262]
             ).reshape((-1, 3)),
-            "A-(T) CORRECTION ENERGY": -0.00701651,  # dfocc
+            "A-(T) CORRECTION ENERGY": -0.00701650721029,  # dfocc, tight
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001298398813,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.254465606264,  # dfocc, tight
             "OLCCD TOTAL GRADIENT": np.array(  # dfocc, tight
@@ -10545,22 +10545,22 @@ _std_suite = [
                     -0.000048563431,
                 ]
             ).reshape((-1, 3)),
-            "CCSD CORRELATION ENERGY": -0.08123709,  # dfocc
+            "CCSD CORRELATION ENERGY": -0.08123709133288,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
-            "CCSD TOTAL GRADIENT": np.array(  # dfocc
+            "CCSD TOTAL GRADIENT": np.array(  # dfocc, tight
                        [-0.,              0.,              0.004955877488,
                          0.,             -0.,             -0.004802960939,
                         -0.,              0.014879065297, -0.000076458275,
                          0.,             -0.014879065297, -0.000076458275]
             ).reshape((-1, 3)),
-            "(T) CORRECTION ENERGY": -0.00060441,  # dfocc
-            "CCSD(T) TOTAL GRADIENT": np.array(  # dfocc
+            "(T) CORRECTION ENERGY": -0.00060440612636,  # dfocc, tight
+            "CCSD(T) TOTAL GRADIENT": np.array(  # dfocc, tight
                        [-0.,              0.,              0.004453849339,
                          0.,             -0.,             -0.004383447765,
                         -0.,              0.014958703713, -0.000035200787,
                          0.,             -0.014958703713, -0.000035200787]
             ).reshape((-1, 3)),
-            "A-(T) CORRECTION ENERGY": -0.00058825,  # dfocc
+            "A-(T) CORRECTION ENERGY": -0.00058824527447,  # dfocc, tight
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001494223667,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.083986395282,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.002308873939,  # dfocc, tight
@@ -10623,20 +10623,20 @@ _std_suite = [
             "LCCD TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.031455324295, 0.0, 0.017108389967, -0.015727662148, 0.0, -0.017108389967, -0.015727662148]
             ).reshape((-1, 3)),
-            "CCSD CORRELATION ENERGY": -0.17173557,  # dfocc
+            "CCSD CORRELATION ENERGY": -0.17173557387375,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
-            "CCSD TOTAL GRADIENT": np.array(  # dfocc
+            "CCSD TOTAL GRADIENT": np.array(  # dfocc, tight
                        [-0.,              0.,              0.030043575132,
                          0.,              0.016300990267, -0.015021787567,
                         -0.,             -0.016300990267, -0.015021787565]
             ).reshape((-1, 3)),
-            "(T) CORRECTION ENERGY": -0.00381544,  # dfocc
-            "CCSD(T) TOTAL GRADIENT": np.array(
+            "(T) CORRECTION ENERGY": -0.00381543842966,  # dfocc, tight
+            "CCSD(T) TOTAL GRADIENT": np.array(  # dfocc, tight
                        [-0.,              0.,              0.031923074308,
                          0.,              0.017296807836, -0.015961537154,
                         -0.,             -0.017296807836, -0.015961537154]
             ).reshape((-1, 3)),
-            "A-(T) CORRECTION ENERGY": -0.00373604,  # dfocc
+            "A-(T) CORRECTION ENERGY": -0.00373604126252,  # dfocc, tight
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001113749802,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.176088417240,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.033693410677,  # dfocc, tight
@@ -10697,20 +10697,20 @@ _std_suite = [
             "LCCD TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.019127907852, 0.0, 0.00829827557, -0.009563953926, 0.0, -0.00829827557, -0.009563953926]
             ).reshape((-1, 3)),
-            "CCSD CORRELATION ENERGY": -0.18830636,  # dfocc
+            "CCSD CORRELATION ENERGY": -0.18830636267506,  # dfocc, tight
             "CCSD SINGLES ENERGY": 0.0,
-            "CCSD TOTAL GRADIENT": np.array(  # dfocc
+            "CCSD TOTAL GRADIENT": np.array(  # dfocc, tight
                        [ 0.,             -0.,              0.017859476803,
                         -0.,              0.007647663282, -0.008929738402,
                          0.,             -0.007647663282, -0.008929738401]
             ).reshape((-1, 3)),
-            "(T) CORRECTION ENERGY": -0.00498171,  # dfocc
-            "CCSD(T) TOTAL GRADIENT": np.array(  # dfocc
+            "(T) CORRECTION ENERGY": -0.00498171470106,  # dfocc, tight
+            "CCSD(T) TOTAL GRADIENT": np.array(  # dfocc, tight
                        [ 0.,             -0.,              0.020007178737,
                         -0.,              0.008716203188, -0.010003589371,
                          0.,             -0.008716203188, -0.010003589367]
             ).reshape((-1, 3)),
-            "A-(T) CORRECTION ENERGY": -0.00488153,  # dfocc
+            "A-(T) CORRECTION ENERGY": -0.00488153123480,  # dfocc, tight
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001218640112,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.192974799277,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.037040961442,  # dfocc, tight

--- a/qcengine/programs/tests/standard_suite_ref.py
+++ b/qcengine/programs/tests/standard_suite_ref.py
@@ -443,6 +443,20 @@ _hess_scf_nh2_adz_cd_uhf = np.zeros(81).reshape((9, 9))
 _hess_scf_nh2_adz_cd_rohf = np.zeros(81).reshape((9, 9))
 # fmt: on
 
+# Rarely, reference values by conventional algorithms are _not_ available, while density-fitted or Cholesky-decomposed values _are_ available.
+#   This deprives DF/CD of a sanity check versus CONV values, so:
+#   (1) make every effort to hunt one down from other programs, reference implementations, etc.
+#   (2) if an inferior but ballpark value is available (e.g., 3-pt findif gradient or value with a small correction (<1e-4) missing), include it with notes on caveats.
+#   (3) if all else fails, add the QCVariable to _std_suite as `_knownmissing`
+#       (a) CONV-AE-CONV and CONV-FC-CONV blocks only
+#       (b) may have to adjust logic in compute_derived_qcvars
+#       (c) only use if it'll show up in checks (e.g., DF checks SAME-SPIN for uhf but not rhf, so CONV only needs _knownmissing for uhf)
+#   (4) revisit and add good CONV refs if opportunity arises.
+#
+#   Current `_knownmissing`s:
+#       * "OLCCD SAME-SPIN CORRELATION ENERGY" in CONV-FC-CONV for uhf/rohf
+#       * "OLCCD TOTAL GRADIENT" in CONV-FC-CONV
+_knownmissing = "KnownMissing"
 
 _std_suite = [
     # <<<  CONV-AE-CONV  >>>
@@ -4564,6 +4578,9 @@ _std_suite = [
             "[Q] CORRECTION ENERGY": -0.000379506649993,  # ncc
             "(Q) CORRECTION ENERGY": -0.000413051703749,  # ncc
             "CCSDTQ CORRELATION ENERGY": -0.209218171097884,  # ncc
+            "OLCCD REFERENCE CORRECTION ENERGY": 0.0005535161,  # p4n (core-occ rotations neglected)
+            "OLCCD CORRELATION ENERGY": -0.2086206237,  # p4n (core-occ rotations neglected)
+            "OLCCD TOTAL GRADIENT": _knownmissing,
             "OCCD REFERENCE CORRECTION ENERGY": 0.000510311,  # qchem
             "OCCD CORRELATION ENERGY": -0.206722125,  # qchem
             "OCCD TOTAL GRADIENT": np.array(  # qchem, rearranged
@@ -5062,6 +5079,9 @@ _std_suite = [
             "[Q] CORRECTION ENERGY": -0.000288788062660,  # ncc
             "(Q) CORRECTION ENERGY": -0.000503838444143,  # ncc
             "CCSDTQ CORRELATION ENERGY": -0.233074721244323,  # ncc
+            "OLCCD REFERENCE CORRECTION ENERGY": 0.0011942797,  # p4n (core-occ rotations neglected)
+            "OLCCD CORRELATION ENERGY": -0.2309009256,  # p4n (core-occ rotations neglected)
+            "OLCCD TOTAL GRADIENT": _knownmissing,
             "OCCD REFERENCE CORRECTION ENERGY": 0.001125755,  # qchem
             "OCCD CORRELATION ENERGY": -0.226880992,  # qchem
             "OCCD TOTAL GRADIENT": np.array(  # qchem, rearranged
@@ -5796,6 +5816,9 @@ _std_suite = [
             "[Q] CORRECTION ENERGY": -0.000151213601440,  # ncc
             "(Q) CORRECTION ENERGY": -0.000368016662584,  # ncc
             "CCSDTQ CORRELATION ENERGY": -0.257824320323573,  # ncc
+            "OLCCD REFERENCE CORRECTION ENERGY": 0.0012982937,  # p4n (core-occ rotations neglected)
+            "OLCCD CORRELATION ENERGY": -0.2544819317,  # p4n (core-occ rotations neglected)
+            "OLCCD TOTAL GRADIENT": _knownmissing,
             "OCCD REFERENCE CORRECTION ENERGY": 0.001225751,  # qchem
             "OCCD CORRELATION ENERGY": -0.250044802,  # qchem
             "OCCD TOTAL GRADIENT": np.array(  # qchem, rearranged
@@ -6446,6 +6469,10 @@ _std_suite = [
             "CCSDT-2 CORRELATION ENERGY": -0.081772292290,  # ecc
             "CCSDT-3 CORRELATION ENERGY": -0.08177701734273,  # vcc
             "CCSDT CORRELATION ENERGY": -0.08208821205578,  # vcc
+            "OLCCD REFERENCE CORRECTION ENERGY": 0.0014923056,  # p4n (core-occ rotations neglected)
+            "OLCCD CORRELATION ENERGY": -0.0839163095,  # p4n (core-occ rotations neglected)
+            "OLCCD SAME-SPIN CORRELATION ENERGY": _knownmissing,
+            "OLCCD TOTAL GRADIENT": _knownmissing,
             "OCCD REFERENCE CORRECTION ENERGY": 0.001154566,  # qchem
             "OCCD CORRELATION ENERGY": -0.081188108,  # qchem
             "OCCD TOTAL GRADIENT": np.array(  # qchem, rearranged
@@ -6679,6 +6706,10 @@ _std_suite = [
                 [[0.0, 0.0, 0.03180282], [0.0, 0.01723825, -0.01590141], [0.0, -0.01723825, -0.01590141]]
             ),
             "CCSDT CORRELATION ENERGY": -0.17591978591647,  # vcc
+            "OLCCD REFERENCE CORRECTION ENERGY": 0.0011137749,  # p4n (core-occ rotations neglected)
+            "OLCCD CORRELATION ENERGY": -0.1759973931,  # p4n (core-occ rotations neglected)
+            "OLCCD SAME-SPIN CORRELATION ENERGY": _knownmissing,
+            "OLCCD TOTAL GRADIENT": _knownmissing,
             "OCCD REFERENCE CORRECTION ENERGY": 0.000986681,  # qchem
             "OCCD CORRELATION ENERGY": -0.171498252,  # qchem
             "OCCD TOTAL GRADIENT": np.array(  # qchem, rearranged
@@ -6873,6 +6904,10 @@ _std_suite = [
             "CCSDT-2 CORRELATION ENERGY": -0.193087540038,  # vcc
             "CCSDT-3 CORRELATION ENERGY": -0.19310599643349,  # vcc
             "CCSDT CORRELATION ENERGY": -0.19368177447948,  # vcc
+            "OLCCD REFERENCE CORRECTION ENERGY": 0.0012186690,  # p4n (core-occ rotations neglected)
+            "OLCCD CORRELATION ENERGY": -0.1929863522,  # p4n (core-occ rotations neglected)
+            "OLCCD SAME-SPIN CORRELATION ENERGY": _knownmissing,
+            "OLCCD TOTAL GRADIENT": _knownmissing,
             "OCCD REFERENCE CORRECTION ENERGY": 0.001089195,  # qchem
             "OCCD CORRELATION ENERGY": -0.188164420,  # qchem
             "OCCD TOTAL GRADIENT": np.array(  # qchem, rearranged
@@ -7125,6 +7160,10 @@ _std_suite = [
             ).reshape((-1, 3)),
             "(T) CORRECTION ENERGY": -0.00068823,  # cfour only
             "CCSDT CORRELATION ENERGY": -0.08361110233142,  # vcc
+            "OLCCD REFERENCE CORRECTION ENERGY": -0.0000318047,  # p4n (core-occ rotations neglected)
+            "OLCCD CORRELATION ENERGY": -0.0854404197,  # p4n (core-occ rotations neglected)
+            "OLCCD SAME-SPIN CORRELATION ENERGY": _knownmissing,
+            "OLCCD TOTAL GRADIENT": _knownmissing,
             "OCCD REFERENCE CORRECTION ENERGY": -0.000362931,  # qchem
             "OCCD CORRELATION ENERGY": -0.082712571,  # qchem
             "OCCD TOTAL GRADIENT": np.array(  # qchem 3-pt findif
@@ -7209,6 +7248,10 @@ _std_suite = [
             ).reshape((-1, 3)),
             "(T) CORRECTION ENERGY": -0.003863167899,  # cfour only
             "CCSDT CORRELATION ENERGY": -0.18030677104047,  # vcc (different orbs: -0.18031166502580)
+            "OLCCD REFERENCE CORRECTION ENERGY": -0.0032999290,  # p4n (core-occ rotations neglected)
+            "OLCCD CORRELATION ENERGY": -0.1804110970,  # p4n (core-occ rotations neglected)
+            "OLCCD SAME-SPIN CORRELATION ENERGY": _knownmissing,
+            "OLCCD TOTAL GRADIENT": _knownmissing,
             "OCCD REFERENCE CORRECTION ENERGY": -0.003402152,  # qchem
             "OCCD CORRELATION ENERGY": -0.175891240,  # qchem
             "OCCD TOTAL GRADIENT": np.array(  # qchem 3-pt findif
@@ -7296,6 +7339,10 @@ _std_suite = [
             ).reshape((-1, 3)),
             "(T) CORRECTION ENERGY": -0.00504351,  # cfour only
             "CCSDT CORRELATION ENERGY": -0.19824510672649,  # vcc
+            "OLCCD REFERENCE CORRECTION ENERGY": -0.0033910391,  # p4n (core-occ rotations neglected)
+            "OLCCD CORRELATION ENERGY": -0.1975960603,  # p4n (core-occ rotations neglected)
+            "OLCCD SAME-SPIN CORRELATION ENERGY": _knownmissing,
+            "OLCCD TOTAL GRADIENT": _knownmissing,
             "OCCD REFERENCE CORRECTION ENERGY": -0.003478949,  # qchem
             "OCCD CORRELATION ENERGY": -0.192732814,  # qchem
             "OCCD TOTAL GRADIENT": np.array(  # qchem 3-pt findif
@@ -8292,9 +8339,8 @@ _std_suite = [
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.04857381,
             "(T) CORRECTION ENERGY": -0.0019363109218456449,
             "A-(T) CORRECTION ENERGY": -0.00196099,  # dfocc
-            "OLCCD REFERENCE CORRECTION ENERGY": 0.00055222,  # dfocc
-            "OLCCD CORRELATION ENERGY": -0.21043798,  # dfocc
-            "OLCCD SAME-SPIN CORRELATION ENERGY": 41,  # dfocc
+            "OLCCD REFERENCE CORRECTION ENERGY": 0.000552265186,  # dfocc, tight
+            "OLCCD CORRELATION ENERGY": -0.210437984945,  # dfocc, tight
             "OCCD REFERENCE CORRECTION ENERGY": 0.00051128,  # dfocc
             "OCCD CORRELATION ENERGY": -0.20864566636,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(6).reshape((-1, 3)),
@@ -8339,9 +8385,8 @@ _std_suite = [
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.05017955,
             "(T) CORRECTION ENERGY": -0.00523867,
             "A-(T) CORRECTION ENERGY": -0.00523629,  # dfocc
-            "OLCCD REFERENCE CORRECTION ENERGY": 0.00118959,  # dfocc
-            "OLCCD CORRELATION ENERGY": -0.23304784,  # dfocc
-            "OLCCD SAME-SPIN CORRELATION ENERGY": 42,  # dfocc
+            "OLCCD REFERENCE CORRECTION ENERGY": 0.001189623873,  # dfocc, tight
+            "OLCCD CORRELATION ENERGY": -0.233047836839,  # dfocc, tight
             "OCCD REFERENCE CORRECTION ENERGY": 0.00112446,  # dfocc
             "OCCD CORRELATION ENERGY": -0.22912033,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
@@ -8386,9 +8431,8 @@ _std_suite = [
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.05801141,
             "(T) CORRECTION ENERGY": -0.00726395,
             "A-(T) CORRECTION ENERGY": -0.00718178,  # dfocc
-            "OLCCD REFERENCE CORRECTION ENERGY": 0.00135219,  # dfocc
-            "OLCCD CORRELATION ENERGY": -0.28000417,  # dfocc
-            "OLCCD SAME-SPIN CORRELATION ENERGY": 43,  # dfocc
+            "OLCCD REFERENCE CORRECTION ENERGY": 0.001352168423,  # dfocc, tight
+            "OLCCD CORRELATION ENERGY": -0.280004165823,  # dfocc, tight
             "OCCD REFERENCE CORRECTION ENERGY": 0.00127925,  # dfocc
             "OCCD CORRELATION ENERGY": -0.27541700,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
@@ -8469,9 +8513,9 @@ _std_suite = [
             "CCSD SINGLES ENERGY": 0.0,
             "(T) CORRECTION ENERGY": -0.00062617,  # dfocc
             "A-(T) CORRECTION ENERGY": -0.00060935,  # dfocc
-            "OLCCD REFERENCE CORRECTION ENERGY": 0.00148385,  # dfocc
-            "OLCCD CORRELATION ENERGY": -0.08473702,  # dfocc
-            "OLCCD SAME-SPIN CORRELATION ENERGY": -0.00244894,  # dfocc
+            "OLCCD REFERENCE CORRECTION ENERGY": 0.001484257667,  # dfocc, tight
+            "OLCCD CORRELATION ENERGY": -0.084737023607,  # dfocc, tight
+            "OLCCD SAME-SPIN CORRELATION ENERGY": -0.002448903277,  # dfocc, tight
             "OCCD REFERENCE CORRECTION ENERGY": 0.00116602,  # dfocc, tight
             "OCCD CORRELATION ENERGY": -0.08218459647,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
@@ -8516,9 +8560,9 @@ _std_suite = [
             "CCSD SINGLES ENERGY": 0.0,
             "(T) CORRECTION ENERGY": -0.00384403,  # dfocc
             "A-(T) CORRECTION ENERGY": -0.00376420,  # dfocc
-            "OLCCD REFERENCE CORRECTION ENERGY": 0.00111173,  # dfocc
-            "OLCCD CORRELATION ENERGY": -0.17810919,  # dfocc
-            "OLCCD SAME-SPIN CORRELATION ENERGY": -0.03447266,  # dfocc
+            "OLCCD REFERENCE CORRECTION ENERGY": 0.001111961826,  # dfocc, tight
+            "OLCCD CORRELATION ENERGY": -0.178109192111,  # dfocc, tight
+            "OLCCD SAME-SPIN CORRELATION ENERGY": -0.034472712167,  # dfocc, tight
             "OCCD REFERENCE CORRECTION ENERGY": 0.0009877675,  # dfocc, tight
             "OCCD CORRELATION ENERGY": -0.17372337478,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
@@ -8563,9 +8607,9 @@ _std_suite = [
             "CCSD SINGLES ENERGY": 0.0,
             "(T) CORRECTION ENERGY": -0.00516682,  # dfocc
             "A-(T) CORRECTION ENERGY": -0.00506455,  # dfocc
-            "OLCCD REFERENCE CORRECTION ENERGY": 0.00128557,  # dfocc
-            "OLCCD CORRELATION ENERGY": -0.21805538,  # dfocc
-            "OLCCD SAME-SPIN CORRELATION ENERGY": -0.04051681,  # dfocc
+            "OLCCD REFERENCE CORRECTION ENERGY": 0.001285760689,  # dfocc, tight
+            "OLCCD CORRELATION ENERGY": -0.218055380962,  # dfocc, tight
+            "OLCCD SAME-SPIN CORRELATION ENERGY": -0.040516816950,  # dfocc, tight
             "OCCD REFERENCE CORRECTION ENERGY": 0.0011550930,  # dfocc, tight
             "OCCD CORRELATION ENERGY": -0.21313921,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
@@ -8591,9 +8635,9 @@ _std_suite = [
                 # dfocc findif-5 ae cd+cd
                 [0.0, 0.0, 0.01359215, 0.0, 0.0, -0.01312116, 0.0, 0.01031541, -0.0002355, 0.0, -0.01031541, -0.0002355]
             ).reshape((-1, 3)),
-            "OLCCD REFERENCE CORRECTION ENERGY": -0.00004009,  # dfocc
-            "OLCCD CORRELATION ENERGY": -0.08626069,  # dfocc
-            "OLCCD SAME-SPIN CORRELATION ENERGY": -0.00244892,  # dfocc
+            "OLCCD REFERENCE CORRECTION ENERGY": -0.000039411002,  # dfocc, tight
+            "OLCCD CORRELATION ENERGY": -0.086260687051,  # dfocc, tight
+            "OLCCD SAME-SPIN CORRELATION ENERGY": -0.002448904007,  # dfocc, tight
             "OCCD REFERENCE CORRECTION ENERGY": -0.00035764,  # dfocc
             "OCCD CORRELATION ENERGY": -0.08370826,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
@@ -8628,9 +8672,9 @@ _std_suite = [
                     -0.012794480501,
                 ]
             ).reshape((-1, 3)),
-            "OLCCD REFERENCE CORRECTION ENERGY": -0.00330177,  # dfocc
-            "OLCCD CORRELATION ENERGY": -0.18252269,  # dfocc
-            "OLCCD SAME-SPIN CORRELATION ENERGY": -0.03447262,  # dfocc
+            "OLCCD REFERENCE CORRECTION ENERGY": -0.003301541633,  # dfocc, tight
+            "OLCCD CORRELATION ENERGY": -0.182522693083,  # dfocc, tight
+            "OLCCD SAME-SPIN CORRELATION ENERGY": -0.034472708888,  # dfocc, tight
             "OCCD REFERENCE CORRECTION ENERGY": -0.00342574,  # dfocc
             "OCCD CORRELATION ENERGY": -0.17813688,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
@@ -8665,9 +8709,9 @@ _std_suite = [
                     -0.006942026833,
                 ]
             ).reshape((-1, 3)),
-            "OLCCD REFERENCE CORRECTION ENERGY": -0.00332424,  # dfocc
-            "OLCCD CORRELATION ENERGY": -0.22266511,  # dfocc
-            "OLCCD SAME-SPIN CORRELATION ENERGY": -0.04051680,  # dfocc
+            "OLCCD REFERENCE CORRECTION ENERGY": -0.003323981369,  # dfocc, tight
+            "OLCCD CORRELATION ENERGY": -0.222665113625,  # dfocc, tight
+            "OLCCD SAME-SPIN CORRELATION ENERGY": -0.040516826809,  # dfocc, tight
             "OCCD REFERENCE CORRECTION ENERGY": -0.00345464,  # dfocc
             "OCCD CORRELATION ENERGY": -0.21774895,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
@@ -8711,6 +8755,8 @@ _std_suite = [
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.04787083,
             "(T) CORRECTION ENERGY": -0.0019204203743072874,
             "A-(T) CORRECTION ENERGY": -0.00194413,  # dfocc
+            "OLCCD REFERENCE CORRECTION ENERGY": 0.000553491444,  # dfocc, tight
+            "OLCCD CORRELATION ENERGY": -0.208617145287,  # dfocc, tight
             "OCCD REFERENCE CORRECTION ENERGY": 0.00051177794,  # dfocc, tight
             "OCCD CORRELATION ENERGY": -0.20682760,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(6).reshape((-1, 3)),
@@ -8755,6 +8801,8 @@ _std_suite = [
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.04939986,
             "(T) CORRECTION ENERGY": -0.00521248,
             "A-(T) CORRECTION ENERGY": -0.00520980,  # dfocc
+            "OLCCD REFERENCE CORRECTION ENERGY": 0.001194389384,  # dfocc, tight
+            "OLCCD CORRELATION ENERGY": -0.230903883683,  # dfocc, tight
             "OCCD REFERENCE CORRECTION ENERGY": 0.00112772,  # dfocc
             "OCCD CORRELATION ENERGY": -0.22699047,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
@@ -8799,6 +8847,8 @@ _std_suite = [
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.05405638,
             "(T) CORRECTION ENERGY": -0.00709686,
             "A-(T) CORRECTION ENERGY": -0.00701826,  # dfocc
+            "OLCCD REFERENCE CORRECTION ENERGY": 0.001298302400,  # dfocc, tight
+            "OLCCD CORRELATION ENERGY": -0.254480886451,  # dfocc, tight
             "OCCD REFERENCE CORRECTION ENERGY": 0.00122690,  # dfocc
             "OCCD CORRELATION ENERGY": -0.25006391,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
@@ -8879,6 +8929,9 @@ _std_suite = [
             "CCSD SINGLES ENERGY": 0.0,
             "(T) CORRECTION ENERGY": -0.00060403,  # dfocc
             "A-(T) CORRECTION ENERGY": -0.00058790,  # dfocc
+            "OLCCD REFERENCE CORRECTION ENERGY": 0.001492355224,  # dfocc, tight
+            "OLCCD CORRELATION ENERGY": -0.083912298766,  # dfocc, tight
+            "OLCCD SAME-SPIN CORRELATION ENERGY": -0.002307760137,  # dfocc, tight
             "OCCD REFERENCE CORRECTION ENERGY": 0.0011735859,  # dfocc, tight
             "OCCD CORRELATION ENERGY": -0.08136638214,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
@@ -8923,6 +8976,9 @@ _std_suite = [
             "CCSD SINGLES ENERGY": 0.0,
             "(T) CORRECTION ENERGY": -0.00381140,  # dfocc
             "A-(T) CORRECTION ENERGY": -0.00373215,  # dfocc
+            "OLCCD REFERENCE CORRECTION ENERGY": 0.001113861889,  # dfocc, tight
+            "OLCCD CORRELATION ENERGY": -0.176001256953,  # dfocc, tight
+            "OLCCD SAME-SPIN CORRELATION ENERGY": -0.033743742943,  # dfocc, tight
             "OCCD REFERENCE CORRECTION ENERGY": 0.0009886431,  # dfocc, tight
             "OCCD CORRELATION ENERGY": -0.17163549,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
@@ -8967,6 +9023,9 @@ _std_suite = [
             "CCSD SINGLES ENERGY": 0.0,
             "(T) CORRECTION ENERGY": -0.00498288,  # dfocc
             "A-(T) CORRECTION ENERGY": -0.00488266,  # dfocc
+            "OLCCD REFERENCE CORRECTION ENERGY": 0.001218721333,  # dfocc, tight
+            "OLCCD CORRELATION ENERGY": -0.192985744725,  # dfocc, tight
+            "OLCCD SAME-SPIN CORRELATION ENERGY": -0.037047752001,  # dfocc, tight
             "OCCD REFERENCE CORRECTION ENERGY": 0.0010911198,  # dfocc, tight
             "OCCD CORRELATION ENERGY": -0.18823687,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
@@ -9005,6 +9064,9 @@ _std_suite = [
                     -0.00024246,
                 ]
             ).reshape((-1, 3)),
+            "OLCCD REFERENCE CORRECTION ENERGY": -0.000031311396,  # dfocc, tight
+            "OLCCD CORRELATION ENERGY": -0.085435962210,  # dfocc, tight
+            "OLCCD SAME-SPIN CORRELATION ENERGY": -0.002307761175,  # dfocc, tight
             "OCCD REFERENCE CORRECTION ENERGY": -0.0003500776,  # dfocc, tight
             "OCCD CORRELATION ENERGY": -0.08289004548,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
@@ -9039,6 +9101,9 @@ _std_suite = [
                     -0.01318846179,
                 ]
             ).reshape((-1, 3)),
+            "OLCCD REFERENCE CORRECTION ENERGY": -0.003299640039,  # dfocc, tight
+            "OLCCD CORRELATION ENERGY": -0.180414757924,  # dfocc, tight
+            "OLCCD SAME-SPIN CORRELATION ENERGY": -0.033743734902,  # dfocc, tight
             "OCCD REFERENCE CORRECTION ENERGY": -0.0034248578,  # dfocc, tight
             "OCCD CORRELATION ENERGY": -0.17604899,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
@@ -9073,6 +9138,9 @@ _std_suite = [
                     -0.007444881162,
                 ]
             ).reshape((-1, 3)),
+            "OLCCD REFERENCE CORRECTION ENERGY": -0.003391009701,  # dfocc, tight
+            "OLCCD CORRELATION ENERGY": -0.197595477381,  # dfocc, tight
+            "OLCCD SAME-SPIN CORRELATION ENERGY": -0.037047749578,  # dfocc, tight
             "OCCD REFERENCE CORRECTION ENERGY": -0.0035186129,  # dfocc, tight
             "OCCD CORRELATION ENERGY": -0.19284661,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
@@ -9605,9 +9673,12 @@ _std_suite = [
                         -0.,             -0.,             -0.003068357914]
             ).reshape((-1, 3)),
             "A-(T) CORRECTION ENERGY": -0.00196275,  # dfocc
-            "OLCCD REFERENCE CORRECTION ENERGY": 0.00055271,  # dfocc
-            "OLCCD CORRELATION ENERGY": -0.21056994,  # dfocc
-            "OLCCD TOTAL GRADIENT": np.zeros(6).reshape((-1, 3)),
+            "OLCCD REFERENCE CORRECTION ENERGY": 0.000552755815,  # dfocc, tight
+            "OLCCD CORRELATION ENERGY": -0.210569944656,  # dfocc, tight
+            "OLCCD TOTAL GRADIENT": np.array(  # dfocc, tight
+              [  0.000000000000,     0.000000000000,     0.003371636637,
+                -0.000000000000,    -0.000000000000,    -0.003371636637]
+            ).reshape((-1, 3)),
             "OCCD REFERENCE CORRECTION ENERGY": 0.00051171478318,  # dfocc, tight
             "OCCD CORRELATION ENERGY": -0.20877455867384,  # dfocc, tight
             "OCCD TOTAL GRADIENT": np.array(  # dfocc, tight
@@ -9680,12 +9751,12 @@ _std_suite = [
                         -0.,             -0.00604923838,  -0.005100003226]
             ).reshape((-1, 3)),
             "A-(T) CORRECTION ENERGY": -0.00524100,  # dfocc
-            "OLCCD REFERENCE CORRECTION ENERGY": 0.00118928,  # dfocc
-            "OLCCD CORRELATION ENERGY": -0.23317306,  # dfocc
-            "OLCCD TOTAL GRADIENT": np.array(  # dfocc
-                       [ 0.,              0.,              0.009760324413,
-                        -0.,              0.005852719747, -0.004880162207,
-                        -0.,             -0.005852719747, -0.004880162207]
+            "OLCCD REFERENCE CORRECTION ENERGY": 0.001189314489,  # dfocc, tight
+            "OLCCD CORRELATION ENERGY": -0.233173062606,  # dfocc, tight
+            "OLCCD TOTAL GRADIENT": np.array(  # dfocc, tight
+                [        0.000000000000,    -0.000000000000,     0.009761700492,
+                        -0.000000000000,     0.005853403252,    -0.004880850246,
+                        -0.000000000000,    -0.005853403251,    -0.004880850246]
             ).reshape((-1, 3)),
             "OCCD REFERENCE CORRECTION ENERGY": 0.0011241002379,  # dfocc, tight
             "OCCD CORRELATION ENERGY": -0.22924045334096,  # dfocc, tight
@@ -9750,9 +9821,13 @@ _std_suite = [
                          0.,              0.000742939441,  0.000108706333]
             ).reshape((-1, 3)),
             "A-(T) CORRECTION ENERGY": -0.00718001,  # dfocc
-            "OLCCD REFERENCE CORRECTION ENERGY": 0.00135231,  # dfocc
-            "OLCCD CORRELATION ENERGY": -0.27998133,  # dfocc
-            "OLCCD TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
+            "OLCCD REFERENCE CORRECTION ENERGY": 0.001352291360,  # dfocc, tight
+            "OLCCD CORRELATION ENERGY": -0.279981325469,  # dfocc, tight
+            "OLCCD TOTAL GRADIENT": np.array(  # dfocc, tight
+             [  0.000000000000,    -0.000000000000,    -0.001075340549,
+               -0.000000000000,    -0.001136934323,     0.000537670274,
+                0.000000000000,     0.001136934323,     0.000537670274]
+            ).reshape((-1, 3)),
             "OCCD REFERENCE CORRECTION ENERGY": 0.00127938819983,  # dfocc, tight
             "OCCD CORRELATION ENERGY": -0.27539517277894,  # dfocc, tight
             "OCCD TOTAL GRADIENT": np.array(  # dfocc, tight
@@ -9850,9 +9925,15 @@ _std_suite = [
                          0.,             -0.014962374742, -0.000028968144]
             ).reshape((-1, 3)),
             "A-(T) CORRECTION ENERGY": -0.00060972,  # dfocc
-            "OLCCD REFERENCE CORRECTION ENERGY": 0.00148572,  # dfocc
-            "OLCCD CORRELATION ENERGY": -0.08481145,  # dfocc
-            "OLCCD SAME-SPIN CORRELATION ENERGY": -0.00245014,  # dfocc
+            "OLCCD REFERENCE CORRECTION ENERGY": 0.001486131044,  # dfocc, tight
+            "OLCCD CORRELATION ENERGY": -0.084811453110,  # dfocc, tight
+            "OLCCD SAME-SPIN CORRELATION ENERGY": -0.002450103204,  # dfocc, tight
+            "OLCCD TOTAL GRADIENT": np.array(  # dfocc, tight
+                [      -0.000000000000,     0.000000000000,     0.002942322545,
+                        0.000000000000,    -0.000000000000,    -0.002924986204,
+                       -0.000000000000,     0.015750409537,    -0.000008668171,
+                        0.000000000000,    -0.015750409537,    -0.000008668171]
+            ).reshape((-1, 3)),
             "OCCD REFERENCE CORRECTION ENERGY": 0.00116757931849,  # dfocc, tight
             "OCCD CORRELATION ENERGY": -0.08225497590846,  # dfocc, tight
             "OCCD TOTAL GRADIENT": np.array(  # dfocc, tight
@@ -9920,13 +10001,13 @@ _std_suite = [
                         -0.,             -0.016805034066, -0.015574387725]
             ).reshape((-1, 3)),
             "A-(T) CORRECTION ENERGY": -0.00376812,  # dfocc
-            "OLCCD REFERENCE CORRECTION ENERGY": 0.00111162,  # dfocc
-            "OLCCD CORRELATION ENERGY": -0.17819693,  # dfocc
-            "OLCCD SAME-SPIN CORRELATION ENERGY": -0.03442235,  # dfocc
-            "OLCCD TOTAL GRADIENT": np.array(  # dfocc
-                       [-0.,             -0.,              0.03186203099,
-                         0.,              0.01725870275,  -0.015931015497,
-                        -0.,             -0.01725870275,  -0.015931015497]
+            "OLCCD REFERENCE CORRECTION ENERGY": 0.001111851483,  # dfocc, tight
+            "OLCCD CORRELATION ENERGY": -0.178196933112,  # dfocc, tight
+            "OLCCD SAME-SPIN CORRELATION ENERGY": -0.034422402711,  # dfocc, tight
+            "OLCCD TOTAL GRADIENT": np.array(  # dfocc, tight
+            [  -0.000000000000,    -0.000000000000,     0.031864432517,
+                0.000000000000,     0.017258987132,    -0.015932216258,
+               -0.000000000000,    -0.017258987132,    -0.015932216258]
             ).reshape((-1, 3)),
             "OCCD REFERENCE CORRECTION ENERGY": 0.00098766230788,  # dfocc, tight
             "OCCD CORRELATION ENERGY": -0.17380639841079,  # dfocc, tight
@@ -9994,9 +10075,14 @@ _std_suite = [
                          0.,             -0.008236968052, -0.009509290722]
             ).reshape((-1, 3)),
             "A-(T) CORRECTION ENERGY": -0.00506341,  # dfocc
-            "OLCCD REFERENCE CORRECTION ENERGY": 0.00128551,  # dfocc
-            "OLCCD CORRELATION ENERGY": -0.21803893,  # dfocc
-            "OLCCD SAME-SPIN CORRELATION ENERGY": -0.04051003,  # dfocc
+            "OLCCD REFERENCE CORRECTION ENERGY": 0.001285702841,  # dfocc, tight
+            "OLCCD CORRELATION ENERGY": -0.218038927594,  # dfocc, tight
+            "OLCCD SAME-SPIN CORRELATION ENERGY": -0.040510034508,  # dfocc, tight
+            "OLCCD TOTAL GRADIENT": np.array(  # dfocc, tight
+                [        0.000000000000,    -0.000000000000,     0.019448090911,
+                        -0.000000000000,     0.008509858260,    -0.009724045456,
+                         0.000000000000,    -0.008509858260,    -0.009724045456]
+            ).reshape((-1, 3)),
             "OCCD REFERENCE CORRECTION ENERGY": 0.00115506325268,  # dfocc, tight
             "OCCD CORRELATION ENERGY": -0.21312358096054,  # dfocc, tight
             "OCCD TOTAL GRADIENT": np.array(  # dfocc, tight
@@ -10042,9 +10128,15 @@ _std_suite = [
             ).reshape((-1, 3)),
             "LCCD CORRELATION ENERGY": -0.0834776542,  # p4n
             "LCCD TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
-            "OLCCD REFERENCE CORRECTION ENERGY": -0.00003862,  # dfocc
-            "OLCCD CORRELATION ENERGY": -0.08633549,  # dfocc
-            "OLCCD SAME-SPIN CORRELATION ENERGY": -0.00245012,  # dfocc
+            "OLCCD REFERENCE CORRECTION ENERGY": -0.000037911160,  # dfocc, tight
+            "OLCCD CORRELATION ENERGY": -0.086335490199,  # dfocc, tight
+            "OLCCD SAME-SPIN CORRELATION ENERGY": -0.002450103939,  # dfocc, tight
+            "OLCCD TOTAL GRADIENT": np.array(  # dfocc, tight
+                [       -0.000000000000,     0.000000000000,     0.002942353924,
+                         0.000000000000,    -0.000000000000,    -0.002925017923,
+                        -0.000000000000,     0.015750403382,    -0.000008668000,
+                         0.000000000000,    -0.015750403382,    -0.000008668000]
+            ).reshape((-1, 3)),
             "OCCD REFERENCE CORRECTION ENERGY": -0.00035645775738,  # dfocc, tight
             "OCCD CORRELATION ENERGY": -0.08377901300913,  # dfocc, tight
             "OCCD TOTAL GRADIENT": np.array(  # dfocc, tight
@@ -10087,13 +10179,13 @@ _std_suite = [
                 ]
             ).reshape((-1, 3)),
             "LCCD CORRELATION ENERGY": -0.1792603912,  # p4n
-            "OLCCD REFERENCE CORRECTION ENERGY": -0.00330233,  # dfocc
-            "OLCCD CORRELATION ENERGY": -0.18261089,  # dfocc
-            "OLCCD SAME-SPIN CORRELATION ENERGY": -0.03442231,  # dfocc
-            "OLCCD TOTAL GRADIENT": np.array(  # dfocc
-                       [-0.,             -0.,              0.031864743   ,
-                         0.,              0.017258564742, -0.0159323715  ,
-                        -0.,             -0.017258564742, -0.0159323715  ]
+            "OLCCD REFERENCE CORRECTION ENERGY": -0.003302111181,  # dfocc, tight
+            "OLCCD CORRELATION ENERGY": -0.182610893321,  # dfocc, tight
+            "OLCCD SAME-SPIN CORRELATION ENERGY": -0.034422399491,  # dfocc, tight
+            "OLCCD TOTAL GRADIENT": np.array(  # dfocc, tight
+                [       -0.000000000000,    -0.000000000000,     0.031864462561,
+                         0.000000000000,     0.017259000991,    -0.015932231281,
+                        -0.000000000000,    -0.017259000990,    -0.015932231281]
             ).reshape((-1, 3)),
             "OCCD REFERENCE CORRECTION ENERGY": -0.00342629789193,  # dfocc, tight
             "OCCD CORRELATION ENERGY": -0.17822035862112,  # dfocc, tight
@@ -10136,9 +10228,14 @@ _std_suite = [
                 ]
             ).reshape((-1, 3)),
             "LCCD CORRELATION ENERGY": -0.2190866990,  # p4n
-            "OLCCD REFERENCE CORRECTION ENERGY": -0.00332461,  # dfocc
-            "OLCCD CORRELATION ENERGY": -0.22264897,  # dfocc
-            "OLCCD SAME-SPIN CORRELATION ENERGY": -0.04051002,  # dfocc
+            "OLCCD REFERENCE CORRECTION ENERGY": -0.003324348494,  # dfocc, tight
+            "OLCCD CORRELATION ENERGY": -0.222648969545,  # dfocc, tight
+            "OLCCD SAME-SPIN CORRELATION ENERGY": -0.040510044397,  # dfocc, tight
+            "OLCCD TOTAL GRADIENT": np.array(  # dfocc, tight
+                [        0.000000000000,    -0.000000000000,     0.019447884570,
+                        -0.000000000000,     0.008509802850,    -0.009723942285,
+                         0.000000000000,    -0.008509802849,    -0.009723942285]
+            ).reshape((-1, 3)),
             "OCCD REFERENCE CORRECTION ENERGY": -0.00345497869314,  # dfocc, tight
             "OCCD CORRELATION ENERGY": -0.21773362291808,  # dfocc, tight
             "OCCD TOTAL GRADIENT": np.array(  # dfocc, tight
@@ -10202,6 +10299,12 @@ _std_suite = [
                         -0.,             -0.,             -0.003412477814]
             ).reshape((-1, 3)),
             "A-(T) CORRECTION ENERGY": -0.00194585,  # dfocc
+            "OLCCD REFERENCE CORRECTION ENERGY": 0.000553992712,  # dfocc, tight
+            "OLCCD CORRELATION ENERGY": -0.208748872411,  # dfocc, tight
+            "OLCCD TOTAL GRADIENT": np.array(  # dfocc, tight
+              [    0.000000000000,     0.000000000000,     0.003792898685,
+                  -0.000000000000,    -0.000000000000,    -0.003792898685]
+            ).reshape((-1, 3)),
             "OCCD REFERENCE CORRECTION ENERGY": 0.00051222526754,  # dfocc, tight
             "OCCD CORRELATION ENERGY": -0.20695630522582,  # dfocc, tight
             "OCCD TOTAL GRADIENT": np.array(  # dfocc, tight
@@ -10274,6 +10377,13 @@ _std_suite = [
                         -0.,             -0.006421774051, -0.005400604283]
             ).reshape((-1, 3)),
             "A-(T) CORRECTION ENERGY": -0.00521446,  # dfocc
+            "OLCCD REFERENCE CORRECTION ENERGY": 0.001194079264,  # dfocc, tight
+            "OLCCD CORRELATION ENERGY": -0.231028592985,  # dfocc, tight
+            "OLCCD TOTAL GRADIENT": np.array(  # dfocc, tight
+       [        0.000000000000,     0.000000000000,     0.010488609074,
+               -0.000000000000,     0.006266448803,    -0.005244304537,
+               -0.000000000000,    -0.006266448803,    -0.005244304537]
+            ).reshape((-1, 3)),
             "OCCD REFERENCE CORRECTION ENERGY": 0.00112736114914,  # dfocc, tight
             "OCCD CORRELATION ENERGY":  -0.22711013815896,  # dfocc, tight
             "OCCD TOTAL GRADIENT": np.array(  # dfocc, tight
@@ -10347,6 +10457,13 @@ _std_suite = [
                          0.,              0.000361314051, -0.000308753262]
             ).reshape((-1, 3)),
             "A-(T) CORRECTION ENERGY": -0.00701651,  # dfocc
+            "OLCCD REFERENCE CORRECTION ENERGY": 0.001298398813,  # dfocc, tight
+            "OLCCD CORRELATION ENERGY": -0.254465606264,  # dfocc, tight
+            "OLCCD TOTAL GRADIENT": np.array(  # dfocc, tight
+                [        0.000000000000,    -0.000000000000,    -0.000178270779,
+                        -0.000000000000,    -0.000741462346,     0.000089135390,
+                         0.000000000000,     0.000741462346,     0.000089135390]
+            ).reshape((-1, 3)),
             "OCCD REFERENCE CORRECTION ENERGY": 0.00122701106154,  # dfocc, tight
             "OCCD CORRELATION ENERGY": -0.25004962087804,  # dfocc, tight
             "OCCD TOTAL GRADIENT": np.array(  # dfocc, tight
@@ -10444,6 +10561,15 @@ _std_suite = [
                          0.,             -0.014958703713, -0.000035200787]
             ).reshape((-1, 3)),
             "A-(T) CORRECTION ENERGY": -0.00058825,  # dfocc
+            "OLCCD REFERENCE CORRECTION ENERGY": 0.001494223667,  # dfocc, tight
+            "OLCCD CORRELATION ENERGY": -0.083986395282,  # dfocc, tight
+            "OLCCD SAME-SPIN CORRELATION ENERGY": -0.002308873939,  # dfocc, tight
+            "OLCCD TOTAL GRADIENT": np.array(  # dfocc, tight
+                [       -0.000000000000,     0.000000000000,     0.002693251383,
+                         0.000000000000,    -0.000000000000,    -0.002664270590,
+                        -0.000000000000,     0.015745905068,    -0.000014490396,
+                         0.000000000000,    -0.015745905068,    -0.000014490396]
+            ).reshape((-1, 3)),
             "OCCD REFERENCE CORRECTION ENERGY": 0.00117513618887,  # dfocc, tight
             "OCCD CORRELATION ENERGY": -0.08143642271488,  # dfocc, tight
             "OCCD TOTAL GRADIENT": np.array(  # dfocc, tight
@@ -10511,6 +10637,14 @@ _std_suite = [
                         -0.,             -0.017296807836, -0.015961537154]
             ).reshape((-1, 3)),
             "A-(T) CORRECTION ENERGY": -0.00373604,  # dfocc
+            "OLCCD REFERENCE CORRECTION ENERGY": 0.001113749802,  # dfocc, tight
+            "OLCCD CORRELATION ENERGY": -0.176088417240,  # dfocc, tight
+            "OLCCD SAME-SPIN CORRELATION ENERGY": -0.033693410677,  # dfocc, tight
+            "OLCCD TOTAL GRADIENT": np.array(  # dfocc, tight
+                [       -0.000000000000,    -0.000000000000,     0.032749728621,
+                         0.000000000000,     0.017783947932,    -0.016374864311,
+                        -0.000000000000,    -0.017783947932,    -0.016374864310]
+            ).reshape((-1, 3)),
             "OCCD REFERENCE CORRECTION ENERGY": 0.00098853594635,  # dfocc, tight
             "OCCD CORRELATION ENERGY": -0.17171797869288,  # dfocc, tight
             "OCCD TOTAL GRADIENT": np.array(  # dfocc, tight
@@ -10577,6 +10711,14 @@ _std_suite = [
                          0.,             -0.008716203188, -0.010003589367]
             ).reshape((-1, 3)),
             "A-(T) CORRECTION ENERGY": -0.00488153,  # dfocc
+            "OLCCD REFERENCE CORRECTION ENERGY": 0.001218640112,  # dfocc, tight
+            "OLCCD CORRELATION ENERGY": -0.192974799277,  # dfocc, tight
+            "OLCCD SAME-SPIN CORRELATION ENERGY": -0.037040961442,  # dfocc, tight
+            "OLCCD TOTAL GRADIENT": np.array(  # dfocc, tight
+                [        0.000000000000,     0.000000000000,     0.020520978467,
+                        -0.000000000000,     0.009009472752,    -0.010260489234,
+                         0.000000000000,    -0.009009472752,    -0.010260489234]
+            ).reshape((-1, 3)),
             "OCCD REFERENCE CORRECTION ENERGY": 0.0010910673835,  # dfocc, tight
             "OCCD CORRELATION ENERGY": -0.18822673037030,  # dfocc, tight
             "OCCD TOTAL GRADIENT": np.array(  # dfocc, tight
@@ -10621,6 +10763,15 @@ _std_suite = [
                 ]
             ).reshape((-1, 3)),
             "LCCD CORRELATION ENERGY": -0.0824737155,  # p4n
+            "OLCCD REFERENCE CORRECTION ENERGY": -0.000029817721,  # dfocc, tight
+            "OLCCD CORRELATION ENERGY": -0.085510432371,  # dfocc, tight
+            "OLCCD SAME-SPIN CORRELATION ENERGY": -0.002308874960,  # dfocc, tight
+            "OLCCD TOTAL GRADIENT": np.array(  # dfocc, tight
+                [       -0.000000000000,     0.000000000000,     0.002693270150,
+                         0.000000000000,    -0.000000000000,    -0.002664286871,
+                        -0.000000000000,     0.015745889183,    -0.000014491640,
+                         0.000000000000,    -0.015745889183,    -0.000014491640]
+            ).reshape((-1, 3)),
             "OCCD REFERENCE CORRECTION ENERGY": -0.00034890091894,  # dfocc, tight
             "OCCD CORRELATION ENERGY": -0.08296045969717,  # dfocc, tight
             "OCCD TOTAL GRADIENT": np.array(  # dfocc, tight
@@ -10663,6 +10814,14 @@ _std_suite = [
                 ]
             ).reshape((-1, 3)),
             "LCCD CORRELATION ENERGY": -0.1769909051,  # p4n
+            "OLCCD REFERENCE CORRECTION ENERGY": -0.003300211378,  # dfocc, tight
+            "OLCCD CORRELATION ENERGY": -0.180502377447,  # dfocc, tight
+            "OLCCD SAME-SPIN CORRELATION ENERGY": -0.033693402688,  # dfocc, tight
+            "OLCCD TOTAL GRADIENT": np.array(  # dfocc, tight
+                [       -0.000000000000,    -0.000000000000,     0.032749671199,
+                         0.000000000000,     0.017783936393,    -0.016374835600,
+                        -0.000000000000,    -0.017783936393,    -0.016374835600]
+            ).reshape((-1, 3)),
             "OCCD REFERENCE CORRECTION ENERGY": -0.00342542420012,  # dfocc, tight
             "OCCD CORRELATION ENERGY": -0.17613193885178,  # dfocc, tight
             "OCCD TOTAL GRADIENT": np.array(  # dfocc, tight
@@ -10704,6 +10863,14 @@ _std_suite = [
                 ]
             ).reshape((-1, 3)),
             "LCCD CORRELATION ENERGY": -0.1939804718,  # p4n
+            "OLCCD REFERENCE CORRECTION ENERGY": -0.003391400191,  # dfocc, tight
+            "OLCCD CORRELATION ENERGY": -0.197584841222,  # dfocc, tight
+            "OLCCD SAME-SPIN CORRELATION ENERGY": -0.037040959020,  # dfocc, tight
+            "OLCCD TOTAL GRADIENT": np.array(  # dfocc, tight
+                [        0.000000000000,     0.000000000000,     0.020521012807,
+                        -0.000000000000,     0.009009479704,    -0.010260506404,
+                         0.000000000000,    -0.009009479704,    -0.010260506404]
+            ).reshape((-1, 3)),
             "OCCD REFERENCE CORRECTION ENERGY": -0.00351897455648,  # dfocc, tight
             "OCCD CORRELATION ENERGY": -0.19283677235188,  # dfocc
             "OCCD TOTAL GRADIENT": np.array(  # dfocc, tight
@@ -11244,11 +11411,14 @@ def compute_derived_qcvars(std_suite_list):
                 calc["data"]["OLCCD CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
             )
             if "OLCCD SAME-SPIN CORRELATION ENERGY" in calc["data"]:
-                calc["data"]["OLCCD OPPOSITE-SPIN CORRELATION ENERGY"] = (
-                    calc["data"]["OLCCD CORRELATION ENERGY"]
-                    - calc["data"]["OLCCD REFERENCE CORRECTION ENERGY"]
-                    - calc["data"]["OLCCD SAME-SPIN CORRELATION ENERGY"]
-                )
+                if calc["data"]["OLCCD SAME-SPIN CORRELATION ENERGY"] == _knownmissing:
+                    calc["data"]["OLCCD OPPOSITE-SPIN CORRELATION ENERGY"] = _knownmissing
+                else:
+                    calc["data"]["OLCCD OPPOSITE-SPIN CORRELATION ENERGY"] = (
+                        calc["data"]["OLCCD CORRELATION ENERGY"]
+                        - calc["data"]["OLCCD REFERENCE CORRECTION ENERGY"]
+                        - calc["data"]["OLCCD SAME-SPIN CORRELATION ENERGY"]
+                    )
 
         if "OCCD CORRELATION ENERGY" in calc["data"]:
             calc["data"]["OCCD TOTAL ENERGY"] = (

--- a/qcengine/programs/tests/standard_suite_ref.py
+++ b/qcengine/programs/tests/standard_suite_ref.py
@@ -7280,6 +7280,7 @@ _std_suite = [
             "CCSD CORRELATION ENERGY": -0.20874537,
             "CCSD SINGLES ENERGY": 0.0,
             "(T) CORRECTION ENERGY": -0.00193646,
+            "A-(T) CORRECTION ENERGY": -0.00196115,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(6).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(36).reshape((6, 6)),
         },
@@ -7306,6 +7307,7 @@ _std_suite = [
             "CCSD CORRELATION ENERGY": -0.22941330,
             "CCSD SINGLES ENERGY": 0.0,
             "(T) CORRECTION ENERGY": -0.00523874,
+            "A-(T) CORRECTION ENERGY": -0.00523635,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -7332,6 +7334,7 @@ _std_suite = [
             "CCSD CORRELATION ENERGY": -0.27570541,
             "CCSD SINGLES ENERGY": 0.0,
             "(T) CORRECTION ENERGY": -0.00726403,
+            "A-(T) CORRECTION ENERGY": -0.00718185,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -7358,6 +7361,10 @@ _std_suite = [
             "LCCD CORRELATION ENERGY": -0.08343267,  # dfocc
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.00240067,  # dfocc
+            "CCSD CORRELATION ENERGY": -0.08217068,  # dfocc
+            "CCSD SINGLES ENERGY": 0.0,
+            "(T) CORRECTION ENERGY": -0.00062618,  # dfocc
+            "A-(T) CORRECTION ENERGY": -0.00060937,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(144).reshape((12, 12)),
         },
@@ -7384,6 +7391,10 @@ _std_suite = [
             "LCCD CORRELATION ENERGY": -0.17701281,  # dfocc
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.03413088,  # dfocc
+            "CCSD CORRELATION ENERGY": -0.17387591,  # dfocc
+            "CCSD SINGLES ENERGY": 0.0,
+            "(T) CORRECTION ENERGY": -0.00384405,  # dfocc
+            "A-(T) CORRECTION ENERGY": -0.00376422,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -7410,6 +7421,10 @@ _std_suite = [
             "LCCD CORRELATION ENERGY": -0.21678793,  # dfocc
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.04013550,  # dfocc
+            "CCSD CORRELATION ENERGY": -0.21329809,  # dfocc
+            "CCSD SINGLES ENERGY": 0.0,
+            "(T) CORRECTION ENERGY": -0.00516691,  # dfocc
+            "A-(T) CORRECTION ENERGY": -0.00506463,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -7497,6 +7512,7 @@ _std_suite = [
             "CCSD CORRELATION ENERGY": -0.20681721,
             "CCSD SINGLES ENERGY": 0.0,
             "(T) CORRECTION ENERGY": -0.00192057,
+            "A-(T) CORRECTION ENERGY": -0.00194429,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(6).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(36).reshape((6, 6)),
         },
@@ -7523,6 +7539,7 @@ _std_suite = [
             "CCSD CORRELATION ENERGY": -0.22717646,
             "CCSD SINGLES ENERGY": 0.0,
             "(T) CORRECTION ENERGY": -0.00521255,
+            "A-(T) CORRECTION ENERGY": -0.00520986,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -7549,6 +7566,7 @@ _std_suite = [
             "CCSD CORRELATION ENERGY": -0.25033052,
             "CCSD SINGLES ENERGY": 0.0,
             "(T) CORRECTION ENERGY": -0.00709694,
+            "A-(T) CORRECTION ENERGY": -0.00701833,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -7575,6 +7593,10 @@ _std_suite = [
             "LCCD CORRELATION ENERGY": -0.08242955,  # dfocc
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.00225358,  # dfocc
+            "CCSD CORRELATION ENERGY": -0.08116911,  # dfocc
+            "CCSD SINGLES ENERGY": 0.0,
+            "(T) CORRECTION ENERGY": -0.00060405,  # dfocc
+            "A-(T) CORRECTION ENERGY": -0.00058791,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(144).reshape((12, 12)),
         },
@@ -7601,6 +7623,10 @@ _std_suite = [
             "LCCD CORRELATION ENERGY": -0.17475833,  # dfocc
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.03344184,  # dfocc
+            "CCSD CORRELATION ENERGY": -0.17165381,  # dfocc
+            "CCSD SINGLES ENERGY": 0.0,
+            "(T) CORRECTION ENERGY": -0.00381142,  # dfocc
+            "A-(T) CORRECTION ENERGY": -0.00373217,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -7627,6 +7653,10 @@ _std_suite = [
             "LCCD CORRELATION ENERGY": -0.19170259,  # dfocc
             "LCCD SINGLES ENERGY": 0.0,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.03676455,  # dfocc
+            "CCSD CORRELATION ENERGY": -0.18831733,  # dfocc
+            "CCSD SINGLES ENERGY": 0.0,
+            "(T) CORRECTION ENERGY": -0.00498297,  # dfocc
+            "A-(T) CORRECTION ENERGY": -0.00488274,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -7720,6 +7750,7 @@ _std_suite = [
             "CCSD CORRELATION ENERGY": -0.20888438,
             "CCSD SINGLES ENERGY": 0.0,
             "(T) CORRECTION ENERGY": -0.00193859,
+            "A-(T) CORRECTION ENERGY": -0.00196333,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(6).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(36).reshape((6, 6)),
         },
@@ -7747,6 +7778,7 @@ _std_suite = [
             "CCSD CORRELATION ENERGY": -0.22954333,
             "CCSD SINGLES ENERGY": 0.0,
             "(T) CORRECTION ENERGY": -0.00524393,
+            "A-(T) CORRECTION ENERGY": -0.00524145,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -7774,6 +7806,7 @@ _std_suite = [
             "CCSD CORRELATION ENERGY": -0.27570207,
             "CCSD SINGLES ENERGY": 0.0,
             "(T) CORRECTION ENERGY": -0.00726375,
+            "A-(T) CORRECTION ENERGY": -0.00718158,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -7800,6 +7833,10 @@ _std_suite = [
             "LCCD CORRELATION ENERGY": -0.0835080983,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0024018298,  # dfocc
+            "CCSD CORRELATION ENERGY": -0.08224363,  # dfocc
+            "CCSD SINGLES ENERGY": 0.0,
+            "(T) CORRECTION ENERGY": -0.00062669,  # dfocc
+            "A-(T) CORRECTION ENERGY": -0.00060985,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(144).reshape((12, 12)),
         },
@@ -7826,6 +7863,10 @@ _std_suite = [
             "LCCD CORRELATION ENERGY": -0.1771107929,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0340809591,  # dfocc
+            "CCSD CORRELATION ENERGY": -0.17396848,  # dfocc
+            "CCSD SINGLES ENERGY": 0.0,
+            "(T) CORRECTION ENERGY": -0.00384851,  # dfocc
+            "A-(T) CORRECTION ENERGY": -0.00376850,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -7852,6 +7893,10 @@ _std_suite = [
             "LCCD CORRELATION ENERGY": -0.2167841215,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0401306929,  # dfocc
+            "CCSD CORRELATION ENERGY": -0.21329436,  # dfocc
+            "CCSD SINGLES ENERGY": 0.0,
+            "(T) CORRECTION ENERGY": -0.00516666,  # dfocc
+            "A-(T) CORRECTION ENERGY": -0.00506439,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -7946,6 +7991,7 @@ _std_suite = [
             "CCSD CORRELATION ENERGY": -0.20695586,
             "CCSD SINGLES ENERGY": 0.0,
             "(T) CORRECTION ENERGY": -0.00192267,
+            "A-(T) CORRECTION ENERGY": -0.00194643,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(6).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(36).reshape((6, 6)),
         },
@@ -7973,6 +8019,7 @@ _std_suite = [
             "CCSD CORRELATION ENERGY": -0.22730597,
             "CCSD SINGLES ENERGY": 0.0,
             "(T) CORRECTION ENERGY": -0.00521769,
+            "A-(T) CORRECTION ENERGY": -0.00521491,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -8000,6 +8047,7 @@ _std_suite = [
             "CCSD CORRELATION ENERGY": -0.25033030,
             "CCSD SINGLES ENERGY": 0.0,
             "(T) CORRECTION ENERGY": -0.00709666,
+            "A-(T) CORRECTION ENERGY": -0.00701806,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -8026,6 +8074,10 @@ _std_suite = [
             "LCCD CORRELATION ENERGY": -0.0825046579,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0022547041,  # dfocc
+            "CCSD CORRELATION ENERGY": -0.08124172,  # dfocc
+            "CCSD SINGLES ENERGY": 0.0,
+            "(T) CORRECTION ENERGY": -0.00060454,  # dfocc
+            "A-(T) CORRECTION ENERGY": -0.00058837,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(144).reshape((12, 12)),
         },
@@ -8052,6 +8104,10 @@ _std_suite = [
             "LCCD CORRELATION ENERGY": -0.1748557523,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0333918420,  # dfocc
+            "CCSD CORRELATION ENERGY": -0.17174585,  # dfocc
+            "CCSD SINGLES ENERGY": 0.0,
+            "(T) CORRECTION ENERGY": -0.00381584,  # dfocc
+            "A-(T) CORRECTION ENERGY": -0.00373642,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -8078,6 +8134,10 @@ _std_suite = [
             "LCCD CORRELATION ENERGY": -0.1917015960,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0367596684,  # dfocc
+            "CCSD CORRELATION ENERGY": -0.18831642,  # dfocc
+            "CCSD SINGLES ENERGY": 0.0,
+            "(T) CORRECTION ENERGY": -0.00498272,  # dfocc
+            "A-(T) CORRECTION ENERGY": -0.00488249,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -8167,12 +8227,21 @@ _std_suite = [
             ).reshape((-1, 3)),
             "MP3 CORRELATION ENERGY": -0.20647618,  # dfocc
             "MP3 SINGLES ENERGY": 0.0,
+            "MP3 TOTAL GRADIENT": np.array(
+                # dfocc findif-5
+                [ 0., 0., -0.000926981449, 0., 0., 0.000926981449]
+            ).reshape((-1, 3)),
             "LCCD CORRELATION ENERGY": -0.20990226,  # dfocc
             "LCCD SINGLES ENERGY": 0.0000000000,
+            "LCCD TOTAL GRADIENT": np.array(
+                # dfocc findif-5
+                [ 0., 0., 0.002193849073, 0., 0., -0.002193849073]
+            ).reshape((-1, 3)),
             "CCSD CORRELATION ENERGY": -0.20873986012771106,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.04857381,
             "(T) CORRECTION ENERGY": -0.0019363109218456449,
+            "A-(T) CORRECTION ENERGY": -0.00196099,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(6).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(36).reshape((6, 6)),
         },
@@ -8214,6 +8283,7 @@ _std_suite = [
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.05017955,
             "(T) CORRECTION ENERGY": -0.00523867,
+            "A-(T) CORRECTION ENERGY": -0.00523629,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -8255,6 +8325,7 @@ _std_suite = [
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.05801141,
             "(T) CORRECTION ENERGY": -0.00726395,
+            "A-(T) CORRECTION ENERGY": -0.00718178,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -8329,6 +8400,10 @@ _std_suite = [
                     -0.000043034255,
                 ]
             ).reshape((-1, 3)),
+            "CCSD CORRELATION ENERGY": -0.08216852,  # dfocc
+            "CCSD SINGLES ENERGY": 0.0,
+            "(T) CORRECTION ENERGY": -0.00062617,  # dfocc
+            "A-(T) CORRECTION ENERGY": -0.00060935,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(144).reshape((12, 12)),
         },
@@ -8367,6 +8442,10 @@ _std_suite = [
             "LCCD CORRELATION ENERGY": -0.17701192,  # dfocc
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.03413070,  # dfocc
+            "CCSD CORRELATION ENERGY": -0.17387519,  # dfocc
+            "CCSD SINGLES ENERGY": 0.0,
+            "(T) CORRECTION ENERGY": -0.00384403,  # dfocc
+            "A-(T) CORRECTION ENERGY": -0.00376420,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -8405,6 +8484,10 @@ _std_suite = [
             "LCCD CORRELATION ENERGY": -0.21678706,  # dfocc
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.04013515,  # dfocc
+            "CCSD CORRELATION ENERGY": -0.21329731,  # dfocc
+            "CCSD SINGLES ENERGY": 0.0,
+            "(T) CORRECTION ENERGY": -0.00516682,  # dfocc
+            "A-(T) CORRECTION ENERGY": -0.00506455,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -8518,12 +8601,21 @@ _std_suite = [
             ).reshape((-1, 3)),
             "MP3 CORRELATION ENERGY": -0.20453260,  # dfocc
             "MP3 SINGLES ENERGY": 0.0,
+            "MP3 TOTAL GRADIENT": np.array(
+                # dfocc findif-5 fc cd+cd
+                [ 0., 0., -0.000588974421, 0., 0., 0.000588974421]
+            ).reshape((-1, 3)),
             "LCCD CORRELATION ENERGY": -0.20795503,  # dfocc
             "LCCD SINGLES ENERGY": 0.0000000000,
+            "LCCD TOTAL GRADIENT": np.array(
+                # dfocc findif-5 fc cd+cd
+                [ 0., 0., 0.002525704147, 0., 0., -0.002525704147]
+            ).reshape((-1, 3)),
             "CCSD CORRELATION ENERGY": -0.2068117080298787,
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.04787083,
             "(T) CORRECTION ENERGY": -0.0019204203743072874,
+            "A-(T) CORRECTION ENERGY": -0.00194413,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(6).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(36).reshape((6, 6)),
         },
@@ -8565,6 +8657,7 @@ _std_suite = [
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.04939986,
             "(T) CORRECTION ENERGY": -0.00521248,
+            "A-(T) CORRECTION ENERGY": -0.00520980,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -8606,6 +8699,7 @@ _std_suite = [
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.05405638,
             "(T) CORRECTION ENERGY": -0.00709686,
+            "A-(T) CORRECTION ENERGY": -0.00701826,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -8680,6 +8774,10 @@ _std_suite = [
                     -0.000048867243,
                 ]
             ).reshape((-1, 3)),
+            "CCSD CORRELATION ENERGY": -0.08116696,  # dfocc
+            "CCSD SINGLES ENERGY": 0.0,
+            "(T) CORRECTION ENERGY": -0.00060403,  # dfocc
+            "A-(T) CORRECTION ENERGY": -0.00058790,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(144).reshape((12, 12)),
         },
@@ -8718,6 +8816,10 @@ _std_suite = [
             "LCCD CORRELATION ENERGY": -0.17475747,  # dfocc
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0334416820,  # dfocc
+            "CCSD CORRELATION ENERGY": -0.17165312,  # dfocc
+            "CCSD SINGLES ENERGY": 0.0,
+            "(T) CORRECTION ENERGY": -0.00381140,  # dfocc
+            "A-(T) CORRECTION ENERGY": -0.00373215,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -8756,6 +8858,10 @@ _std_suite = [
             "LCCD CORRELATION ENERGY": -0.19170174,  # dfocc
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.03676422,  # dfocc
+            "CCSD CORRELATION ENERGY": -0.18831658,  # dfocc
+            "CCSD SINGLES ENERGY": 0.0,
+            "(T) CORRECTION ENERGY": -0.00498288,  # dfocc
+            "A-(T) CORRECTION ENERGY": -0.00488266,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -8890,6 +8996,7 @@ _std_suite = [
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.04845784,
             "(T) CORRECTION ENERGY": -0.00193844,
+            "A-(T) CORRECTION ENERGY": -0.00196317,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(6).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(36).reshape((6, 6)),
         },
@@ -8917,6 +9024,7 @@ _std_suite = [
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.05010092,
             "(T) CORRECTION ENERGY": -0.00524386,
+            "A-(T) CORRECTION ENERGY": -0.00524138,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -8944,6 +9052,7 @@ _std_suite = [
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.05800702,
             "(T) CORRECTION ENERGY": -0.00726367,
+            "A-(T) CORRECTION ENERGY": -0.00718150,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -8969,6 +9078,10 @@ _std_suite = [
             "LCCD CORRELATION ENERGY": -0.0835057932,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0024017496,  # dfocc
+            "CCSD CORRELATION ENERGY": -0.08224146,  # dfocc
+            "CCSD SINGLES ENERGY": 0.0,
+            "(T) CORRECTION ENERGY": -0.00062667,  # dfocc
+            "A-(T) CORRECTION ENERGY": -0.00060983,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(144).reshape((12, 12)),
         },
@@ -8994,6 +9107,10 @@ _std_suite = [
             "LCCD CORRELATION ENERGY": -0.1771099018,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0340807883,  # dfocc
+            "CCSD CORRELATION ENERGY": -0.17396776,  # dfocc
+            "CCSD SINGLES ENERGY": 0.0,
+            "(T) CORRECTION ENERGY": -0.00384848,  # dfocc
+            "A-(T) CORRECTION ENERGY": -0.00376848,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -9019,6 +9136,10 @@ _std_suite = [
             "LCCD CORRELATION ENERGY": -0.2167832515,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0401303480,  # dfocc
+            "CCSD CORRELATION ENERGY": -0.21329358,  # dfocc
+            "CCSD SINGLES ENERGY": 0.0,
+            "(T) CORRECTION ENERGY": -0.00516657,  # dfocc
+            "A-(T) CORRECTION ENERGY": -0.00506430,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -9111,6 +9232,7 @@ _std_suite = [
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.04775464,
             "(T) CORRECTION ENERGY": -0.00192252,
+            "A-(T) CORRECTION ENERGY": -0.00194627,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(6).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(36).reshape((6, 6)),
         },
@@ -9138,6 +9260,7 @@ _std_suite = [
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.04932106,
             "(T) CORRECTION ENERGY": -0.00521762,
+            "A-(T) CORRECTION ENERGY": -0.00521484,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -9165,6 +9288,7 @@ _std_suite = [
             "CCSD SINGLES ENERGY": 0.0,
             "CCSD SAME-SPIN CORRELATION ENERGY": -0.05405189,
             "(T) CORRECTION ENERGY": -0.00709658,
+            "A-(T) CORRECTION ENERGY": -0.00701799,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -9190,6 +9314,10 @@ _std_suite = [
             "LCCD CORRELATION ENERGY": -0.0825023638,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0022546311,  # dfocc
+            "CCSD CORRELATION ENERGY": -0.08123956,  # dfocc
+            "CCSD SINGLES ENERGY": 0.0,
+            "(T) CORRECTION ENERGY": -0.00060452,  # dfocc
+            "A-(T) CORRECTION ENERGY": -0.00058836,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(144).reshape((12, 12)),
         },
@@ -9215,6 +9343,10 @@ _std_suite = [
             "LCCD CORRELATION ENERGY": -0.1748548876,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0333916888,  # dfocc
+            "CCSD CORRELATION ENERGY": -0.17174515,  # dfocc
+            "CCSD SINGLES ENERGY": 0.0,
+            "(T) CORRECTION ENERGY": -0.00381581,  # dfocc
+            "A-(T) CORRECTION ENERGY": -0.00373640,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -9240,6 +9372,10 @@ _std_suite = [
             "LCCD CORRELATION ENERGY": -0.1917007514,  # p4n
             "LCCD SINGLES ENERGY": 0.0000000000,
             "LCCD SAME-SPIN CORRELATION ENERGY": -0.0367593319,  # dfocc
+            "CCSD CORRELATION ENERGY": -0.18831566,  # dfocc
+            "CCSD SINGLES ENERGY": 0.0,
+            "(T) CORRECTION ENERGY": -0.00498264,  # dfocc
+            "A-(T) CORRECTION ENERGY": -0.00488241,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -9351,6 +9487,11 @@ _std_suite = [
                 ]
             ).reshape((-1, 3)),
             "(T) CORRECTION ENERGY": -0.0019380186429220421,
+            "CCSD(T) TOTAL GRADIENT": np.array(  # dfocc
+                       [ 0.,              0.,              0.003068357914,
+                        -0.,             -0.,             -0.003068357914]
+            ).reshape((-1, 3)),
+            "A-(T) CORRECTION ENERGY": -0.00196275,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(6).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(36).reshape((6, 6)),
         },
@@ -9411,6 +9552,12 @@ _std_suite = [
                 ]
             ).reshape((-1, 3)),
             "(T) CORRECTION ENERGY": -0.00524345,
+            "CCSD(T) TOTAL GRADIENT": np.array(  # dfocc
+                       [ 0.,              0.,              0.01020000645,
+                        -0.,              0.00604923838,  -0.005100003223,
+                        -0.,             -0.00604923838,  -0.005100003226]
+            ).reshape((-1, 3)),
+            "A-(T) CORRECTION ENERGY": -0.00524100,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -9461,6 +9608,12 @@ _std_suite = [
                 [0.0, 0.0, -0.003408844165, 0.0, -0.002343169064, 0.001704422083, 0.0, 0.002343169064, 0.001704422083]
             ).reshape((-1, 3)),
             "(T) CORRECTION ENERGY": -0.00726213,
+            "CCSD(T) TOTAL GRADIENT": np.array(  # dfocc
+                       [ 0.,              0.,             -0.000217412659,
+                        -0.,             -0.000742939442,  0.000108706327,
+                         0.,              0.000742939441,  0.000108706333]
+            ).reshape((-1, 3)),
+            "A-(T) CORRECTION ENERGY": -0.00718001,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -9535,6 +9688,22 @@ _std_suite = [
                     -0.00004272599,
                 ]
             ).reshape((-1, 3)),
+            "CCSD CORRELATION ENERGY": -0.08223901,  # dfocc
+            "CCSD SINGLES ENERGY": 0.0,
+            "CCSD TOTAL GRADIENT": np.array(  # dfocc
+                       [-0.,              0.,              0.005201169988,
+                         0.,             -0.,             -0.005060084065,
+                        -0.,              0.014882201275, -0.000070542962,
+                         0.,             -0.014882201275, -0.000070542961]
+            ).reshape((-1, 3)),
+            "(T) CORRECTION ENERGY": -0.00062656,  # dfocc
+            "CCSD(T) TOTAL GRADIENT": np.array(  # dfocc
+                       [-0.,              0.,              0.004689654727,
+                         0.,             -0.,             -0.004631718438,
+                        -0.,              0.014962374742, -0.000028968145,
+                         0.,             -0.014962374742, -0.000028968144]
+            ).reshape((-1, 3)),
+            "A-(T) CORRECTION ENERGY": -0.00060972,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(144).reshape((12, 12)),
         },
@@ -9580,6 +9749,20 @@ _std_suite = [
             "LCCD TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.030686886723, 0.0, 0.016619966665, -0.015343443362, 0.0, -0.016619966665, -0.015343443362]
             ).reshape((-1, 3)),
+            "CCSD CORRELATION ENERGY": -0.17395819,  # dfocc
+            "CCSD SINGLES ENERGY": 0.0,
+            "CCSD TOTAL GRADIENT": np.array(  # dfocc
+                [-0.,              0.,              0.029266386707,
+                 0.,              0.015807793582, -0.014633193357,
+                -0.,             -0.015807793582, -0.014633193351]
+            ).reshape((-1, 3)),
+            "(T) CORRECTION ENERGY": -0.00384810,  # dfocc
+            "CCSD(T) TOTAL GRADIENT": np.array(  # dfocc
+                       [-0.,              0.,              0.031148775451,
+                         0.,              0.016805034066, -0.015574387726,
+                        -0.,             -0.016805034066, -0.015574387725]
+            ).reshape((-1, 3)),
+            "A-(T) CORRECTION ENERGY": -0.00376812,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -9625,6 +9808,20 @@ _std_suite = [
             "LCCD TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.018122428755, 0.0, 0.007810952273, -0.009061214377, 0.0, -0.007810952273, -0.009061214377]
             ).reshape((-1, 3)),
+            "CCSD CORRELATION ENERGY": -0.21328159,  # dfocc
+            "CCSD SINGLES ENERGY": 0.0,
+            "CCSD TOTAL GRADIENT": np.array(  # dfocc
+                [ 0.,             -0.,              0.016818391166,
+                -0.,              0.0071380193,   -0.008409195584,
+                 0.,             -0.0071380193,   -0.008409195582]
+            ).reshape((-1, 3)),
+            "(T) CORRECTION ENERGY": -0.00516564,  # dfocc
+            "CCSD(T) TOTAL GRADIENT": np.array(  # dfocc
+                       [ 0.,             -0.,              0.019018581448,
+                        -0.,              0.008236968052, -0.009509290726,
+                         0.,             -0.008236968052, -0.009509290722]
+            ).reshape((-1, 3)),
+            "A-(T) CORRECTION ENERGY": -0.00506341,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -9782,6 +9979,11 @@ _std_suite = [
                 ]
             ).reshape((-1, 3)),
             "(T) CORRECTION ENERGY": -0.001922093564526723,
+            "CCSD(T) TOTAL GRADIENT": np.array(
+                       [ 0.,              0.,              0.003412477814,
+                        -0.,             -0.,             -0.003412477814]
+            ).reshape((-1, 3)),
+            "A-(T) CORRECTION ENERGY": -0.00194585,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(6).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(36).reshape((6, 6)),
         },
@@ -9842,6 +10044,12 @@ _std_suite = [
                 ]
             ).reshape((-1, 3)),
             "(T) CORRECTION ENERGY": -0.00521721,
+            "CCSD(T) TOTAL GRADIENT": np.array(  # dfocc
+                       [ 0.,              0.,              0.010801208563,
+                        -0.,              0.006421774051, -0.00540060428 ,
+                        -0.,             -0.006421774051, -0.005400604283]
+            ).reshape((-1, 3)),
+            "A-(T) CORRECTION ENERGY": -0.00521446,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -9902,6 +10110,12 @@ _std_suite = [
                 ]
             ).reshape((-1, 3)),
             "(T) CORRECTION ENERGY": -0.00709505,
+            "CCSD(T) TOTAL GRADIENT": np.array(  # dfocc
+                       [ 0.,              0.,              0.00061750653 ,
+                        -0.,             -0.000361314051, -0.000308753267,
+                         0.,              0.000361314051, -0.000308753262]
+            ).reshape((-1, 3)),
+            "A-(T) CORRECTION ENERGY": -0.00701651,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -9976,6 +10190,22 @@ _std_suite = [
                     -0.000048563431,
                 ]
             ).reshape((-1, 3)),
+            "CCSD CORRELATION ENERGY": -0.08123709,  # dfocc
+            "CCSD SINGLES ENERGY": 0.0,
+            "CCSD TOTAL GRADIENT": np.array(  # dfocc
+                       [-0.,              0.,              0.004955877488,
+                         0.,             -0.,             -0.004802960939,
+                        -0.,              0.014879065297, -0.000076458275,
+                         0.,             -0.014879065297, -0.000076458275]
+            ).reshape((-1, 3)),
+            "(T) CORRECTION ENERGY": -0.00060441,  # dfocc
+            "CCSD(T) TOTAL GRADIENT": np.array(  # dfocc
+                       [-0.,              0.,              0.004453849339,
+                         0.,             -0.,             -0.004383447765,
+                        -0.,              0.014958703713, -0.000035200787,
+                         0.,             -0.014958703713, -0.000035200787]
+            ).reshape((-1, 3)),
+            "A-(T) CORRECTION ENERGY": -0.00058825,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(144).reshape((12, 12)),
         },
@@ -10021,6 +10251,20 @@ _std_suite = [
             "LCCD TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.031455324295, 0.0, 0.017108389967, -0.015727662148, 0.0, -0.017108389967, -0.015727662148]
             ).reshape((-1, 3)),
+            "CCSD CORRELATION ENERGY": -0.17173557,  # dfocc
+            "CCSD SINGLES ENERGY": 0.0,
+            "CCSD TOTAL GRADIENT": np.array(  # dfocc
+                       [-0.,              0.,              0.030043575132,
+                         0.,              0.016300990267, -0.015021787567,
+                        -0.,             -0.016300990267, -0.015021787565]
+            ).reshape((-1, 3)),
+            "(T) CORRECTION ENERGY": -0.00381544,  # dfocc
+            "CCSD(T) TOTAL GRADIENT": np.array(
+                       [-0.,              0.,              0.031923074308,
+                         0.,              0.017296807836, -0.015961537154,
+                        -0.,             -0.017296807836, -0.015961537154]
+            ).reshape((-1, 3)),
+            "A-(T) CORRECTION ENERGY": -0.00373604,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -10066,6 +10310,20 @@ _std_suite = [
             "LCCD TOTAL GRADIENT": np.array(
                 [0.0, 0.0, 0.019127907852, 0.0, 0.00829827557, -0.009563953926, 0.0, -0.00829827557, -0.009563953926]
             ).reshape((-1, 3)),
+            "CCSD CORRELATION ENERGY": -0.18830636,  # dfocc
+            "CCSD SINGLES ENERGY": 0.0,
+            "CCSD TOTAL GRADIENT": np.array(  # dfocc
+                       [ 0.,             -0.,              0.017859476803,
+                        -0.,              0.007647663282, -0.008929738402,
+                         0.,             -0.007647663282, -0.008929738401]
+            ).reshape((-1, 3)),
+            "(T) CORRECTION ENERGY": -0.00498171,  # dfocc
+            "CCSD(T) TOTAL GRADIENT": np.array(  # dfocc
+                       [ 0.,             -0.,              0.020007178737,
+                        -0.,              0.008716203188, -0.010003589371,
+                         0.,             -0.008716203188, -0.010003589367]
+            ).reshape((-1, 3)),
+            "A-(T) CORRECTION ENERGY": -0.00488153,  # dfocc
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },

--- a/qcengine/programs/tests/standard_suite_ref.py
+++ b/qcengine/programs/tests/standard_suite_ref.py
@@ -456,6 +456,8 @@ _hess_scf_nh2_adz_cd_rohf = np.zeros(81).reshape((9, 9))
 #   Current `_knownmissing`s:
 #       * "OLCCD SAME-SPIN CORRELATION ENERGY" in CONV-FC-CONV for uhf/rohf
 #       * "OLCCD TOTAL GRADIENT" in CONV-FC-CONV
+#       * "O(T) CORRECTION ENERGY in CONV-AE-CONV and CONV-FC-CONV
+#       * "A-O(T) CORRECTION ENERGY" in CONV-AE-CONV and CONV-FC-CONV
 _knownmissing = "KnownMissing"
 
 _std_suite = [
@@ -682,6 +684,8 @@ _std_suite = [
             "OCCD TOTAL GRADIENT": np.array(  # qchem, rearranged
                 [    0.00000000,    0.00000000, 0.00184797, 0, 0, -0.00184797]
             ).reshape((-1, 3)),
+            "O(T) CORRECTION ENERGY": _knownmissing,
+            "A-O(T) CORRECTION ENERGY": _knownmissing,
             "PBE TOTAL ENERGY": -100.33517315116806,  # psi 99,590
             "PBE TOTAL GRADIENT": np.array([[0.0, 0.0, 0.020107103338], [0.0, 0.0, -0.020107128125]]),  # psi 99,590
             "B3LYP TOTAL ENERGY": -100.43544624005466,  # psi 99,590
@@ -1496,6 +1500,8 @@ _std_suite = [
             "OCCD TOTAL GRADIENT": np.array(  # qchem, rearranged
                 [ 0., 0., 0.00727331, 0., 0.00447444, -0.00363665, 0., -0.00447444, -0.00363665]
             ).reshape((-1, 3)),
+            "O(T) CORRECTION ENERGY": _knownmissing,
+            "A-O(T) CORRECTION ENERGY": _knownmissing,
             "PBE TOTAL ENERGY": -76.35896461348528,  # psi 99,590
             "PBE TOTAL GRADIENT": np.array(  # psi 99,590
                 [
@@ -2494,6 +2500,8 @@ _std_suite = [
             "OCCD TOTAL GRADIENT": np.array(  # qchem, rearranged
                 [0, 0, -0.00363692, 0, -0.00246929, 0.00181846, 0, 0.00246929, 0.00181846]
             ).reshape((-1, 3)),
+            "O(T) CORRECTION ENERGY": _knownmissing,
+            "A-O(T) CORRECTION ENERGY": _knownmissing,
             "PBE TOTAL ENERGY": -76.38209089347507,  # psi 99,590
             "PBE TOTAL GRADIENT": np.array(  # psi 99,590
                 [
@@ -3348,6 +3356,8 @@ _std_suite = [
             "OCCD TOTAL GRADIENT": np.array(  # qchem, rearranged
               [0, 0, 0.00520110, 0, 0, -0.00505850, 0., 0.01487527, -0.00007130, 0., -0.01487527, -0.00007130]
             ).reshape((-1, 3)),
+            "O(T) CORRECTION ENERGY": _knownmissing,
+            "A-O(T) CORRECTION ENERGY": _knownmissing,
             "PBE TOTAL ENERGY": -26.04681636799003,  # psi 99,590
             "PBE TOTAL GRADIENT": np.array(  # psi 99,590
                 [
@@ -3599,6 +3609,8 @@ _std_suite = [
             "OCCD TOTAL GRADIENT":  np.array(  # qchem, rearranged
                 [0., 0., 0.02915872, 0., 0.01575094, -0.01457936, 0., -0.01575094, -0.01457936]
             ).reshape((-1, 3)),
+            "O(T) CORRECTION ENERGY": _knownmissing,
+            "A-O(T) CORRECTION ENERGY": _knownmissing,
             "PBE TOTAL ENERGY": -55.81473169701641,  # psi 99,590
             "PBE TOTAL GRADIENT": np.array(  # psi 99,590
                 [
@@ -3838,6 +3850,8 @@ _std_suite = [
             "OCCD TOTAL GRADIENT": np.array(  # qchem, rearranged
                 [0, 0, 0.01669862, 0,  0.00707632 , -0.00834931, 0, -0.00707632, -0.00834931],
             ).reshape((-1, 3)),
+            "O(T) CORRECTION ENERGY": _knownmissing,
+            "A-O(T) CORRECTION ENERGY": _knownmissing,
             "PBE TOTAL ENERGY": -55.83097248811423,  # psi 99,590
             "PBE TOTAL GRADIENT": np.array(  # psi 99,590
                 [
@@ -4135,6 +4149,8 @@ _std_suite = [
                 0.,  1.487654179061328e-02,  -7.165259590676168e-05,
                 0., -1.487654176147304e-02,  -7.165259308673899e-05]
             ).reshape((-1, 3)),
+            "O(T) CORRECTION ENERGY": _knownmissing,
+            "A-O(T) CORRECTION ENERGY": _knownmissing,
             "PBE TOTAL ENERGY": -26.046275584237,  # nwc 99,590
             "PBE TOTAL GRADIENT": np.array(  # nwc 99,590
                 [
@@ -4265,6 +4281,8 @@ _std_suite = [
                 0.,    1.575113356366842e-02,  -1.457995768916476e-02,
                 0.,   -1.575113354590485e-02,  -1.457995755771435e-02]
             ).reshape((-1, 3)),
+            "O(T) CORRECTION ENERGY": _knownmissing,
+            "A-O(T) CORRECTION ENERGY": _knownmissing,
             "PBE TOTAL ENERGY": -55.813318056978,  # nwc 99,590
             "PBE TOTAL GRADIENT": np.array(  # nwc 99,590
                 [
@@ -4392,6 +4410,8 @@ _std_suite = [
                 0.,   7.076450128096212e-03,  -8.349414756025908e-03,
                 0.,  -7.076449627163584e-03,  -8.349414585495651e-03]
             ).reshape((-1, 3)),
+            "O(T) CORRECTION ENERGY": _knownmissing,
+            "A-O(T) CORRECTION ENERGY": _knownmissing,
             "PBE TOTAL ENERGY": -55.829414170216,  # nwc 99,590
             "PBE TOTAL GRADIENT": np.array(  # nwc 99,590
                 [
@@ -4586,6 +4606,8 @@ _std_suite = [
             "OCCD TOTAL GRADIENT": np.array(  # qchem, rearranged
                 [0, 0, 0.00227059, 0, 0, -0.00227059]
             ).reshape((-1, 3)),
+            "O(T) CORRECTION ENERGY": _knownmissing,
+            "A-O(T) CORRECTION ENERGY": _knownmissing,
             # "XXX TOTAL GRADIENT": np.zeros(6).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(36).reshape((6, 6)),
         },
@@ -5087,6 +5109,8 @@ _std_suite = [
             "OCCD TOTAL GRADIENT": np.array(  # qchem, rearranged
                 [ 0, 0, 0.00797428, 0, 0.00488548, -0.00398714, 0, -0.00488548, -0.00398714]
             ).reshape((-1, 3)),
+            "O(T) CORRECTION ENERGY": _knownmissing,
+            "A-O(T) CORRECTION ENERGY": _knownmissing,
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -5824,6 +5848,8 @@ _std_suite = [
             "OCCD TOTAL GRADIENT": np.array(  # qchem, rearranged
                 [0, 0, -0.00269153 , 0, -0.00204152, 0.00134576, 0,  0.00204152, 0.00134576]
             ).reshape((-1, 3)),
+            "O(T) CORRECTION ENERGY": _knownmissing,
+            "A-O(T) CORRECTION ENERGY": _knownmissing,
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -6478,6 +6504,8 @@ _std_suite = [
             "OCCD TOTAL GRADIENT": np.array(  # qchem, rearranged
                 [0, 0, 0.00494989, 0, 0,  -0.00479521, 0, 0.01487079, -0.00007734, 0, -0.01487079, -0.00007734]
             ).reshape((-1, 3)),
+            "O(T) CORRECTION ENERGY": _knownmissing,
+            "A-O(T) CORRECTION ENERGY": _knownmissing,
             # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(144).reshape((12, 12)),
         },
@@ -6715,6 +6743,8 @@ _std_suite = [
             "OCCD TOTAL GRADIENT": np.array(  # qchem, rearranged
                 [0, 0, 0.03004030, 0, 0.01627564, -0.01502015, 0, -0.01627564, -0.01502015]
             ).reshape((-1, 3)),
+            "O(T) CORRECTION ENERGY": _knownmissing,
+            "A-O(T) CORRECTION ENERGY": _knownmissing,
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -6913,6 +6943,8 @@ _std_suite = [
             "OCCD TOTAL GRADIENT": np.array(  # qchem, rearranged
                 [0, 0, 0.01780351, 0,  0.00760260, -0.00890176 , 0, -0.00760260, -0.00890176]
             ).reshape((-1, 3)),
+            "O(T) CORRECTION ENERGY": _knownmissing,
+            "A-O(T) CORRECTION ENERGY": _knownmissing,
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -7172,6 +7204,8 @@ _std_suite = [
                  0.,    1.487359483495976e-02,  -7.746235397720769e-05,
                  0.,   -1.487359480111949e-02,  -7.746237653738908e-05]
             ).reshape((-1, 3)),
+            "O(T) CORRECTION ENERGY": _knownmissing,
+            "A-O(T) CORRECTION ENERGY": _knownmissing,
             # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(144).reshape((12, 12)),
         },
@@ -7259,6 +7293,8 @@ _std_suite = [
                0.,    1.624512323772365e-02,  -1.497021096596995e-02,
                0.,   -1.624512344378104e-02,  -1.497021098018081e-02]
             ).reshape((-1, 3)),
+            "O(T) CORRECTION ENERGY": _knownmissing,
+            "A-O(T) CORRECTION ENERGY": _knownmissing,
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -7350,6 +7386,8 @@ _std_suite = [
                  0.,   7.588575865469238e-03,  -8.872690465011601e-03,
                  0.,  -7.588575776651396e-03,  -8.872690337113909e-03]
             ).reshape((-1, 3)),
+            "O(T) CORRECTION ENERGY": _knownmissing,
+            "A-O(T) CORRECTION ENERGY": _knownmissing,
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -8341,8 +8379,10 @@ _std_suite = [
             "A-(T) CORRECTION ENERGY": -0.00196099396220,  # dfocc, tight
             "OLCCD REFERENCE CORRECTION ENERGY": 0.000552265186,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.210437984945,  # dfocc, tight
-            "OCCD REFERENCE CORRECTION ENERGY": 0.00051128,  # dfocc
-            "OCCD CORRELATION ENERGY": -0.20864566636,  # dfocc, tight
+            "OCCD REFERENCE CORRECTION ENERGY": 0.000511278480,  # dfocc, tight
+            "OCCD CORRELATION ENERGY": -0.208645666360,  # dfocc, tight
+            "O(T) CORRECTION ENERGY": -0.002062122653,  # dfocc, tight
+            "A-O(T) CORRECTION ENERGY": -0.002042124365,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(6).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(36).reshape((6, 6)),
         },
@@ -8387,8 +8427,10 @@ _std_suite = [
             "A-(T) CORRECTION ENERGY": -0.00523628844912,  # dfocc, tight
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001189623873,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.233047836839,  # dfocc, tight
-            "OCCD REFERENCE CORRECTION ENERGY": 0.00112446,  # dfocc
-            "OCCD CORRELATION ENERGY": -0.22912033,  # dfocc
+            "OCCD REFERENCE CORRECTION ENERGY": 0.001124461842,  # dfocc, tight
+            "OCCD CORRELATION ENERGY": -0.229120333540,  # dfocc, tight
+            "O(T) CORRECTION ENERGY": -0.005573969849,  # dfocc, tight
+            "A-O(T) CORRECTION ENERGY": -0.005476248095,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -8433,8 +8475,10 @@ _std_suite = [
             "A-(T) CORRECTION ENERGY": -0.00718177622315,  # dfocc, tight
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001352168423,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.280004165823,  # dfocc, tight
-            "OCCD REFERENCE CORRECTION ENERGY": 0.00127925,  # dfocc
-            "OCCD CORRELATION ENERGY": -0.27541700,  # dfocc
+            "OCCD REFERENCE CORRECTION ENERGY": 0.001279252698,  # dfocc, tight
+            "OCCD CORRELATION ENERGY": -0.275416999785,  # dfocc, tight
+            "O(T) CORRECTION ENERGY": -0.007572980491,  # dfocc, tight
+            "A-O(T) CORRECTION ENERGY": -0.007457755255,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -8516,8 +8560,10 @@ _std_suite = [
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001484257667,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.084737023607,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.002448903277,  # dfocc, tight
-            "OCCD REFERENCE CORRECTION ENERGY": 0.00116602,  # dfocc, tight
-            "OCCD CORRELATION ENERGY": -0.08218459647,  # dfocc, tight
+            "OCCD REFERENCE CORRECTION ENERGY": 0.001166023651,  # dfocc, tight
+            "OCCD CORRELATION ENERGY": -0.082184596469,  # dfocc, tight
+            "O(T) CORRECTION ENERGY": -0.000628150337,  # dfocc, tight
+            "A-O(T) CORRECTION ENERGY": -0.000605639575,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(144).reshape((12, 12)),
         },
@@ -8563,8 +8609,10 @@ _std_suite = [
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001111961826,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.178109192111,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.034472712167,  # dfocc, tight
-            "OCCD REFERENCE CORRECTION ENERGY": 0.0009877675,  # dfocc, tight
-            "OCCD CORRELATION ENERGY": -0.17372337478,  # dfocc, tight
+            "OCCD REFERENCE CORRECTION ENERGY": 0.000987767517,  # dfocc, tight
+            "OCCD CORRELATION ENERGY": -0.173723374782,  # dfocc, tight
+            "O(T) CORRECTION ENERGY": -0.003989459873,  # dfocc, tight
+            "A-O(T) CORRECTION ENERGY": -0.003889358031,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -8610,8 +8658,10 @@ _std_suite = [
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001285760689,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.218055380962,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.040516816950,  # dfocc, tight
-            "OCCD REFERENCE CORRECTION ENERGY": 0.0011550930,  # dfocc, tight
-            "OCCD CORRELATION ENERGY": -0.21313921,  # dfocc
+            "OCCD REFERENCE CORRECTION ENERGY": 0.001155093018,  # dfocc, tight
+            "OCCD CORRELATION ENERGY": -0.213139214735,  # dfocc, tight
+            "O(T) CORRECTION ENERGY": -0.005339052936,  # dfocc, tight
+            "A-O(T) CORRECTION ENERGY": -0.005215408128,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -8638,8 +8688,10 @@ _std_suite = [
             "OLCCD REFERENCE CORRECTION ENERGY": -0.000039411002,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.086260687051,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.002448904007,  # dfocc, tight
-            "OCCD REFERENCE CORRECTION ENERGY": -0.00035764,  # dfocc
-            "OCCD CORRELATION ENERGY": -0.08370826,  # dfocc
+            "OCCD REFERENCE CORRECTION ENERGY": -0.000357639780,  # dfocc, tight
+            "OCCD CORRELATION ENERGY": -0.083708259924,  # dfocc, tight
+            "O(T) CORRECTION ENERGY": -0.000628150338,  # dfocc, tight
+            "A-O(T) CORRECTION ENERGY": -0.000605639576,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(144).reshape((12, 12)),
         },
@@ -8675,8 +8727,10 @@ _std_suite = [
             "OLCCD REFERENCE CORRECTION ENERGY": -0.003301541633,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.182522693083,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.034472708888,  # dfocc, tight
-            "OCCD REFERENCE CORRECTION ENERGY": -0.00342574,  # dfocc
-            "OCCD CORRELATION ENERGY": -0.17813688,  # dfocc
+            "OCCD REFERENCE CORRECTION ENERGY": -0.003425733446,  # dfocc, tight
+            "OCCD CORRELATION ENERGY": -0.178136875756,  # dfocc, tight
+            "O(T) CORRECTION ENERGY": -0.003989459878,  # dfocc, tight
+            "A-O(T) CORRECTION ENERGY": -0.003889358035,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -8712,8 +8766,10 @@ _std_suite = [
             "OLCCD REFERENCE CORRECTION ENERGY": -0.003323981369,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.222665113625,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.040516826809,  # dfocc, tight
-            "OCCD REFERENCE CORRECTION ENERGY": -0.00345464,  # dfocc
-            "OCCD CORRELATION ENERGY": -0.21774895,  # dfocc
+            "OCCD REFERENCE CORRECTION ENERGY": -0.003454639639,  # dfocc, tight
+            "OCCD CORRELATION ENERGY": -0.217748947404,  # dfocc, tight
+            "O(T) CORRECTION ENERGY": -0.005339052938,  # dfocc, tight
+            "A-O(T) CORRECTION ENERGY": -0.005215408130,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -8757,8 +8813,10 @@ _std_suite = [
             "A-(T) CORRECTION ENERGY": -0.00194413458399,  # dfocc, tight
             "OLCCD REFERENCE CORRECTION ENERGY": 0.000553491444,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.208617145287,  # dfocc, tight
-            "OCCD REFERENCE CORRECTION ENERGY": 0.00051177794,  # dfocc, tight
-            "OCCD CORRELATION ENERGY": -0.20682760,  # dfocc
+            "OCCD REFERENCE CORRECTION ENERGY": 0.000511777936,  # dfocc, tight
+            "OCCD CORRELATION ENERGY": -0.206827599221,  # dfocc, tight
+            "O(T) CORRECTION ENERGY": -0.002043157128,  # dfocc, tight
+            "A-O(T) CORRECTION ENERGY": -0.002023030659,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(6).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(36).reshape((6, 6)),
         },
@@ -8803,8 +8861,10 @@ _std_suite = [
             "A-(T) CORRECTION ENERGY": -0.00520979601465,  # dfocc, tight
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001194389384,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.230903883683,  # dfocc, tight
-            "OCCD REFERENCE CORRECTION ENERGY": 0.00112772,  # dfocc
-            "OCCD CORRELATION ENERGY": -0.22699047,  # dfocc
+            "OCCD REFERENCE CORRECTION ENERGY": 0.001127721989,  # dfocc, tight
+            "OCCD CORRELATION ENERGY": -0.226990468428,  # dfocc, tight
+            "O(T) CORRECTION ENERGY": -0.005543695574,  # dfocc, tight
+            "A-O(T) CORRECTION ENERGY": -0.005445988059,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -8849,8 +8909,10 @@ _std_suite = [
             "A-(T) CORRECTION ENERGY": -0.00701825978933,  # dfocc, tight
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001298302400,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.254480886451,  # dfocc, tight
-            "OCCD REFERENCE CORRECTION ENERGY": 0.00122690,  # dfocc
-            "OCCD CORRELATION ENERGY": -0.25006391,  # dfocc
+            "OCCD REFERENCE CORRECTION ENERGY": 0.001226900919,  # dfocc, tight
+            "OCCD CORRELATION ENERGY": -0.250063908572,  # dfocc, tight
+            "O(T) CORRECTION ENERGY": -0.007402343012,  # dfocc, tight
+            "A-O(T) CORRECTION ENERGY": -0.007289120982,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -8932,8 +8994,10 @@ _std_suite = [
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001492355224,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.083912298766,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.002307760137,  # dfocc, tight
-            "OCCD REFERENCE CORRECTION ENERGY": 0.0011735859,  # dfocc, tight
-            "OCCD CORRELATION ENERGY": -0.08136638214,  # dfocc, tight
+            "OCCD REFERENCE CORRECTION ENERGY": 0.001173585912,  # dfocc, tight
+            "OCCD CORRELATION ENERGY": -0.081366382141,  # dfocc, tight
+            "O(T) CORRECTION ENERGY": -0.000608522852,  # dfocc, tight
+            "A-O(T) CORRECTION ENERGY": -0.000586642668,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(144).reshape((12, 12)),
         },
@@ -8979,8 +9043,10 @@ _std_suite = [
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001113861889,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.176001256953,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.033743742943,  # dfocc, tight
-            "OCCD REFERENCE CORRECTION ENERGY": 0.0009886431,  # dfocc, tight
-            "OCCD CORRELATION ENERGY": -0.17163549,  # dfocc
+            "OCCD REFERENCE CORRECTION ENERGY": 0.000988643093,  # dfocc, tight
+            "OCCD CORRELATION ENERGY": -0.171635485628,  # dfocc, tight
+            "O(T) CORRECTION ENERGY": -0.003954325581,  # dfocc, tight
+            "A-O(T) CORRECTION ENERGY": -0.003854709089,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -9026,8 +9092,10 @@ _std_suite = [
             "OLCCD REFERENCE CORRECTION ENERGY": 0.001218721333,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.192985744725,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.037047752001,  # dfocc, tight
-            "OCCD REFERENCE CORRECTION ENERGY": 0.0010911198,  # dfocc, tight
-            "OCCD CORRELATION ENERGY": -0.18823687,  # dfocc
+            "OCCD REFERENCE CORRECTION ENERGY": 0.001091119790,  # dfocc, tight
+            "OCCD CORRELATION ENERGY": -0.188236874643,  # dfocc, tight
+            "O(T) CORRECTION ENERGY": -0.005146215122,  # dfocc, tight
+            "A-O(T) CORRECTION ENERGY": -0.005026054902,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -9067,8 +9135,10 @@ _std_suite = [
             "OLCCD REFERENCE CORRECTION ENERGY": -0.000031311396,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.085435962210,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.002307761175,  # dfocc, tight
-            "OCCD REFERENCE CORRECTION ENERGY": -0.0003500776,  # dfocc, tight
-            "OCCD CORRELATION ENERGY": -0.08289004548,  # dfocc, tight
+            "OCCD REFERENCE CORRECTION ENERGY": -0.000350077551,  # dfocc, tight
+            "OCCD CORRELATION ENERGY": -0.082890045477,  # dfocc, tight
+            "O(T) CORRECTION ENERGY": -0.000608522844,  # dfocc, tight
+            "A-O(T) CORRECTION ENERGY": -0.000586642661,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(144).reshape((12, 12)),
         },
@@ -9104,8 +9174,10 @@ _std_suite = [
             "OLCCD REFERENCE CORRECTION ENERGY": -0.003299640039,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.180414757924,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.033743734902,  # dfocc, tight
-            "OCCD REFERENCE CORRECTION ENERGY": -0.0034248578,  # dfocc, tight
-            "OCCD CORRELATION ENERGY": -0.17604899,  # dfocc
+            "OCCD REFERENCE CORRECTION ENERGY": -0.003424857817,  # dfocc, tight
+            "OCCD CORRELATION ENERGY": -0.176048986550,  # dfocc, tight
+            "O(T) CORRECTION ENERGY": -0.003954325599,  # dfocc, tight
+            "A-O(T) CORRECTION ENERGY": -0.003854709106,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -9141,8 +9213,10 @@ _std_suite = [
             "OLCCD REFERENCE CORRECTION ENERGY": -0.003391009701,  # dfocc, tight
             "OLCCD CORRELATION ENERGY": -0.197595477381,  # dfocc, tight
             "OLCCD SAME-SPIN CORRELATION ENERGY": -0.037047749578,  # dfocc, tight
-            "OCCD REFERENCE CORRECTION ENERGY": -0.0035186129,  # dfocc, tight
-            "OCCD CORRELATION ENERGY": -0.19284661,  # dfocc
+            "OCCD REFERENCE CORRECTION ENERGY": -0.003518612862,  # dfocc, tight
+            "OCCD CORRELATION ENERGY": -0.192846607336,  # dfocc, tight
+            "O(T) CORRECTION ENERGY": -0.005146215124,  # dfocc, tight
+            "A-O(T) CORRECTION ENERGY": -0.005026054904,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -9685,6 +9759,8 @@ _std_suite = [
               [ 0., 0.,    0.001829701353,
                 0., 0.,   -0.001829701353]
             ).reshape((-1, 3)),
+            "O(T) CORRECTION ENERGY": -0.002064008068,  # dfocc, tight
+            "A-O(T) CORRECTION ENERGY": -0.002043954736,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(6).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(36).reshape((6, 6)),
         },
@@ -9765,6 +9841,8 @@ _std_suite = [
                -0.,  0.004473960460,    -0.003629531749,
                -0., -0.004473960460,    -0.003629531749]
             ).reshape((-1, 3)),
+            "O(T) CORRECTION ENERGY": -0.005578769043,  # dfocc, tight
+            "A-O(T) CORRECTION ENERGY": -0.005480838164,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -9835,6 +9913,8 @@ _std_suite = [
                -0., -0.002477953103,     0.001835328072,
                 0.,  0.002477953103,     0.001835328072]
             ).reshape((-1, 3)),
+            "O(T) CORRECTION ENERGY": -0.007571167323,  # dfocc, tight
+            "A-O(T) CORRECTION ENERGY": -0.007455996809,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -9942,6 +10022,8 @@ _std_suite = [
                         -0.,  0.014877327584,   -0.000073107828,
                          0., -0.014877327584,   -0.000073107828]
             ).reshape((-1, 3)),
+            "O(T) CORRECTION ENERGY": -0.000628655467,  # dfocc, tight
+            "A-O(T) CORRECTION ENERGY": -0.000606118093,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(144).reshape((12, 12)),
         },
@@ -10016,6 +10098,8 @@ _std_suite = [
                          0.,              0.01574493194,  -0.014573813372,
                         -0.,             -0.01574493194,  -0.014573813372]
             ).reshape((-1, 3)),
+            "O(T) CORRECTION ENERGY": -0.003993549226,  # dfocc, tight
+            "A-O(T) CORRECTION ENERGY": -0.003893263740,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -10090,6 +10174,8 @@ _std_suite = [
                -0.,  0.007064234315,   -0.008337577467,
                 0., -0.007064234315,   -0.008337577467]
             ).reshape((-1, 3)),
+            "O(T) CORRECTION ENERGY": -0.005337854371,  # dfocc, tight
+            "A-O(T) CORRECTION ENERGY": -0.005214252989,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -10145,6 +10231,8 @@ _std_suite = [
               -0.,  0.014877327583,    -0.000073107828,
                0., -0.014877327583,    -0.000073107828]
             ).reshape((-1, 3)),
+            "O(T) CORRECTION ENERGY": -0.000628655467,  # dfocc, tight
+            "A-O(T) CORRECTION ENERGY": -0.000606118094,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(144).reshape((12, 12)),
         },
@@ -10194,6 +10282,8 @@ _std_suite = [
                0.,  0.015744932006,    -0.014573813535,
               -0., -0.015744932006,    -0.014573813535]
             ).reshape((-1, 3)),
+            "O(T) CORRECTION ENERGY": -0.003993549230,  # dfocc, tight
+            "A-O(T) CORRECTION ENERGY": -0.003893263743,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -10243,6 +10333,8 @@ _std_suite = [
               -0.,  0.007064234369,    -0.008337577516,
                0., -0.007064234369,    -0.008337577516]
             ).reshape((-1, 3)),
+            "O(T) CORRECTION ENERGY": -0.005337854373,  # dfocc, tight
+            "A-O(T) CORRECTION ENERGY": -0.005214252991,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -10311,6 +10403,8 @@ _std_suite = [
              [  0.,  0.,   0.002245645626,
                -0., -0.,  -0.002245645626]
             ).reshape((-1, 3)),
+            "O(T) CORRECTION ENERGY": -0.002045023614,  # dfocc, tight
+            "A-O(T) CORRECTION ENERGY": -0.002024842553,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(6).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(36).reshape((6, 6)),
         },
@@ -10391,6 +10485,8 @@ _std_suite = [
               -0.,  0.004884098446,    -0.003988655057,
               -0., -0.004884098446,    -0.003988655057]
             ).reshape((-1, 3)),
+            "O(T) CORRECTION ENERGY": -0.005548457534,  # dfocc, tight
+            "A-O(T) CORRECTION ENERGY": -0.005450541943,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -10471,6 +10567,8 @@ _std_suite = [
               -0., -0.002056141369,     0.001369423268,
                0.,  0.002056141369,     0.001369423268]
             ).reshape((-1, 3)),
+            "O(T) CORRECTION ENERGY": -0.007400543965,  # dfocc, tight
+            "A-O(T) CORRECTION ENERGY": -0.007287376322,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -10578,6 +10676,8 @@ _std_suite = [
               -0.,  0.014873123435,    -0.000078781362,
                0., -0.014873123435,    -0.000078781362]
             ).reshape((-1, 3)),
+            "O(T) CORRECTION ENERGY": -0.000609013952,  # dfocc, tight
+            "A-O(T) CORRECTION ENERGY": -0.000587107823,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(144).reshape((12, 12)),
         },
@@ -10652,6 +10752,8 @@ _std_suite = [
                0.,  0.016268352543,    -0.015013680662,
               -0., -0.016268352543,    -0.015013680662]
             ).reshape((-1, 3)),
+            "O(T) CORRECTION ENERGY": -0.003958389693,  # dfocc, tight
+            "A-O(T) CORRECTION ENERGY": -0.003858590576,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -10726,6 +10828,8 @@ _std_suite = [
               -0.,  0.007590501254,    -0.008890843038,
                0., -0.007590501254,    -0.008890843038]
             ).reshape((-1, 3)),
+            "O(T) CORRECTION ENERGY": -0.005145029771,  # dfocc, tight
+            "A-O(T) CORRECTION ENERGY": -0.005024912480,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -10780,6 +10884,8 @@ _std_suite = [
               -0.,  0.014873123401,    -0.000078781338,
                0., -0.014873123401,    -0.000078781338]
             ).reshape((-1, 3)),
+            "O(T) CORRECTION ENERGY": -0.000609013944,  # dfocc, tight
+            "A-O(T) CORRECTION ENERGY": -0.000587107816,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(12).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(144).reshape((12, 12)),
         },
@@ -10829,6 +10935,8 @@ _std_suite = [
                0.,  0.016268353265,    -0.015013682235,
               -0., -0.016268353265,    -0.015013682235]
             ).reshape((-1, 3)),
+            "O(T) CORRECTION ENERGY": -0.003958389711,  # dfocc, tight
+            "A-O(T) CORRECTION ENERGY": -0.003858590593,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -10872,12 +10980,14 @@ _std_suite = [
                          0.000000000000,    -0.009009479704,    -0.010260506404]
             ).reshape((-1, 3)),
             "OCCD REFERENCE CORRECTION ENERGY": -0.00351897455648,  # dfocc, tight
-            "OCCD CORRELATION ENERGY": -0.19283677235188,  # dfocc
+            "OCCD CORRELATION ENERGY": -0.19283677235185,  # dfocc, tight
             "OCCD TOTAL GRADIENT": np.array(  # dfocc, tight
             [  0.,  0.000000000000,     0.017781687051,
               -0.,  0.007590501825,    -0.008890843526,
                0., -0.007590501825,    -0.008890843526]
             ).reshape((-1, 3)),
+            "O(T) CORRECTION ENERGY": -0.005145029773,  # dfocc, tight
+            "A-O(T) CORRECTION ENERGY": -0.005024912482,  # dfocc, tight
             # "XXX TOTAL GRADIENT": np.zeros(9).reshape((-1, 3)),
             # "XXX TOTAL HESSIAN": np.zeros(81).reshape((9, 9)),
         },
@@ -11429,6 +11539,30 @@ def compute_derived_qcvars(std_suite_list):
                     calc["data"]["OCCD CORRELATION ENERGY"]
                     - calc["data"]["OCCD REFERENCE CORRECTION ENERGY"]
                     - calc["data"]["OCCD SAME-SPIN CORRELATION ENERGY"]
+                )
+
+        if "O(T) CORRECTION ENERGY" in calc["data"]:
+            if calc["data"]["O(T) CORRECTION ENERGY"] == _knownmissing:
+                calc["data"]["OCCD(T) CORRELATION ENERGY"] = _knownmissing
+                calc["data"]["OCCD(T) TOTAL ENERGY"] = _knownmissing
+            else:
+                calc["data"]["OCCD(T) CORRELATION ENERGY"] = (
+                    calc["data"]["OCCD CORRELATION ENERGY"] + calc["data"]["O(T) CORRECTION ENERGY"]
+                )
+                calc["data"]["OCCD(T) TOTAL ENERGY"] = (
+                    calc["data"]["OCCD(T) CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
+                )
+
+        if "A-O(T) CORRECTION ENERGY" in calc["data"]:
+            if calc["data"]["A-O(T) CORRECTION ENERGY"] == _knownmissing:
+                calc["data"]["A-OCCD(T) CORRELATION ENERGY"] = _knownmissing
+                calc["data"]["A-OCCD(T) TOTAL ENERGY"] = _knownmissing
+            else:
+                calc["data"]["A-OCCD(T) CORRELATION ENERGY"] = (
+                    calc["data"]["OCCD CORRELATION ENERGY"] + calc["data"]["A-O(T) CORRECTION ENERGY"]
+                )
+                calc["data"]["A-OCCD(T) TOTAL ENERGY"] = (
+                    calc["data"]["A-OCCD(T) CORRELATION ENERGY"] + calc["data"]["HF TOTAL ENERGY"]
                 )
 
     calc["data"].update(_std_generics[f"{calc['meta']['system']}_{calc['meta']['basis']}_{calc['meta']['fcae']}"])

--- a/qcengine/programs/tests/standard_suite_runner.py
+++ b/qcengine/programs/tests/standard_suite_runner.py
@@ -12,36 +12,7 @@ import qcengine as qcng
 from qcengine.programs.util import mill_qcvars
 
 from .standard_suite_ref import answer_hash, std_suite
-
-from .standard_suite_contracts import (  # isort:skip
-    contractual_hf,
-    contractual_mp2,
-    contractual_mp2p5,
-    contractual_mp3,
-    contractual_mp4_prsdq_pr,
-    contractual_mp4,
-    contractual_cisd,
-    contractual_qcisd,
-    contractual_qcisd_prt_pr,
-    contractual_lccd,
-    contractual_lccsd,
-    contractual_ccd,
-    contractual_ccsd,
-    contractual_ccsdpt_prccsd_pr,
-    contractual_ccsd_prt_pr,
-    contractual_accsd_prt_pr,
-    contractual_ccsdt1a,
-    contractual_ccsdt1b,
-    contractual_ccsdt2,
-    contractual_ccsdt3,
-    contractual_ccsdt,
-    contractual_ccsdt_prq_pr,
-    contractual_ccsdtq,
-    contractual_dft_current,
-    contractual_current,
-    query_has_qcvar,
-    query_qcvar,
-)
+from .standard_suite_contracts import *
 
 pp = pprint.PrettyPrinter(width=120)
 

--- a/qcengine/programs/tests/test_standard_suite.py
+++ b/qcengine/programs/tests/test_standard_suite.py
@@ -27,7 +27,7 @@
 #
 # * (E4) Calculation the QC program thinks it can run but we know better -- `return_result` wrong.
 #   example: NWChem ROHF MP2 that's missing singles contribution
-#   handle: add "wrong" typle to test like `_w1`
+#   handle: add "wrong" tuple to test like `_w1`
 #   result: runner checks assertion fails at expected result and triggers pytest.xfail
 
 

--- a/qcengine/programs/util/ao_reordering.py
+++ b/qcengine/programs/util/ao_reordering.py
@@ -74,7 +74,9 @@ def mill_qcvars(mill: "AlignmentMill", qcvars: Dict[str, Any]) -> Dict[str, Any]
 
     milled = {}
     for k, v in qcvars.items():
-        if k.endswith("GRADIENT"):
+        if v == "KnownMissing":
+            milled[k] = v
+        elif k.endswith("GRADIENT"):
             milled[k] = mill.align_gradient(v)
         elif k.endswith("HESSIAN"):
             milled[k] = mill.align_hessian(v)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
This pairs with https://github.com/psi4/psi4/pull/2633. It doesn't affect QCEngine's general purpose, so I'll plan to mint a v0.24.1 with this when the Psi4 use is finalized.

Adds ref values for df ccsd, ccsd(t), a-ccsd(t), for orbital-optimized mp2, mp2.5, mp3, ccd, ccd(t), a-ccd(t), and for remp2 and oremp2. Existing reference values computed with Psi4's dfocc and occ modules have been updated now that it can converge tighter.

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
