### PR TITLE
Prepend psiimport path instead of overwriting `$PYTHONPATH`

### DIFF
--- a/qcengine/programs/psi4.py
+++ b/qcengine/programs/psi4.py
@@ -66,7 +66,9 @@ class Psi4Harness(ProgramHarness):
         if psiapi and not psithon:
             psiimport = str(Path(which_import("psi4")).parent.parent)
             env = os.environ.copy()
-            env["PYTHONPATH"] = psiimport
+            pythonpath = env.get("PYTHONPATH")
+            # Prepend psiimport to $PYTHONPATH (carefull if it's empty/unset)
+            env["PYTHONPATH"] = os.pathsep.join([psiimport, pythonpath] if pythonpath else [psiimport])
             with popen(["python", "-c", "import psi4; print(psi4.executable[:-5])"], popen_kwargs={"env": env}) as exc:
                 exc["proc"].wait(timeout=30)
             os.environ["PATH"] += os.pathsep + exc["stdout"].split()[-1]


### PR DESCRIPTION
## Description

When `psi4` binary is found but the Python package is not we should not overwrite the `$PYTHONPATH` before importing `psi4` as that may cause other required packages to be not found anymore. Hence prepend it.

See https://github.com/MolSSI/QCEngine/issues/292#issuecomment-1337320606

## Changelog description

Fix `IndexError` in PSI4 Harness when `psi4` Python package is not found but the binary is.