### PR TITLE
fix qcore and adcc CI

### DIFF
--- a/devtools/conda-envs/adcc.yaml
+++ b/devtools/conda-envs/adcc.yaml
@@ -1,10 +1,10 @@
 name: test
 channels:
-  - adcc
+  #- adcc
   - psi4/label/dev
   - conda-forge
 dependencies:
-  - adcc>=0.15.7
+  - conda-forge::adcc>=0.15.7
   - psi4
   - blas=*=mkl  # not needed but an example of disuading solver from openblas and old psi
   - intel-openmp!=2019.5

--- a/devtools/conda-envs/adcc.yaml
+++ b/devtools/conda-envs/adcc.yaml
@@ -1,6 +1,7 @@
 name: test
 channels:
   #- adcc
+  - defaults
   - psi4/label/dev
   - conda-forge
 dependencies:

--- a/devtools/conda-envs/qcore.yaml
+++ b/devtools/conda-envs/qcore.yaml
@@ -12,6 +12,7 @@ dependencies:
   - psutil
   - qcelemental >=0.24
   - pydantic >=0.30.1
+  - tbb<2021
 
     # Testing
   - pytest


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->
* according to https://software.entos.ai/qcore/tutorial/ , entos needs a tbb constraint. that fixes the CI error that was showing up at license check time
* @maxscheurer, I think what was happening with the h5 error in adcc CI (e.g., https://github.com/MolSSI/QCEngine/actions/runs/3847917831/jobs/6555003472) was that psi needs hdf5 1.10, and with c-f higher in channel priority, it was having to grab old h5py 3.3 since c-f switched to 1.12 earlier. Now it's getting 1.10-based hdf5 packages from defaults and adcc itself from c-f instead of adcc channel. Presently adcc 0.15.14 and psi4 1.7.

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
