### PR TITLE
FIX: berny should respect the task_config

### DIFF
--- a/devtools/conda-envs/openmm.yaml
+++ b/devtools/conda-envs/openmm.yaml
@@ -17,6 +17,7 @@ dependencies:
   - psutil
   - qcelemental >=0.11.1
   - pydantic >=1.8.2
+  - pint <0.22
 
     # Testing
   - pytest

--- a/qcengine/procedures/berny.py
+++ b/qcengine/procedures/berny.py
@@ -58,6 +58,7 @@ class BernyProcedure(ProcedureHarness):
         geom_qcng = input_data["initial_molecule"]
         comput = {**input_data["input_specification"], "molecule": geom_qcng}
         program = input_data["keywords"].pop("program")
+        task_config = config.dict()
         trajectory = []
         output_data = input_data.copy()
         try:
@@ -67,7 +68,7 @@ class BernyProcedure(ProcedureHarness):
             opt = berny.Berny(geom_berny, logger=log, **input_data["keywords"])
             for geom_berny in opt:
                 geom_qcng["geometry"] = np.stack(geom_berny.coords * berny.angstrom)
-                ret = qcengine.compute(comput, program)
+                ret = qcengine.compute(comput, program, task_config=task_config)
                 if ret.success:
                     trajectory.append(ret.dict())
                     opt.send((ret.properties.return_energy, ret.return_result))

--- a/qcengine/tests/test_procedures.py
+++ b/qcengine/tests/test_procedures.py
@@ -317,7 +317,7 @@ def test_torsiondrive_generic():
         optimization_spec=OptimizationSpecification(
             procedure="geomeTRIC",
             keywords={
-                "coordsys": "tric",
+                "coordsys": "hdlc",
                 "maxiter": 500,
                 "program": "rdkit",
             },

--- a/qcengine/tests/test_procedures.py
+++ b/qcengine/tests/test_procedures.py
@@ -21,6 +21,7 @@ def input_data():
 
 
 @using("psi4")
+@pytest.mark.parametrize("ncores", [1, 2])
 @pytest.mark.parametrize(
     "optimizer",
     [
@@ -29,7 +30,7 @@ def input_data():
         pytest.param("berny", marks=using("berny")),
     ],
 )
-def test_geometric_psi4(input_data, optimizer):
+def test_geometric_psi4(input_data, optimizer, ncores):
 
     input_data["initial_molecule"] = qcng.get_molecule("hydrogen")
     input_data["input_specification"]["model"] = {"method": "HF", "basis": "sto-3g"}
@@ -38,12 +39,21 @@ def test_geometric_psi4(input_data, optimizer):
 
     input_data = OptimizationInput(**input_data)
 
-    ret = qcng.compute_procedure(input_data, optimizer, raise_error=True)
+    task_config = {
+        "ncores": ncores,
+    }
+
+    ret = qcng.compute_procedure(input_data, optimizer, raise_error=True, task_config=task_config)
     assert 10 > len(ret.trajectory) > 1
 
     assert pytest.approx(ret.final_molecule.measure([0, 1]), 1.0e-4) == 1.3459150737
     assert ret.provenance.creator.lower() == optimizer
     assert ret.trajectory[0].provenance.creator.lower() == "psi4"
+
+    if optimizer == "optking" and ncores == 2:
+        pytest.xfail("not passing threads to psi4")
+    else:
+        assert ret.trajectory[0].provenance.nthreads == ncores
 
     # Check keywords passing
     for single in ret.trajectory:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description

As explained in #402, `berny` optimizer did not respect the `task_config` options. This PR should fix that.

## Changelog description

Fix berny optimizer to respect the task_config options

## Status
- [ ] Code base linted
- [ ] Ready to go
