### PR TITLE
Pydanticv2again

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,56 +17,56 @@ jobs:
       fail-fast: false
       matrix:
         cfg:
-          #- conda-env: psi
-          #  python-version: 3.7
-          #  label: Psi4-release
-          #  runs-on: ubuntu-latest
+          - conda-env: psi
+            python-version: 3.7
+            label: Psi4-release
+            runs-on: ubuntu-latest
 
-          #- conda-env: psi-nightly
-          #  python-version: "3.10"
-          #  label: Psi4-nightly
-          #  runs-on: ubuntu-latest
+          - conda-env: psi-nightly
+            python-version: "3.10"
+            label: Psi4-nightly
+            runs-on: ubuntu-latest
 
-          #- conda-env: torchani
-          #  python-version: 3.8
-          #  label: ANI
-          #  runs-on: ubuntu-latest
+          - conda-env: torchani
+            python-version: 3.8
+            label: ANI
+            runs-on: ubuntu-latest
 
-          #- conda-env: openmm
-          #  python-version: 3.8
-          #  label: OpenMM
-          #  runs-on: ubuntu-latest
+          - conda-env: openmm
+            python-version: 3.8
+            label: OpenMM
+            runs-on: ubuntu-latest
 
           - conda-env: xtb
             python-version: "3.10"
             label: xTB
             runs-on: ubuntu-latest
 
-          #- conda-env: qcore
-          #  python-version: 3.7
-          #  label: QCore
-          #  runs-on: ubuntu-latest
+          - conda-env: qcore
+            python-version: 3.7
+            label: QCore
+            runs-on: ubuntu-latest
 
-          #- conda-env: nwchem
-          #  python-version: 3.8
-          #  label: NWChem
-          #  runs-on: ubuntu-20.04
-          #  # formerly NWChem v6.6 with python-version: 3.6 & runs-on: ubuntu-16.04 but ubuntu env retired by GH Sep 2021
+          - conda-env: nwchem
+            python-version: 3.8
+            label: NWChem
+            runs-on: ubuntu-20.04
+            # formerly NWChem v6.6 with python-version: 3.6 & runs-on: ubuntu-16.04 but ubuntu env retired by GH Sep 2021
 
-          #- conda-env: mrchem
-          #  python-version: 3.8
-          #  label: MRChem
-          #  runs-on: ubuntu-latest
+          - conda-env: mrchem
+            python-version: 3.8
+            label: MRChem
+            runs-on: ubuntu-latest
 
-          #- conda-env: adcc
-          #  python-version: 3.8
-          #  label: ADCC
-          #  runs-on: ubuntu-latest
+          - conda-env: adcc
+            python-version: 3.8
+            label: ADCC
+            runs-on: ubuntu-latest
 
