### PR TITLE
Support OpenFF Toolkit v0.11+ in openmm.py

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,12 +28,12 @@ jobs:
             runs-on: ubuntu-latest
 
           - conda-env: torchani
-            python-version: 3.6
+            python-version: 3.8
             label: ANI
             runs-on: ubuntu-latest
 
           - conda-env: openmm
-            python-version: 3.6
+            python-version: 3.8
             label: OpenMM
             runs-on: ubuntu-latest
 
@@ -54,7 +54,7 @@ jobs:
             # formerly NWChem v6.6 with python-version: 3.6 & runs-on: ubuntu-16.04 but ubuntu env retired by GH Sep 2021
 
           - conda-env: mrchem
-            python-version: 3.6
+            python-version: 3.8
             label: MRChem
             runs-on: ubuntu-latest
 

--- a/qcengine/programs/openmm.py
+++ b/qcengine/programs/openmm.py
@@ -297,7 +297,10 @@ class OpenMMHarness(ProgramHarness):
         context = openmm.Context(openmm_system, integrator, platform, properties)
 
         # Set positions from our Open Force Field `Molecule`
-        context.setPositions(off_mol.conformers[0])
+        try:
+            context.setPositions(off_mol.conformers[0])
+        except ValueError:
+            context.setPositions(off_mol.conformers[0].to_openmm())
 
         # Compute the energy of the configuration
         state = context.getState(getEnergy=True)


### PR DESCRIPTION
Hi! This is my first contribution here, let me know if I've done anything wrong!

## Description

The OpenFF Toolkit v0.11 includes breaking changes, including enforcing that conformer units are specified with the new OpenFF Units package rather than OpenMM units. This PR updates QCEngine to be compatible with the new version while preserving compatibility with the old versions.

## Changelog description

Support OpenFF Toolkit v0.11+

## Status

<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
