### PR TITLE
Some Turbomole fixes

### DIFF
--- a/qcengine/config.py
+++ b/qcengine/config.py
@@ -84,7 +84,7 @@ class NodeDescriptor(pydantic.BaseModel):
     
     The default value, ``None``, will allow QCEngine to autodetect the number of cores.""",
     )
-    jobs_per_node: int = 1
+    jobs_per_node: int = 2
     retries: int = 0
 
     # Cluster options

--- a/qcengine/config.py
+++ b/qcengine/config.py
@@ -84,7 +84,7 @@ class NodeDescriptor(pydantic.BaseModel):
     
     The default value, ``None``, will allow QCEngine to autodetect the number of cores.""",
     )
-    jobs_per_node: int = 2
+    jobs_per_node: int = 1
     retries: int = 0
 
     # Cluster options

--- a/qcengine/programs/tests/test_turbomole.py
+++ b/qcengine/programs/tests/test_turbomole.py
@@ -43,6 +43,8 @@ def h2o_ricc2_def2svp():
         pytest.param("pbe0", {"grid": "m5"}, -76.27371135900, marks=using("turbomole")),
         pytest.param("ricc2", {}, -76.1603807755, marks=using("turbomole")),
         pytest.param("rimp2", {}, -76.1593614075, marks=using("turbomole")),
+        pytest.param("hf", {"scf_conv": 4, "scf_iters": 1}, -75.95536954370,
+                     marks=[using("turbomole"), pytest.mark.xfail(raises=AssertionError, strict=True)]),
     ],
 )
 def test_turbomole_energy(method, keywords, ref_energy, h2o):

--- a/qcengine/programs/tests/test_turbomole.py
+++ b/qcengine/programs/tests/test_turbomole.py
@@ -43,8 +43,12 @@ def h2o_ricc2_def2svp():
         pytest.param("pbe0", {"grid": "m5"}, -76.27371135900, marks=using("turbomole")),
         pytest.param("ricc2", {}, -76.1603807755, marks=using("turbomole")),
         pytest.param("rimp2", {}, -76.1593614075, marks=using("turbomole")),
-        pytest.param("hf", {"scf_conv": 4, "scf_iters": 1}, -75.95536954370,
-                     marks=[using("turbomole"), pytest.mark.xfail(raises=AssertionError, strict=True)]),
+        pytest.param(
+            "hf",
+            {"scf_conv": 4, "scf_iters": 1},
+            -75.95536954370,
+            marks=[using("turbomole"), pytest.mark.xfail(raises=AssertionError, strict=True)],
+        ),
     ],
 )
 def test_turbomole_energy(method, keywords, ref_energy, h2o):

--- a/qcengine/programs/turbomole/define.py
+++ b/qcengine/programs/turbomole/define.py
@@ -65,6 +65,8 @@ def prepare_stdin(
     # Load data from keywords
     unrestricted = keywords.get("unrestricted", False)
     grid = keywords.get("grid", "m3")
+    scf_conv = keywords.get("scf_conv", 8)
+    scf_iters = keywords.get("scf_iters", 150)
 
     methods_flat = list(it.chain(*[m for m in METHODS.values()]))
     if method not in methods_flat:
@@ -191,8 +193,8 @@ def prepare_stdin(
         "ri": set_ri(keywords),
         "dsp": set_dsp(keywords),
         "title": "QCEngine Turbomole",
-        "scf_conv": 8,
-        "scf_iters": 150,
+        "scf_conv": scf_conv,
+        "scf_iters": scf_iters,
         "basis": basis,
     }
 

--- a/qcengine/programs/turbomole/runner.py
+++ b/qcengine/programs/turbomole/runner.py
@@ -131,6 +131,7 @@ class TurbomoleHarness(ProgramHarness):
 
         env = os.environ.copy()
         env["PARA_ARCH"] = "SMP"
+        env["TM_PAR_OMP"] = "on"
         env["PARNODES"] = str(config.ncores)
         env["SMPCPUS"] = str(config.ncores)
         turbomolerec["environment"] = env
@@ -238,6 +239,9 @@ class TurbomoleHarness(ProgramHarness):
             inputs["infiles"],
             inputs["outfiles"],
             shell=True,
+            environment=inputs["environment"],
+            # TODO:
+            # scratch_directory="/path/to/userdefined/scratch",
             # TODO: scratch_messy?
             # scratch_messy=False,
         )

--- a/qcengine/tests/test_procedures.py
+++ b/qcengine/tests/test_procedures.py
@@ -21,7 +21,7 @@ def input_data():
 
 
 @using("psi4")
-@pytest.mark.parametrize("ncores", [1, 2])
+@pytest.mark.parametrize("ncores", [1, 4])
 @pytest.mark.parametrize(
     "optimizer",
     [
@@ -50,7 +50,7 @@ def test_geometric_psi4(input_data, optimizer, ncores):
     assert ret.provenance.creator.lower() == optimizer
     assert ret.trajectory[0].provenance.creator.lower() == "psi4"
 
-    if optimizer == "optking" and ncores == 2:
+    if optimizer == "optking" and ncores == 4:
         pytest.xfail("not passing threads to psi4")
     else:
         assert ret.trajectory[0].provenance.nthreads == ncores


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->
This PR incorporates some fixes/additions for the Turbomole runner:
- Pass SCF convergence and SCF max. iterations to `define`
- Correctly enable OMP
- Pass `environment` to `execute`

@loriab I'm actually @maxscheurer but from my corporate GH account 😄 

## Questions
- [x] Is the new test okay using `xfail`?
- [ ] How should one allow a user-specified scratch directory? Is `TaskConfig` -> `execute` the correct route?
- [ ] I changed the (unusual?) `jobs_per_node` default from `2` to `1`, is that okay, or was there a reason for it being set to `2` specifically?
- [ ] `make format` reformats almost all files...

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [ ] Code base linted
- [ ] Ready to go
