### PR TITLE
defer MPI in MDI

### DIFF
--- a/qcengine/mdi_server.py
+++ b/qcengine/mdi_server.py
@@ -31,12 +31,7 @@ try:
 except ImportError:
     use_mdi = False
 
-try:
-    from mpi4py import MPI
-
-    use_mpi4py = True
-except ImportError:
-    use_mpi4py = False
+use_mpi4py = which_import("mpi4py", return_bool=True)
 
 
 class MDIServer:
@@ -110,6 +105,8 @@ class MDIServer:
 
         # Get correct intra-code MPI communicator
         if use_mpi4py:
+            from mpi4py import MPI
+
             self.mpi_world = MDI_MPI_get_world_comm()
             self.world_rank = self.mpi_world.Get_rank()
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->
This addresses #399. If one has `pymdi` and `mpi4py` packages in the environment, then merely `import qcengine` adds a bunch of potentially interfering mpi envvars. The culprit in particular is `from mpi4py import MPI`.

This PR solves #399 by deferring import of mpi4py until the `MDIServer` is created. But (1) I don't know if that interferes with MDI, hence the @taylor-a-barnes ping (though he's out of the office for a while). Also (2) since MDI isn't a harness like all other programs or procedures, its code is more exposed and can't really be hidden behind `execute()`. Thus, the problem is still present if MDI has ever been invoked, and qcengine can still interfere with other, potentially non-qcng-controlled processes. Probably there should at least be a toggle to turn off MDI MPI even if mpi4py is present.

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [ ] Ready to go
