### PR TITLE
overhaul psi4 detection parsing

### DIFF
--- a/qcengine/procedures/optking.py
+++ b/qcengine/procedures/optking.py
@@ -20,7 +20,7 @@ class OptKingProcedure(ProcedureHarness):
             "optking",
             return_bool=True,
             raise_error=raise_error,
-            raise_msg="Please install via `conda install optking -c psi4/label/dev`.",
+            raise_msg="Please install via `conda install optking -c conda-forge`.",
         )
 
     def build_input_model(self, data: Union[Dict[str, Any], "OptimizationInput"]) -> "OptimizationInput":

--- a/qcengine/programs/adcc.py
+++ b/qcengine/programs/adcc.py
@@ -50,13 +50,13 @@ class AdccHarness(ProgramHarness):
             "adcc",
             return_bool=True,
             raise_error=raise_error,
-            raise_msg="Please install via `conda install adcc -c adcc`.",
+            raise_msg="Please install via `conda install adcc -c conda-forge`.",
         )
         found_psi4 = which_import(
             "psi4",
             return_bool=True,
             raise_error=raise_error,
-            raise_msg="Please install psi4 for adcc harness via `conda install psi4 -c psi4`.",
+            raise_msg="Please install psi4 for adcc harness via `conda install psi4 -c conda-forge/label/libint_dev -c conda-forge`.",
         )
         return found_adcc and found_psi4
 

--- a/qcengine/programs/psi4.py
+++ b/qcengine/programs/psi4.py
@@ -61,7 +61,7 @@ class Psi4Harness(ProgramHarness):
             with popen([which("psi4"), "--module"]) as exc:
                 exc["proc"].wait(timeout=30)
             if "module does not exist" in exc["stderr"]:
-                pass  # --module argument only in Psi4 DDD branch, so >=1.6
+                psiapi = True  # --module argument only in Psi4 DDD branch (or >=1.6) so grandfather in this check
             else:
                 so, se = exc["stdout"], exc["stderr"]
                 error_msg = f" In particular, psi4 command found but unable to load psi4 module into sys.path. stdout: {so}, stderr: {se}"
@@ -220,7 +220,7 @@ class Psi4Harness(ProgramHarness):
                     psi4.core.set_num_threads(config.ncores, quiet=True)
                     psi4.set_memory(f"{config.memory}GiB", quiet=True)
                     # psi4.core.IOManager.shared_object().set_default_path(str(tmpdir))
-                    if pversion < parse_version("1.6a2"):  # adjust to where DDD merged
+                    if pversion < parse_version("1.6"):  # adjust to where DDD merged
                         # slightly dangerous in that if `qcng.compute({..., psiapi=True}, "psi4")` called *from psi4
                         #   session*, session could unexpectedly get its own files cleaned away.
                         output_data = psi4.schema_wrapper.run_qcschema(input_model).dict()

--- a/qcengine/programs/psi4.py
+++ b/qcengine/programs/psi4.py
@@ -75,6 +75,8 @@ class Psi4Harness(ProgramHarness):
             so, se = exc["stdout"], exc["stderr"]
             error_msg = f" In particular, psi4 module found but unable to load psi4 command into PATH. stdout: {so}, stderr: {se}"
             psiexe = Path(so.rstrip())  # stdout is string & Path is tolerant, so safe op; at worst, psiexe='.'
+            # yes, everthing up to here could be got from `import psi4; psiexe = psi4.executable`. but, we try not to
+            #   load programs/modules in the `def found` fns.
             if not se and psiexe.exists():
                 os.environ["PATH"] += os.pathsep + str(psiexe.parent)
                 psithon = which("psi4", return_bool=True)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
The existing psi4 detection has worked great when psi4 is in order and conda environments prevail, but #389 and #292 show that if something is set up a little wrong with psi4, then everything devolves into an IndexError with the existing psi4 detection.

This PR improves matters by
* in the complete-the-psithon-psiapi-pair blocks:
  * only doing string-safe operations on stdout
  * forming clearer error responses
  * catching stderr instead of tossing it and parsing stdout anyways
  * getting rid of `env` passing. As @Flamefire pointed out, the psi4 module is already in sys.path or which_import wouldn't have worked. unlike #389, code is now passing no env so current env is used (and can provide numpy, etc.). I've tested that there's no need to provide env=os.environ to get current env.
  * checking returncode
  * it was also not showing error messages when psithon found but not psiapi b/c final check was of psithon only. now checking at the weak point
* in the version fn:
  * only doing string-safe operations on stdout
  * catching stderr instead of tossing it and parsing stdout anyways
  * checking returncode

Hopefully this will be more robust. closes #389 closes #391 closes #292

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