-          #- conda-env: opt-disp
-          #  python-version: 3.8
-          #  label: optimization-dispersion
-          #  runs-on: ubuntu-latest
+          - conda-env: opt-disp
+            python-version: 3.8
+            label: optimization-dispersion
+            runs-on: ubuntu-latest
 
     name: "🐍 ${{ matrix.cfg.python-version }} • ${{ matrix.cfg.label }}" # • ${{ matrix.cfg.runs-on }}"
     runs-on: ${{ matrix.cfg.runs-on }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -72,7 +72,7 @@ jobs:
     runs-on: ${{ matrix.cfg.runs-on }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
@@ -87,7 +87,7 @@ jobs:
         miniforge-variant: Mambaforge
         use-mamba: true
         add-pip-as-python-dependency: true
-        #channels: conda-forge
+        # note: conda-forge chnl req'd for Mambaforge, but we'll spec in file, not here `channels: conda-forge,...`
         # note: any activate/deactivate use the conda cmd. other cmds use mamba cmd.
 
     - name: Special Config - NWChem
@@ -100,6 +100,8 @@ jobs:
       run: |
         qcore --accept-license
 
+      # note: conda remove --force, not mamba remove --force b/c https://github.com/mamba-org/mamba/issues/412
+      #       alt. is micromamba but not yet ready for setup-miniconda https://github.com/conda-incubator/setup-miniconda/issues/75
     - name: Special Config - QCEngine Dep
       if: "(matrix.cfg.label == 'Psi4-nightly') || (matrix.cfg.label == 'ADCC') || (matrix.cfg.label == 'optimization-dispersion')"
       run: |
@@ -109,8 +111,6 @@ jobs:
     - name: Special Config - Faux Pydantic Upgrade
       if: "(matrix.cfg.label == 'Psi4-nightly') || (matrix.cfg.label == 'ADCC') || (matrix.cfg.label == 'optimization-dispersion')"
       run: |
-        ls -l ${CONDA_PREFIX}/lib/python${{ matrix.cfg.python-version }}/site-packages
-        ls -l ${CONDA_PREFIX}/lib/python${{ matrix.cfg.python-version }}/site-packages/psi4/driver
         sed -i s/from\ pydantic\ /from\ pydantic.v1\ /g ${CONDA_PREFIX}/lib/python${{ matrix.cfg.python-version }}/site-packages/psi4/driver/*py
 
     - name: Environment Information
@@ -134,7 +134,7 @@ jobs:
         pytest -rws -v --cov=qcengine --color=yes --cov-report=xml qcengine/
 
     - name: CodeCov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
 
   release_sphinx:
     needs: [build]
@@ -154,7 +154,7 @@ jobs:
     runs-on: ${{ matrix.cfg.runs-on }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Create Environment
       uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -105,10 +105,12 @@ jobs:
       run: |
         mamba remove qcengine --force
 
+      # QCEngine CI and Psi4 are circularly dependent, so a hack is in order
     - name: Special Config - Faux Pydantic Upgrade
       if: "(matrix.cfg.label == 'Psi4-nightly') || (matrix.cfg.label == 'ADCC') || (matrix.cfg.label == 'optimization-dispersion')"
-      # QCEngine CI and Psi4 are circularly dependent, so a hack is in order
       run: |
+        ls -l ${CONDA_PREFIX}/lib/python${{ matrix.cfg.python-version }}/site-packages
+        ls -l ${CONDA_PREFIX}/lib/python${{ matrix.cfg.python-version }}/site-packages/psi4/driver
         sed -i s/from\ pydantic\ /from\ pydantic.v1\ /g ${CONDA_PREFIX}/lib/python${{ matrix.cfg.python-version }}/site-packages/psi4/driver/*py
 
     - name: Environment Information

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,56 +17,56 @@ jobs:
       fail-fast: false
       matrix:
         cfg:
-          - conda-env: psi
-            python-version: 3.7
-            label: Psi4-release
-            runs-on: ubuntu-latest
+          #- conda-env: psi
+          #  python-version: 3.7
+          #  label: Psi4-release
+          #  runs-on: ubuntu-latest
 
-          - conda-env: psi-nightly
-            python-version: "3.10"
-            label: Psi4-nightly
-            runs-on: ubuntu-latest
+          #- conda-env: psi-nightly
+          #  python-version: "3.10"
+          #  label: Psi4-nightly
+          #  runs-on: ubuntu-latest
 
-          - conda-env: torchani
-            python-version: 3.8
-            label: ANI
-            runs-on: ubuntu-latest
+          #- conda-env: torchani
+          #  python-version: 3.8
+          #  label: ANI
+          #  runs-on: ubuntu-latest
 
-          - conda-env: openmm
-            python-version: 3.8
-            label: OpenMM
-            runs-on: ubuntu-latest
+          #- conda-env: openmm
+          #  python-version: 3.8
+          #  label: OpenMM
+          #  runs-on: ubuntu-latest
 
           - conda-env: xtb
             python-version: "3.10"
             label: xTB
             runs-on: ubuntu-latest
 
-          - conda-env: qcore
-            python-version: 3.7
-            label: QCore
-            runs-on: ubuntu-latest
+          #- conda-env: qcore
+          #  python-version: 3.7
+          #  label: QCore
+          #  runs-on: ubuntu-latest
 
-          - conda-env: nwchem
-            python-version: 3.8
-            label: NWChem
-            runs-on: ubuntu-20.04
-            # formerly NWChem v6.6 with python-version: 3.6 & runs-on: ubuntu-16.04 but ubuntu env retired by GH Sep 2021
+          #- conda-env: nwchem
+          #  python-version: 3.8
+          #  label: NWChem
+          #  runs-on: ubuntu-20.04
+          #  # formerly NWChem v6.6 with python-version: 3.6 & runs-on: ubuntu-16.04 but ubuntu env retired by GH Sep 2021
 
-          - conda-env: mrchem
-            python-version: 3.8
-            label: MRChem
-            runs-on: ubuntu-latest
+          #- conda-env: mrchem
+          #  python-version: 3.8
+          #  label: MRChem
+          #  runs-on: ubuntu-latest
 
-          - conda-env: adcc
-            python-version: 3.8
-            label: ADCC
-            runs-on: ubuntu-latest
+          #- conda-env: adcc
+          #  python-version: 3.8
+          #  label: ADCC
+          #  runs-on: ubuntu-latest
 
-          - conda-env: opt-disp
-            python-version: 3.8
-            label: optimization-dispersion
-            runs-on: ubuntu-latest
+          #- conda-env: opt-disp
+          #  python-version: 3.8
+          #  label: optimization-dispersion
+          #  runs-on: ubuntu-latest
 
     name: "🐍 ${{ matrix.cfg.python-version }} • ${{ matrix.cfg.label }}" # • ${{ matrix.cfg.runs-on }}"
     runs-on: ${{ matrix.cfg.runs-on }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -114,12 +114,11 @@ jobs:
         python -m pip install . --no-deps
 
     - name: QCEngineRecords
-      if: false
       run: |
         qcengine info
         export QCER_VER=`python -c "import qcengine.testing; print(qcengine.testing.QCENGINE_RECORDS_COMMIT)"`
         #pip install git+https://github.com/MolSSI/QCEngineRecords.git@${QCER_VER}#egg=qcenginerecords
-        pip install git+https://github.com/loriab/QCEngineRecords.git@${QCER_VER}#egg=qcenginerecords
+        pip install git+https://github.com/loriab/QCEngineRecords.git@${QCER_VER}
         python -c "import qcengine; print(qcengine.config.global_repr())"
 
     - name: PyTest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -100,11 +100,12 @@ jobs:
       run: |
         qcore --accept-license
 
-    - name: Special Config - QCElemental Dep
-      if: (matrix.cfg.label == 'ADCC')
-      run: |
-        conda remove qcelemental --force
-        python -m pip install qcelemental>=0.26.0 --no-deps
+    # note: psi4 on c-f pins to a single qcel and qcng, so this may be handy for solve-and-replace
+    #- name: Special Config - QCElemental Dep
+    #  if: (matrix.cfg.label == 'ADCC')
+    #  run: |
+    #    conda remove qcelemental --force
+    #    python -m pip install qcelemental>=0.26.0 --no-deps
 
       # note: conda remove --force, not mamba remove --force b/c https://github.com/mamba-org/mamba/issues/412
       #       alt. is micromamba but not yet ready for setup-miniconda https://github.com/conda-incubator/setup-miniconda/issues/75
@@ -115,7 +116,7 @@ jobs:
 
       # QCEngine CI and Psi4 are circularly dependent, so a hack is in order
     - name: Special Config - Faux Pydantic Upgrade
-      if: "(matrix.cfg.label == 'Psi4-nightly') || (matrix.cfg.label == 'ADCC') || (matrix.cfg.label == 'optimization-dispersion')"
+      if: "(matrix.cfg.label == 'Psi4-nightly') || (matrix.cfg.label == 'optimization-dispersion')"
       run: |
         sed -i s/from\ pydantic\ /from\ pydantic.v1\ /g ${CONDA_PREFIX}/lib/python${{ matrix.cfg.python-version }}/site-packages/psi4/driver/*py
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -102,7 +102,7 @@ jobs:
     - name: Special Config - Faux Pydantic Upgrade
       run: |
         echo ${CONDA_PREFIX}
-        sed -i s;from\ pydantic\ ;from\ pydantic.v1\ ;g ${CONDA_PREFIX}/lib/python${{ matrix.cfg.python-version }}/site-packages/psi4/driver/*py
+        sed -i s/from\ pydantic\ /from\ pydantic.v1\ /g ${CONDA_PREFIX}/lib/python${{ matrix.cfg.python-version }}/site-packages/psi4/driver/*py
 
     - name: Environment Information
       run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -109,6 +109,7 @@ jobs:
         python -m pip install . --no-deps
 
     - name: QCEngineRecords
+      if: false
       run: |
         qcengine info
         export QCER_VER=`python -c "import qcengine.testing; print(qcengine.testing.QCENGINE_RECORDS_COMMIT)"`

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -112,7 +112,8 @@ jobs:
       run: |
         qcengine info
         export QCER_VER=`python -c "import qcengine.testing; print(qcengine.testing.QCENGINE_RECORDS_COMMIT)"`
-        pip install git+https://github.com/MolSSI/QCEngineRecords.git@${QCER_VER}#egg=qcenginerecords
+        #pip install git+https://github.com/MolSSI/QCEngineRecords.git@${QCER_VER}#egg=qcenginerecords
+        pip install git+https://github.com/loriab/QCEngineRecords.git@${QCER_VER}#egg=qcenginerecords
         python -c "import qcengine; print(qcengine.config.global_repr())"
 
     - name: PyTest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -117,8 +117,7 @@ jobs:
       run: |
         qcengine info
         export QCER_VER=`python -c "import qcengine.testing; print(qcengine.testing.QCENGINE_RECORDS_COMMIT)"`
-        #pip install git+https://github.com/MolSSI/QCEngineRecords.git@${QCER_VER}#egg=qcenginerecords
-        pip install git+https://github.com/loriab/QCEngineRecords.git@${QCER_VER}
+        pip install git+https://github.com/MolSSI/QCEngineRecords.git@${QCER_VER}#egg=qcenginerecords
         python -c "import qcengine; print(qcengine.config.global_repr())"
 
     - name: PyTest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -100,8 +100,8 @@ jobs:
         conda remove qcengine --force
 
     - name: Special Config - Faux Pydantic Upgrade
+      if: "(matrix.cfg.label == 'Psi4-nightly') || (matrix.cfg.label == 'ADCC') || (matrix.cfg.label == 'optimization-dispersion')"
       run: |
-        echo ${CONDA_PREFIX}
         sed -i s/from\ pydantic\ /from\ pydantic.v1\ /g ${CONDA_PREFIX}/lib/python${{ matrix.cfg.python-version }}/site-packages/psi4/driver/*py
 
     - name: Environment Information

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -83,6 +83,12 @@ jobs:
         environment-file: devtools/conda-envs/${{ matrix.cfg.conda-env }}.yaml
         python-version: ${{ matrix.cfg.python-version }}
         auto-activate-base: false
+        show-channel-urls: true
+        miniforge-variant: Mambaforge
+        use-mamba: true
+        add-pip-as-python-dependency: true
+        #channels: conda-forge
+        # note: any activate/deactivate use the conda cmd. other cmds use mamba cmd.
 
     - name: Special Config - NWChem
       if: "(matrix.cfg.label == 'NWChem')"
@@ -97,17 +103,18 @@ jobs:
     - name: Special Config - QCEngine Dep
       if: "(matrix.cfg.label == 'Psi4-nightly') || (matrix.cfg.label == 'ADCC') || (matrix.cfg.label == 'optimization-dispersion')"
       run: |
-        conda remove qcengine --force
+        mamba remove qcengine --force
 
     - name: Special Config - Faux Pydantic Upgrade
       if: "(matrix.cfg.label == 'Psi4-nightly') || (matrix.cfg.label == 'ADCC') || (matrix.cfg.label == 'optimization-dispersion')"
+      # QCEngine CI and Psi4 are circularly dependent, so a hack is in order
       run: |
         sed -i s/from\ pydantic\ /from\ pydantic.v1\ /g ${CONDA_PREFIX}/lib/python${{ matrix.cfg.python-version }}/site-packages/psi4/driver/*py
 
     - name: Environment Information
       run: |
-        conda info
-        conda list --show-channel-urls
+        mamba info
+        mamba list
 
     - name: Install QCEngine
       run: |
@@ -154,11 +161,15 @@ jobs:
         environment-file: devtools/conda-envs/${{ matrix.cfg.conda-env }}.yaml
         python-version: ${{ matrix.cfg.python-version }}
         auto-activate-base: false
+        miniforge-variant: Mambaforge
+        use-mamba: true
+        add-pip-as-python-dependency: true
+        channels: conda-forge
 
     - name: Environment Information
       run: |
-        conda info
-        conda list --show-channel-urls
+        mamba info
+        mamba list --show-channel-urls
 
     - name: Build Documentation
       run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -103,7 +103,7 @@ jobs:
     - name: Special Config - QCEngine Dep
       if: "(matrix.cfg.label == 'Psi4-nightly') || (matrix.cfg.label == 'ADCC') || (matrix.cfg.label == 'optimization-dispersion')"
       run: |
-        mamba remove qcengine --force
+        conda remove qcengine --force
 
       # QCEngine CI and Psi4 are circularly dependent, so a hack is in order
     - name: Special Config - Faux Pydantic Upgrade

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -99,6 +99,11 @@ jobs:
       run: |
         conda remove qcengine --force
 
+    - name: Special Config - Faux Pydantic Upgrade
+      run: |
+        echo ${CONDA_PREFIX}
+        sed -i s;from\ pydantic\ ;from\ pydantic.v1\ ;g ${CONDA_PREFIX}/lib/python${{ matrix.cfg.python-version }}/site-packages/psi4/driver/*py
+
     - name: Environment Information
       run: |
         conda info

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -100,6 +100,12 @@ jobs:
       run: |
         qcore --accept-license
 
+    - name: Special Config - QCElemental Dep
+      if: (matrix.cfg.label == 'ADCC')
+      run: |
+        conda remove qcelemental --force
+        python -m pip install qcelemental>=0.26.0 --no-deps
+
       # note: conda remove --force, not mamba remove --force b/c https://github.com/mamba-org/mamba/issues/412
       #       alt. is micromamba but not yet ready for setup-miniconda https://github.com/conda-incubator/setup-miniconda/issues/75
     - name: Special Config - QCEngine Dep

--- a/devtools/conda-envs/adcc.yaml
+++ b/devtools/conda-envs/adcc.yaml
@@ -6,6 +6,7 @@ channels:
 dependencies:
   - adcc>=0.15.7
   - psi4>=1.8.1
+  - conda-forge/label/libint_dev::libint
 
   # Core
   - python

--- a/devtools/conda-envs/adcc.yaml
+++ b/devtools/conda-envs/adcc.yaml
@@ -1,20 +1,17 @@
 name: test
 channels:
   #- adcc
-  - psi4/label/dev
   - conda-forge
-  - defaults
+  - nodefaults
 dependencies:
-  - conda-forge::adcc>=0.15.7
-  - psi4
-  - blas=*=mkl  # not needed but an example of disuading solver from openblas and old psi
+  - adcc>=0.15.7
+  - psi4>=1.8.1
 
   # Core
   - python
-  - pyyaml
   - py-cpuinfo
   - psutil
-  - qcelemental >=0.26.0
+  - qcelemental >=0.24.0
   - pydantic>=2
   - msgpack-python
 

--- a/devtools/conda-envs/adcc.yaml
+++ b/devtools/conda-envs/adcc.yaml
@@ -7,7 +7,6 @@ dependencies:
   - adcc>=0.15.7
   - psi4=1.8.1
   - conda-forge/label/libint_dev::libint
-  - blas=*=mkl  # not needed but an example of disuading solver from openblas and old psi
 
   # Core
   - python
@@ -15,7 +14,7 @@ dependencies:
   - py-cpuinfo
   - psutil
   - qcelemental >=0.26.0
-  - pydantic>=1.0.0
+  - pydantic
   - msgpack-python
 
     # Testing

--- a/devtools/conda-envs/adcc.yaml
+++ b/devtools/conda-envs/adcc.yaml
@@ -5,7 +5,7 @@ channels:
   - nodefaults
 dependencies:
   - adcc>=0.15.7
-  - psi4
+  - psi4=1.8.1
   - conda-forge/label/libint_dev::libint
   - blas=*=mkl  # not needed but an example of disuading solver from openblas and old psi
 

--- a/devtools/conda-envs/adcc.yaml
+++ b/devtools/conda-envs/adcc.yaml
@@ -13,7 +13,7 @@ dependencies:
   - py-cpuinfo
   - psutil
   - qcelemental >=0.24.0
-  - pydantic>=2
+  - pydantic=1
   - msgpack-python
 
     # Testing

--- a/devtools/conda-envs/adcc.yaml
+++ b/devtools/conda-envs/adcc.yaml
@@ -1,12 +1,12 @@
 name: test
 channels:
   #- adcc
-  - defaults
-  - psi4/label/dev
   - conda-forge
+  - nodefaults
 dependencies:
-  - conda-forge::adcc>=0.15.7
+  - adcc>=0.15.7
   - psi4
+  - conda-forge/label/libint_dev::libint
   - blas=*=mkl  # not needed but an example of disuading solver from openblas and old psi
   - intel-openmp!=2019.5
 

--- a/devtools/conda-envs/adcc.yaml
+++ b/devtools/conda-envs/adcc.yaml
@@ -8,14 +8,13 @@ dependencies:
   - psi4
   - conda-forge/label/libint_dev::libint
   - blas=*=mkl  # not needed but an example of disuading solver from openblas and old psi
-  - intel-openmp!=2019.5
 
   # Core
   - python
   - pyyaml
   - py-cpuinfo
   - psutil
-  - qcelemental >=0.24.0
+  - qcelemental >=0.26.0
   - pydantic>=1.0.0
   - msgpack-python
 

--- a/devtools/conda-envs/adcc.yaml
+++ b/devtools/conda-envs/adcc.yaml
@@ -1,14 +1,13 @@
 name: test
 channels:
   #- adcc
-  - defaults
   - psi4/label/dev
   - conda-forge
+  - defaults
 dependencies:
   - conda-forge::adcc>=0.15.7
   - psi4
   - blas=*=mkl  # not needed but an example of disuading solver from openblas and old psi
-  - intel-openmp!=2019.5
 
   # Core
   - python
@@ -16,6 +15,7 @@ dependencies:
   - py-cpuinfo
   - psutil
   - qcelemental >=0.26.0
+  - pydantic>=2
   - msgpack-python
 
     # Testing

--- a/devtools/conda-envs/adcc.yaml
+++ b/devtools/conda-envs/adcc.yaml
@@ -10,7 +10,6 @@ dependencies:
 
   # Core
   - python
-  - pyyaml
   - py-cpuinfo
   - psutil
   - qcelemental >=0.26.0

--- a/devtools/conda-envs/adcc.yaml
+++ b/devtools/conda-envs/adcc.yaml
@@ -1,15 +1,18 @@
 name: test
 channels:
   #- adcc
+  - defaults
+  - psi4/label/dev
   - conda-forge
-  - nodefaults
 dependencies:
-  - adcc>=0.15.7
-  - psi4=1.8.1
-  - conda-forge/label/libint_dev::libint
+  - conda-forge::adcc>=0.15.7
+  - psi4
+  - blas=*=mkl  # not needed but an example of disuading solver from openblas and old psi
+  - intel-openmp!=2019.5
 
   # Core
   - python
+  - pyyaml
   - py-cpuinfo
   - psutil
   - qcelemental >=0.26.0

--- a/devtools/conda-envs/adcc.yaml
+++ b/devtools/conda-envs/adcc.yaml
@@ -13,7 +13,6 @@ dependencies:
   - py-cpuinfo
   - psutil
   - qcelemental >=0.26.0
-  - pydantic
   - msgpack-python
 
     # Testing

--- a/devtools/conda-envs/docs-cf.yaml
+++ b/devtools/conda-envs/docs-cf.yaml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - python
   - networkx
-  - pydantic
+  - pydantic=1
   - numpy
   - pint
 

--- a/devtools/conda-envs/opt-disp.yaml
+++ b/devtools/conda-envs/opt-disp.yaml
@@ -24,7 +24,7 @@ dependencies:
   - pyyaml
   - py-cpuinfo
   - psutil
-  - qcelemental >=0.24.0
+  - qcelemental >=0.26.0
   - pydantic>=1.0.0
   - msgpack-python
 

--- a/devtools/conda-envs/psi-nightly.yaml
+++ b/devtools/conda-envs/psi-nightly.yaml
@@ -5,14 +5,13 @@ channels:
 dependencies:
   - psi4
   - blas=*=mkl  # not needed but an example of disuading solver from openblas and old psi
-  - intel-openmp!=2019.5
 
     # Core
   - python
   - pyyaml
   - py-cpuinfo
   - psutil
-  - qcelemental >=0.24.0
+  - qcelemental >=0.26.0
   - pydantic>=1.0.0
   - msgpack-python
 

--- a/devtools/conda-envs/psi.yaml
+++ b/devtools/conda-envs/psi.yaml
@@ -17,6 +17,7 @@ dependencies:
   - psutil
   - qcelemental=0.24.0
   - pydantic=1.8.2  # test minimun stated version.
+  - msgpack-python
 
     # Testing
   - pytest

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -18,22 +18,23 @@ Changelog
 .. +++++++++
 
 
-.. v0.27.0 / 2023-08-DD
-Unreleased
+v0.27.0 / 2023-08-DD
 --------------------
 
-.. Breaking Changes
-.. ++++++++++++++++
+Breaking Changes
+++++++++++++++++
 
-.. New Features
-.. ++++++++++++
+New Features
+++++++++++++
 
-.. Enhancements
-.. ++++++++++++
+Enhancements
+++++++++++++
 
 Bug Fixes
 +++++++++
 - (:pr:`394`) Entos/Qcore - updated model environments.
+- (:pr:`414`) Import `pydantic.v1` from pydantic v2 so that QCEngine can work with any >=1.8.2 pydantic
+  until QCEngine is updated for v2. If using v2, use QCElemental >=v0.26.0 that has a similar change.
 
 
 v0.26.0 / 2022-11-30

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -21,20 +21,17 @@ Changelog
 v0.27.0 / 2023-08-DD
 --------------------
 
-Breaking Changes
-++++++++++++++++
-
-New Features
-++++++++++++
-
-Enhancements
-++++++++++++
-
 Bug Fixes
 +++++++++
-- (:pr:`394`) Entos/Qcore - updated model environments.
 - (:pr:`414`) Import `pydantic.v1` from pydantic v2 so that QCEngine can work with any >=1.8.2 pydantic
   until QCEngine is updated for v2. If using v2, use QCElemental >=v0.26.0 that has a similar change.
+  QCEngineRecords received similar treatment. @Lnaden, @loriab
+- (:pr:`414`) Versioneer - update so works with Python 3.12.
+- (:pr:`414`) Maintenance
+   - Sphinx - fix build errors.
+   - Lint - pin black to 2022 format.
+   - GHA - switch to mamba solver. @loriab
+- (:pr:`394`) Entos/Qcore - updated model environments. @loriab
 
 
 v0.26.0 / 2022-11-30

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,7 +1,8 @@
 Changelog
 =========
 
-.. vX.Y.0 / 2022-MM-DD
+.. vX.Y.0 / 2023-MM-DD
+.. Unreleased
 .. --------------------
 ..
 .. Breaking Changes
@@ -15,6 +16,24 @@ Changelog
 ..
 .. Bug Fixes
 .. +++++++++
+
+
+.. v0.27.0 / 2023-08-DD
+Unreleased
+--------------------
+
+.. Breaking Changes
+.. ++++++++++++++++
+
+.. New Features
+.. ++++++++++++
+
+.. Enhancements
+.. ++++++++++++
+
+Bug Fixes
++++++++++
+- (:pr:`394`) Entos/Qcore - updated model environments.
 
 
 v0.26.0 / 2022-11-30

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -90,7 +90,7 @@ master_doc = 'index'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -190,8 +190,8 @@ texinfo_documents = [
 # -- Extension configuration -------------------------------------------------
 
 extlinks = {
-    'issue': ('https://github.com/MolSSI/QCEngine/issues/%s', 'GH#'),
-    'pr': ('https://github.com/MolSSI/QCEngine/pull/%s', 'GH#')
+    'issue': ('https://github.com/MolSSI/QCEngine/issues/%s', 'GH#%s'),
+    'pr': ('https://github.com/MolSSI/QCEngine/pull/%s', 'GH#%s')
 }
 
 # -- Options for intersphinx extension ---------------------------------------

--- a/qcengine/compute.py
+++ b/qcengine/compute.py
@@ -13,7 +13,10 @@ from .programs import get_program
 from .util import compute_wrapper, environ_context, handle_output_metadata, model_wrapper
 
 if TYPE_CHECKING:
-    from pydantic.main import BaseModel
+    try:
+        from pydantic.v1.main import BaseModel
+    except ImportError:
+        from pydantic.main import BaseModel
     from qcelemental.models import AtomicResult
 
 

--- a/qcengine/config.py
+++ b/qcengine/config.py
@@ -9,7 +9,10 @@ import os
 import socket
 from typing import Any, Dict, Optional, Union
 
-import pydantic
+try:
+    import pydantic.v1 as pydantic
+except ImportError:
+    import pydantic
 
 from .extras import get_information
 

--- a/qcengine/procedures/model.py
+++ b/qcengine/procedures/model.py
@@ -1,7 +1,10 @@
 import abc
 from typing import Any, Dict, Union
 
-from pydantic import BaseModel
+try:
+    from pydantic.v1 import BaseModel
+except ImportError:
+    from pydantic import BaseModel
 
 from ..util import model_wrapper
 

--- a/qcengine/programs/model.py
+++ b/qcengine/programs/model.py
@@ -2,7 +2,10 @@ import abc
 import logging
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-from pydantic import BaseModel
+try:
+    from pydantic.v1 import BaseModel
+except ImportError:
+    from pydantic import BaseModel
 from qcelemental.models import AtomicInput, AtomicResult, FailedOperation
 
 from qcengine.exceptions import KnownErrorException

--- a/qcengine/programs/tests/test_qchem.py
+++ b/qcengine/programs/tests/test_qchem.py
@@ -16,6 +16,7 @@ qchem_forgive = [
     "root.provenance.routine",
     "root.provenance.creator",
     "root.extras",
+    "root.molecule.extras",
 ]
 
 

--- a/qcengine/testing.py
+++ b/qcengine/testing.py
@@ -12,7 +12,7 @@ from qcelemental.util import which, which_import
 
 import qcengine as qcng
 
-QCENGINE_RECORDS_COMMIT = "17945e5"
+QCENGINE_RECORDS_COMMIT = "0e2fdb4"
 
 
 def _check_qcenginerecords(return_data=False):

--- a/qcengine/testing.py
+++ b/qcengine/testing.py
@@ -12,7 +12,7 @@ from qcelemental.util import which, which_import
 
 import qcengine as qcng
 
-QCENGINE_RECORDS_COMMIT = "aa4a1b2"
+QCENGINE_RECORDS_COMMIT = "17945e5"
 
 
 def _check_qcenginerecords(return_data=False):

--- a/qcengine/tests/test_config.py
+++ b/qcengine/tests/test_config.py
@@ -4,7 +4,10 @@ Tests the QCEngine compute module configuration
 
 import copy
 
-import pydantic
+try:
+    import pydantic.v1 as pydantic
+except ImportError:
+    import pydantic
 import pytest
 
 import qcengine as qcng

--- a/qcengine/tests/test_harness_canonical.py
+++ b/qcengine/tests/test_harness_canonical.py
@@ -84,7 +84,7 @@ def test_compute_gradient(program, model, keywords):
         with pytest.raises(qcng.exceptions.InputError) as e:
             qcng.compute(inp, program, raise_error=True)
 
-        assert "Driver gradient not implemented" in str(e.value)
+        assert "gradient not implemented" in str(e.value)
 
     else:
         ret = qcng.compute(inp, program, raise_error=True)

--- a/qcengine/util.py
+++ b/qcengine/util.py
@@ -18,7 +18,10 @@ from pathlib import Path
 from threading import Thread
 from typing import Any, BinaryIO, Dict, List, Optional, TextIO, Tuple, Union
 
-from pydantic import BaseModel, ValidationError
+try:
+    from pydantic.v1 import BaseModel, ValidationError
+except ImportError:
+    from pydantic import BaseModel, ValidationError
 from qcelemental.models import AtomicResult, FailedOperation, OptimizationResult
 
 from qcengine.config import TaskConfig

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ if __name__ == "__main__":
         cmdclass=versioneer.get_cmdclass(),
         packages=setuptools.find_packages(),
         setup_requires=[] + pytest_runner,
-        install_requires=["pyyaml", "py-cpuinfo", "psutil", "qcelemental>=0.24.0,<0.26.0", "pydantic>=1.8.2"],
+        install_requires=["pyyaml", "py-cpuinfo", "psutil", "qcelemental>=0.24.0,<0.27.0", "pydantic>=1.8.2"],
         entry_points={"console_scripts": ["qcengine=qcengine.cli:main"]},
         extras_require={
             "docs": [
@@ -38,7 +38,7 @@ if __name__ == "__main__":
                 "numpydoc",
             ],
             "tests": ["pytest", "pytest-cov"],
-            "lint": ["black"],
+            "lint": ["black>=22.1.0,<23.0a0"],
         },
         tests_require=["pytest", "pytest-cov"],
         classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,8 @@ if __name__ == "__main__":
             "Programming Language :: Python :: 3.7",
             "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",
+            "Programming Language :: Python :: 3.10",
+            "Programming Language :: Python :: 3.11",
         ],
         zip_safe=False,
         long_description=long_description,

--- a/versioneer.py
+++ b/versioneer.py
@@ -339,9 +339,9 @@ def get_config_from_root(root):
     # configparser.NoOptionError (if it lacks "VCS="). See the docstring at
     # the top of versioneer.py for instructions on writing your setup.cfg .
     setup_cfg = os.path.join(root, "setup.cfg")
-    parser = configparser.SafeConfigParser()
+    parser = configparser.ConfigParser()
     with open(setup_cfg, "r") as f:
-        parser.readfp(f)
+        parser.read_file(f)
     VCS = parser.get("versioneer", "VCS")  # mandatory
 
     def get(parser, name):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
iterating on #412 -- I was going to PR to that, but this PR grew, so better to collect comments here.

## Description
<!-- Provide a brief description of the PR's purpose here. -->
- [x] Apply Levi's pydantic v1/v2 tolerant import approach. qcng is still using v1 API  closes #412
- [x] Update GHA versions for checkout and codecov and switch GHA from conda to mamba for speedier solves and more comprehensive can't-solves
- [x] Update QCEngineRecords to a commit that also has Levi's pydantic v1/v2 tolerant approach. Add an excuse for QChem molecules for None != {} resulting from https://github.com/MolSSI/QCElemental/pull/305
- [x] Pin black to year 2022, since that's before the great blank line removing kerfluffle, which apparently can't be compromised on until 2024.
- [x] I saw a case where it was sometimes "Driver gradient not implemented" and sometimes "Driver DriverEnum.gradient not implemented", so pass either since it's just a check.
- [x] Fixed a couple Sphinx complaints, so it'll build again. Note that Sphinx is restrained to pydantic=1 for autodoc-pydantic package's sake.
- [x] Tweaked some environment spec files. Note that any with psi4 could use an overhaul b/c moved to c-f. But qcel, qcng, and psi4 are so co-dependent, we need to get pydantic straightened out first.
- [x] Edit versioneer according to plan in https://github.com/MolSSI/QCElemental/issues/313 so that it hopefully works with Python 3.12

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
