### PR TITLE
cleanup: known test fault, codeql

### DIFF
--- a/qcengine/programs/tests/test_programs.py
+++ b/qcengine/programs/tests/test_programs.py
@@ -73,7 +73,8 @@ def test_psi4_interactive_task():
 
     assert "Final Energy" in ret.stdout
     assert ret.success
-    assert ret.extras.pop("psiapi_evaluated", False)
+    is_psiapi_evaluated = ret.extras.pop("psiapi_evaluated", False)
+    assert is_psiapi_evaluated
 
 
 @using("psi4_runqcsk")


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->
* there's a highly symmetric system that different versions of nwchem return a different root for. I've kept it at the one our CI uses, but others (#377) have hit it. so let's allow it.
* fix a couple codeql complaints to see what that looks like.

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [ ] Ready to go
