### PR TITLE
update torsiondrive to use task config

### DIFF
--- a/qcengine/procedures/torsiondrive.py
+++ b/qcengine/procedures/torsiondrive.py
@@ -206,7 +206,7 @@ class TorsionDriveProcedure(ProcedureHarness):
         )
 
         return compute_procedure(
-            input_data, procedure=input_model.optimization_spec.procedure, local_options=config.dict()
+            input_data, procedure=input_model.optimization_spec.procedure, task_config=config.dict()
         )
 
     @staticmethod


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
This PR updates the torsiondrive procedure to use the new `task_config` argument which will stop warnings when running torsiondrives, see #408.

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->
The torsiondrive procedure now uses `task_config` internally.

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [ ] Code base linted
- [x] Ready to go
