### PR TITLE
Fix psi4 windows version detection

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -29,7 +29,7 @@ Changelog
 .. - UNSOLVED (:issue:`397`) extras failed
 
 
-v0.28.1 / 2023-08-17
+v0.28.1 / 2023-08-18
 --------------------
 
 Bug Fixes

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -29,12 +29,12 @@ Changelog
 .. - UNSOLVED (:issue:`397`) extras failed
 
 
-v0.28.1 / 2023-08-DD (Unreleased)
+v0.28.1 / 2023-08-17
 --------------------
 
 Bug Fixes
 +++++++++
-- UNMERGED () Psi4 - fix ``get_version`` on Windows where whole path and command were getting passed to version parser.
+- (:pr:`426`) Psi4 - fix ``get_version`` on Windows where whole path and command were getting passed to version parser. @loriab
 
 
 v0.28.0 / 2023-08-15

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -29,6 +29,14 @@ Changelog
 .. - UNSOLVED (:issue:`397`) extras failed
 
 
+v0.28.1 / 2023-08-DD (Unreleased)
+--------------------
+
+Bug Fixes
++++++++++
+- UNMERGED () Psi4 - fix ``get_version`` on Windows where whole path and command were getting passed to version parser.
+
+
 v0.28.0 / 2023-08-15
 --------------------
 

--- a/qcengine/programs/psi4.py
+++ b/qcengine/programs/psi4.py
@@ -59,7 +59,7 @@ class Psi4Harness(ProgramHarness):
 
         if psithon and not psiapi:
             with popen([which("psi4"), "--module"]) as exc:
-                exc["proc"].wait(timeout=3)
+                exc["proc"].wait(timeout=30)
             if "module does not exist" in exc["stderr"]:
                 psiapi = True  # --module argument only in Psi4 DDD branch (or >=1.6) so grandfathered in
             else:
@@ -74,7 +74,7 @@ class Psi4Harness(ProgramHarness):
 
         if psiapi and not psithon:
             with popen(["python", "-c", "import psi4; print(psi4.executable)"]) as exc:
-                exc["proc"].wait(timeout=3)
+                exc["proc"].wait(timeout=30)
             so, se, rc = exc["stdout"].strip(), exc["stderr"], exc["proc"].returncode
             error_msg = f" In particular, psi4 module found but unable to load psi4 command into PATH. stdout: {so}, stderr: {se}"
             # yes, everthing up to here could be got from `import psi4; psiexe = psi4.executable`. but, we try not to
@@ -103,7 +103,7 @@ class Psi4Harness(ProgramHarness):
         which_prog = which("psi4")
         if which_prog not in self.version_cache:
             with popen([which_prog, "--version"]) as exc:
-                exc["proc"].wait(timeout=3)
+                exc["proc"].wait(timeout=30)
             so, se, rc = exc["stdout"].strip(), exc["stderr"], exc["proc"].returncode
             if (not so) or (se) or (rc != 0):
                 raise TypeError(f"Error {rc} retrieving Psi4 version: stdout: {so}, stderr: {se}")

--- a/qcengine/programs/psi4.py
+++ b/qcengine/programs/psi4.py
@@ -64,6 +64,7 @@ class Psi4Harness(ProgramHarness):
                 psiapi = True  # --module argument only in Psi4 DDD branch (or >=1.6) so grandfathered in
             else:
                 so, se = exc["stdout"], exc["stderr"]
+                print(f"""found (no psiapi) {exc["proc"].returncode=} {so=} {se=}""")
                 error_msg = f" In particular, psi4 command found but unable to load psi4 module into sys.path. stdout: {so}, stderr: {se}"
                 error_which = which_import
                 if (so) and (not se) and (exc["proc"].returncode == 0):
@@ -76,6 +77,7 @@ class Psi4Harness(ProgramHarness):
             with popen(["python", "-c", "import psi4; print(psi4.executable)"]) as exc:
                 exc["proc"].wait(timeout=30)
             so, se = exc["stdout"], exc["stderr"]
+            print(f"""found (no psithon) {exc["proc"].returncode=} {so=} {se=}""")
             error_msg = f" In particular, psi4 module found but unable to load psi4 command into PATH. stdout: {so}, stderr: {se}"
             # yes, everthing up to here could be got from `import psi4; psiexe = psi4.executable`. but, we try not to
             #   load programs/modules in the `def found` fns.
@@ -103,6 +105,7 @@ class Psi4Harness(ProgramHarness):
         if which_prog not in self.version_cache:
             with popen([which_prog, "--version"]) as exc:
                 exc["proc"].wait(timeout=30)
+            print(f"""get_version {exc["proc"].returncode=} {exc["stdout"]=} {exc["stderr"]=}""")
             if (exc["proc"].returncode != 0) or exc["stderr"]:
                 raise TypeError(f"Error {exc['proc'].returncode} retrieving Psi4 version: " + exc["stderr"])
             self.version_cache[which_prog] = safe_version(exc["stdout"].rstrip())

