### PR TITLE
Psi4 random fail restarts 

### DIFF
--- a/devtools/conda-envs/openmm.yaml
+++ b/devtools/conda-envs/openmm.yaml
@@ -16,7 +16,7 @@ dependencies:
   - py-cpuinfo
   - psutil
   - qcelemental >=0.11.1
-  - pydantic >=0.30.1
+  - pydantic >=1.8.2
 
     # Testing
   - pytest

--- a/devtools/conda-envs/qcore.yaml
+++ b/devtools/conda-envs/qcore.yaml
@@ -11,7 +11,7 @@ dependencies:
   - py-cpuinfo
   - psutil
   - qcelemental >=0.24
-  - pydantic >=0.30.1
+  - pydantic >=1.8.2
   - tbb<2021
 
     # Testing

--- a/devtools/conda-envs/xtb.yaml
+++ b/devtools/conda-envs/xtb.yaml
@@ -11,7 +11,7 @@ dependencies:
   - py-cpuinfo
   - psutil
   - qcelemental >=0.11.1
-  - pydantic >=0.30.1
+  - pydantic >=1.8.2
 
     # Extras
   - gcp-correction

--- a/qcengine/programs/psi4.py
+++ b/qcengine/programs/psi4.py
@@ -108,7 +108,7 @@ class Psi4Harness(ProgramHarness):
                 error_message = output_data["error"]["error_message"]
                 error_type = output_data["error"].get("error_type", "unknown_error")
         else:
-            error_message = "Unknown error, error message is not found, possible segmentation fault"
+            error_message = "Unknown error, error message is not found, possible segmentation fault!"
             error_type = "internal_error"
 
         return error_message, error_type

--- a/qcengine/programs/psi4.py
+++ b/qcengine/programs/psi4.py
@@ -108,7 +108,7 @@ class Psi4Harness(ProgramHarness):
                 error_message = output_data["error"]["error_message"]
                 error_type = output_data["error"].get("error_type", "unknown_error")
         else:
-            error_message = "Unknown error, error message is not found, possibly segfaulted"
+            error_message = "Unknown error, error message is not found, possible segmentation fault"
             error_type = "internal_error"
 
         return error_message, error_type

--- a/qcengine/tests/test_harness_canonical.py
+++ b/qcengine/tests/test_harness_canonical.py
@@ -150,6 +150,7 @@ def test_compute_bad_models(program, model):
     with pytest.raises(qcng.exceptions.InputError) as exc:
         ret = qcng.compute(inp, program, raise_error=True)
 
+
 def test_psi4_restarts(monkeypatch):
     """
     Make sure that a random error is raised which can be restarted if psi4 fails with no error message
@@ -159,15 +160,13 @@ def test_psi4_restarts(monkeypatch):
 
     # create the psi4 task
     inp = AtomicInput(molecule=qcng.get_molecule("hydrogen"), driver="energy", model={"method": "hf", "basis": "6-31G"})
+
     def mock_execute(*args, **kwargs):
         """
         Mock the output of a failed psi4 task with missing error message.
         """
 
-        mock_output = {
-            "sucess": False,
-            "outfiles": {"data.msgpack": msgpack.dumps({"missing": "data"})}
-        }
+        mock_output = {"sucess": False, "outfiles": {"data.msgpack": msgpack.dumps({"missing": "data"})}}
         return True, mock_output
 
     monkeypatch.setattr("qcengine.programs.psi4.execute", mock_execute)

--- a/qcengine/tests/test_harness_canonical.py
+++ b/qcengine/tests/test_harness_canonical.py
@@ -1,6 +1,7 @@
 """
 Tests the DQM compute dispatch module
 """
+import msgpack
 import numpy as np
 import pytest
 from qcelemental.models import AtomicInput, BasisSet
@@ -153,7 +154,9 @@ def test_psi4_restarts(monkeypatch):
     """
     Make sure that a random error is raised which can be restarted if psi4 fails with no error message
     """
-    import msgpack
+    if not has_program("psi4"):
+        pytest.skip("Program psi4 not found.")
+
     # create the psi4 task
     inp = AtomicInput(molecule=qcng.get_molecule("hydrogen"), driver="energy", model={"method": "hf", "basis": "6-31G"})
     def mock_execute(*args, **kwargs):

--- a/qcengine/tests/test_harness_canonical.py
+++ b/qcengine/tests/test_harness_canonical.py
@@ -157,7 +157,9 @@ def test_psi4_restarts(monkeypatch):
     # create the psi4 task
     inp = AtomicInput(molecule=qcng.get_molecule("hydrogen"), driver="energy", model={"method": "hf", "basis": "6-31G"})
     def mock_execute(*args, **kwargs):
-        "mock the output of a failed psi4 task with missing error message"
+        """
+        Mock the output of a failed psi4 task with missing error message.
+        """
 
         mock_output = {
             "sucess": False,

--- a/qcengine/tests/test_harness_canonical.py
+++ b/qcengine/tests/test_harness_canonical.py
@@ -148,3 +148,24 @@ def test_compute_bad_models(program, model):
 
     with pytest.raises(qcng.exceptions.InputError) as exc:
         ret = qcng.compute(inp, program, raise_error=True)
+
+def test_psi4_restarts(monkeypatch):
+    """
+    Make sure that a random error is raised which can be restarted if psi4 fails with no error message
+    """
+    import msgpack
+    # create the psi4 task
+    inp = AtomicInput(molecule=qcng.get_molecule("hydrogen"), driver="energy", model={"method": "hf", "basis": "6-31G"})
+    def mock_execute(*args, **kwargs):
+        "mock the output of a failed psi4 task with missing error message"
+
+        mock_output = {
+            "sucess": False,
+            "outfiles": {"data.msgpack": msgpack.dumps({"missing": "data"})}
+        }
+        return True, mock_output
+
+    monkeypatch.setattr("qcengine.programs.psi4.execute", mock_execute)
+
+    with pytest.raises(qcng.exceptions.RandomError):
+        _ = qcng.compute(input_data=inp, program="psi4", raise_error=True, task_config={"retries": 0})


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
This PR fixes #407 by adding a valid error message which raises a `RandomError` needed to restart the calculations.

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->
Psi4 tasks are now correctly restarted when there is no valid error message.

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [ ] Code base linted
- [x] Ready to go
