### PR TITLE
[DNM] Attempt to isolate regression in OpenMM harness

### DIFF
--- a/devtools/conda-envs/openmm.yaml
+++ b/devtools/conda-envs/openmm.yaml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - rdkit
   - openmm
-  - openff-toolkit
+  - openff-toolkit ==0.11.3
   - openff-forcefields
   - openmmforcefields
   - geometric


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->

https://github.com/MolSSI/QCEngine/actions/runs/3448063275/jobs/5754722254 passes,
https://github.com/MolSSI/QCEngine/actions/runs/3467455220/jobs/5792340295 fails, the only notable difference in environments being the OpenFF Toolkit being bumped to 0.11.4. Changelog: https://docs.openforcefield.org/projects/toolkit/en/stable/releasehistory.html#bugfix-release

The only the dif
## Changelog description
<!-- Provide a brief single sentence for the changelog. -->

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [ ] Code base linted
- [ ] Ready to go