--- a/qcengine/programs/psi4.py
+++ b/qcengine/programs/psi4.py
@@ -59,7 +59,7 @@ class Psi4Harness(ProgramHarness):
 
         if psithon and not psiapi:
             with popen([which("psi4"), "--module"]) as exc:
-                exc["proc"].wait(timeout=30)
+                exc["proc"].wait(timeout=3)
             if "module does not exist" in exc["stderr"]:
                 psiapi = True  # --module argument only in Psi4 DDD branch (or >=1.6) so grandfathered in
             else:
@@ -75,7 +75,7 @@ class Psi4Harness(ProgramHarness):
 
         if psiapi and not psithon:
             with popen(["python", "-c", "import psi4; print(psi4.executable)"]) as exc:
-                exc["proc"].wait(timeout=30)
+                exc["proc"].wait(timeout=3)
             so, se = exc["stdout"], exc["stderr"]
             print(f"""found (no psithon) {exc["proc"].returncode=} {so=} {se=}""")
             error_msg = f" In particular, psi4 module found but unable to load psi4 command into PATH. stdout: {so}, stderr: {se}"
@@ -88,6 +88,7 @@ class Psi4Harness(ProgramHarness):
                     psithon = which("psi4", return_bool=True)
 
         if psithon and psiapi:
+            print(f"{psithon=} {psiapi=}")
             return True
 
         return error_which(
@@ -104,11 +105,11 @@ class Psi4Harness(ProgramHarness):
         which_prog = which("psi4")
         if which_prog not in self.version_cache:
             with popen([which_prog, "--version"]) as exc:
-                exc["proc"].wait(timeout=30)
+                exc["proc"].wait(timeout=3)
             print(f"""get_version {exc["proc"].returncode=} {exc["stdout"]=} {exc["stderr"]=}""")
             if (exc["proc"].returncode != 0) or exc["stderr"]:
                 raise TypeError(f"Error {exc['proc'].returncode} retrieving Psi4 version: " + exc["stderr"])
-            self.version_cache[which_prog] = safe_version(exc["stdout"].rstrip())
+            self.version_cache[which_prog] = safe_version(exc["stdout"].rstrip().split()[-1])
 
         candidate_version = self.version_cache[which_prog]
 

--- a/qcengine/programs/psi4.py
+++ b/qcengine/programs/psi4.py
@@ -104,10 +104,11 @@ class Psi4Harness(ProgramHarness):
             with popen([which_prog, "--version"]) as exc:
                 exc["proc"].wait(timeout=30)
             so, se, rc = exc["stdout"].strip(), exc["stderr"], exc["proc"].returncode
-            if (not so) or (se) or (rc != 0):
+            if (so) and (not se) and (rc == 0):
+                # Windows echos the command, so split stdout to collect response
+                self.version_cache[which_prog] = safe_version(so.split()[-1])
+            else:
                 raise TypeError(f"Error {rc} retrieving Psi4 version: stdout: {so}, stderr: {se}")
-            # Windows echos the command, so split stdout to collect response
-            self.version_cache[which_prog] = safe_version(so.split()[-1])
 
         candidate_version = self.version_cache[which_prog]
 

--- a/qcengine/programs/psi4.py
+++ b/qcengine/programs/psi4.py
@@ -86,7 +86,6 @@ class Psi4Harness(ProgramHarness):
                     psithon = which("psi4", return_bool=True)
 
         if psithon and psiapi:
-            print(f"{psithon=} {psiapi=}")
             return True
 
         return error_which(


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
psi4 on windows was computing lovely stuff like the below, so clearly the `.split()[-1]` that I removed in #418 was needed. The new check that stdout isn't empty should avert trouble with the split. And stdout is a string in util.popen(), so the strip() should be safe.
```
+#2023-08-17T20:15:44.6106581Z [1m[31mE   pkg_resources.extern.packaging.version.InvalidVersion: Invalid version: '-D-a-psi4-psi4-objdir-C-Miniconda3-envs-baseenv-python.exe.D-a-psi4-psi4-objdir-stage-bin-psi4.-version.-1.9a1.dev42'[0m
+#2023-08-17T20:15:44.6107842Z ------------------------------- Captured stdout -------------------------------
+#2023-08-17T20:15:44.6108602Z found (no psithon) exc["proc"].returncode=0 so='D:\\a\\psi4\\psi4\\objdir\\stage\\bin\\psi4\r\n' se=''
+#2023-08-17T20:15:44.6109594Z get_version exc["proc"].returncode=0 exc["stdout"]='\r\nD:\\a\\psi4\\psi4\\objdir>C:/Miniconda3/envs/baseenv/python.exe D:\\a\\psi4\\psi4\\objdir\\stage\\bin\\psi4 --version \r\n1.9a1.dev42\r\n' exc["stderr"]=''
```


## Changelog description
<!-- Provide a brief single sentence for the changelog. -->

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
