### PR TITLE
better config loading

### DIFF
--- a/qcengine/config.py
+++ b/qcengine/config.py
@@ -190,7 +190,7 @@ def _load_defaults() -> None:
 
         LOGGER.info("Found 'qcengine.yaml' at path: {}".format(load_path))
         with open(load_path, "r") as stream:
-            user_config = yaml.load(stream)
+            user_config = yaml.load(stream, Loader=yaml.SafeLoader)
 
         for k, v in user_config.items():
             NODE_DESCRIPTORS[k] = NodeDescriptor(name=k, **v)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
Fixes #379 . @bennybp, I think that's all about loading qca config files. Those are all POD, right, not trying to create objects such that `FullLoader` would be needed?

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [ ] Code base linted
- [ ] Ready to go
