### PR TITLE
update gCP levels and extend D4 defaults

### DIFF
--- a/qcengine/programs/empirical_dispersion_resources.py
+++ b/qcengine/programs/empirical_dispersion_resources.py
@@ -908,6 +908,9 @@ try:
     new_d4_api = parse_version(d4_version) >= parse_version("3.5.0")
 except ModuleNotFoundError:
     new_d4_api = False
+except ImportError:
+    # handles when no dftd4 present
+    new_d4_api = False
 
 # different defaults for dftd4 versions < 3.5.0
 if new_d4_api is False:

--- a/qcengine/programs/empirical_dispersion_resources.py
+++ b/qcengine/programs/empirical_dispersion_resources.py
@@ -5,7 +5,7 @@ import copy
 from typing import Dict, List, Optional, Union
 
 from ..exceptions import InputError
-from pkg_resources import parse_version
+from qcelemental.util import parse_version
 
 ## ==> Dispersion Aliases and Parameters <== ##
 

--- a/qcengine/programs/empirical_dispersion_resources.py
+++ b/qcengine/programs/empirical_dispersion_resources.py
@@ -881,7 +881,17 @@ dashcoeff = {
         "bibtex": "Caldeweyher:2019:154122",
         "doi": "10.1063/1.5090222150",
         "default": collections.OrderedDict(
-            [("a1", 1.0), ("a2", 1.0), ("alp", 16.0), ("s6", 1.0), ("s8", 1.0), ("s9", 1.0)]
+            [
+                ("a1", 1.0),
+                ("a2", 1.0),
+                ("alp", 16.0),
+                ("s6", 1.0),
+                ("s8", 1.0),
+                ("s9", 1.0),
+                ("ga", 3.0),
+                ("gc", 2.0),
+                ("wf", 6.0),
+            ]
         ),
         "definitions": {
             # D4 parameters loaded below from authoritative source below. Keep a couple for reference
@@ -968,6 +978,11 @@ def _get_d4bj_definitions() -> dict:
 
 
 dashcoeff["d4bjeeqatm"]["definitions"].update(_get_d4bj_definitions())
+# defaults ga, gc, wf are not in the toml parameter file and need to be provided by qcengine
+for k, v in dashcoeff["d4bjeeqatm"]["definitions"].items():
+    dashcoeff["d4bjeeqatm"]["definitions"][k]["params"]["ga"] = 3.0
+    dashcoeff["d4bjeeqatm"]["definitions"][k]["params"]["gc"] = 2.0
+    dashcoeff["d4bjeeqatm"]["definitions"][k]["params"]["wf"] = 6.0
 
 try:
 

--- a/qcengine/programs/empirical_dispersion_resources.py
+++ b/qcengine/programs/empirical_dispersion_resources.py
@@ -906,10 +906,7 @@ try:
     from dftd4 import __version__ as d4_version
 
     new_d4_api = parse_version(d4_version) >= parse_version("3.5.0")
-except ModuleNotFoundError:
-    new_d4_api = False
-except ImportError:
-    # handles when no dftd4 present
+except (ModuleNotFoundError, ImportError):
     new_d4_api = False
 
 # different defaults for dftd4 versions < 3.5.0

--- a/qcengine/programs/empirical_dispersion_resources.py
+++ b/qcengine/programs/empirical_dispersion_resources.py
@@ -910,7 +910,7 @@ except (ModuleNotFoundError, ImportError):
     new_d4_api = False
 
 # different defaults for dftd4 versions < 3.5.0
-if new_d4_api is False:
+if not new_d4_api:
     dashcoeff["d4bjeeqatm"]["default"] = collections.OrderedDict(
         [("a1", 1.0), ("a2", 1.0), ("alp", 16.0), ("s6", 1.0), ("s8", 1.0), ("s9", 1.0)]
     )

--- a/qcengine/programs/gcp.py
+++ b/qcengine/programs/gcp.py
@@ -171,7 +171,10 @@ class GCPHarness(ProgramHarness):
         # temp until actual options object
         method = input_model.model.method.upper()
         if method not in available_levels:
-            raise InputError(f"GCP does not have method: {method}")
+            if method in mctc_gcp_levels and executable == "gcp":
+                raise InputError(f"GCP does not have method {method} but MCTC-GCP does.")
+            else:
+                raise InputError(f"GCP does not have method: {method}")
 
         # Need 'real' field later and that's only guaranteed for molrec
         molrec = qcel.molparse.from_schema(input_model.molecule.dict())

--- a/qcengine/programs/gcp.py
+++ b/qcengine/programs/gcp.py
@@ -160,6 +160,13 @@ class GCPHarness(ProgramHarness):
             # thus code blocks with FILE below are not used yet.
             # 'file',
         ]
+        # some methods not available in legacy version
+        mctc_gcp_levels = ["B973C", "R2SCAN3C"]
+
+        executable = self._defaults["name"].lower()
+        if executable == "mctc-gcp":
+            available_levels.extend(mctc_gcp_levels)
+
         available_levels = [f.upper() for f in available_levels]
         # temp until actual options object
         method = input_model.model.method.upper()
@@ -169,7 +176,6 @@ class GCPHarness(ProgramHarness):
         # Need 'real' field later and that's only guaranteed for molrec
         molrec = qcel.molparse.from_schema(input_model.molecule.dict())
 
-        executable = self._defaults["name"].lower()
         calldash = {"gcp": "-", "mctc-gcp": "--"}[executable]
 
         command = [executable, "gcp_geometry.xyz", calldash + "level", method]

--- a/qcengine/testing.py
+++ b/qcengine/testing.py
@@ -157,7 +157,7 @@ _programs = {
     "dftd3": which("dftd3", return_bool=True),
     "dftd3_321": is_program_new_enough("dftd3", "3.2.1"),
     "dftd4": which_import("dftd4", return_bool=True),
-    "dftd4_350": is_program_new_enough("dftd", "3.5.0"),
+    "dftd4_350": is_program_new_enough("dftd4", "3.5.0"),
     "s-dftd3": which_import("dftd3", return_bool=True),
     "qcore": is_program_new_enough("qcore", "0.8.9"),
     "gamess": which("rungms", return_bool=True),

--- a/qcengine/testing.py
+++ b/qcengine/testing.py
@@ -157,6 +157,7 @@ _programs = {
     "dftd3": which("dftd3", return_bool=True),
     "dftd3_321": is_program_new_enough("dftd3", "3.2.1"),
     "dftd4": which_import("dftd4", return_bool=True),
+    "dftd4_350": is_program_new_enough("dftd", "3.5.0"),
     "s-dftd3": which_import("dftd3", return_bool=True),
     "qcore": is_program_new_enough("qcore", "0.8.9"),
     "gamess": which("rungms", return_bool=True),


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
For psi4 to run B97-3c and r2SCAN-3c the gCP harness needs an update to the allowed methods (limited to the new 'mctc-gcp'). (https://github.com/psi4/psi4/pull/2842) r2SCAN-3c requires manipulation of additional parameters. `dftd4` has been updated to allow this. The D4 harness update sets the additional defaults. Because the dftd4 toml file does not contain these parameters the D4 harness sets them.

Closes #392 

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->
Adds `b973c` and `r2scan3c` methods to the gcp and dftd4 harness.

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [ ] Ready to go
