### PR TITLE
Enable Pydantic v2 using v1 API

### DIFF
--- a/qcengine/config.py
+++ b/qcengine/config.py
@@ -9,8 +9,10 @@ import os
 import socket
 from typing import Any, Dict, Optional, Union
 
-import pydantic
-
+try:
+    import pydantic.v1 as pydantic
+except ImportError:
+    import pydantic
 from .extras import get_information
 
 __all__ = ["get_config", "get_provenance_augments", "global_repr", "NodeDescriptor"]
@@ -44,7 +46,9 @@ def get_global(key: Optional[str] = None) -> Union[str, Dict[str, Any]]:
         _global_values["ncores"] = cpu_cnt
 
         _global_values["cpuinfo"] = cpuinfo.get_cpu_info()
-        _global_values["cpu_brand"] = _global_values["cpuinfo"]["brand"]
+        # Change in newer versions of cpuinfo where brand_was renamed to brand_raw
+        # (See: https://github.com/workhorsy/py-cpuinfo/pull/123)
+        _global_values["cpu_brand"] = _global_values["cpuinfo"].get("brand", _global_values["cpuinfo"]["brand_raw"])
 
     if key is None:
         return _global_values.copy()

--- a/qcengine/procedures/model.py
+++ b/qcengine/procedures/model.py
@@ -1,7 +1,10 @@
 import abc
 from typing import Any, Dict, Union
 
-from pydantic import BaseModel
+try:
+    from pydantic.v1 import BaseModel
+except ImportError:
+    from pydantic import BaseModel
 
 from ..util import model_wrapper
 

--- a/qcengine/programs/model.py
+++ b/qcengine/programs/model.py
@@ -1,7 +1,10 @@
 import abc
 from typing import Any, Dict, List, Optional, Tuple
 
-from pydantic import BaseModel
+try:
+    from pydantic.v1 import BaseModel
+except ImportError:
+    from pydantic import BaseModel
 
 
 class ProgramHarness(BaseModel, abc.ABC):

--- a/qcengine/tests/test_config.py
+++ b/qcengine/tests/test_config.py
@@ -5,7 +5,10 @@ Tests the DQM compute module configuration
 import copy
 import os
 
-import pydantic
+try:
+    import pydantic.v1 as pydantic
+except ImportError:
+    import pydantic
 import pytest
 
 import qcengine as qcng

--- a/qcengine/util.py
+++ b/qcengine/util.py
@@ -18,7 +18,10 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
-from pydantic import ValidationError
+try:
+    from pydantic.v1 import ValidationError
+except ImportError:
+    from pydantic import ValidationError
 
 from qcelemental.models import FailedOperation
 


### PR DESCRIPTION
## Description
As it says. This is a stopgap until we can properly implement Pydantic v2.

there was also a small change in the way `cpuinfo` does its `brand` key, its now `brand_raw` but I changed it to try both. 
Part of the larger QCA upgrade

## Changelog description
Enable Pydantic v2 support

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [ ] Code base linted
- [ ] Ready to go
