### PR TITLE
Fix parse_environment task_config

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -29,6 +29,30 @@ Changelog
 .. - UNSOLVED (:issue:`397`) extras failed
 
 
+v0.28.2 / 2023-MM-DD (Unreleased)
+--------------------
+
+Breaking Changes
+++++++++++++++++
+
+New Features
+++++++++++++
+
+Enhancements
+++++++++++++
+
+Bug Fixes
++++++++++
+
+Misc.
++++++
+
+MUST (Unmerged)
++++++++++++++++
+- UNMERGED (:pr:`427`) Config - Once again, expand environment variables (now more flexibly) and newly expand ``~``
+  passed into TaskConfig. Particularly relevant for scratch setting.
+
+
 v0.28.1 / 2023-08-18
 --------------------
 

--- a/qcengine/config.py
+++ b/qcengine/config.py
@@ -293,7 +293,7 @@ def get_config(*, hostname: Optional[str] = None, task_config: Dict[str, Any] = 
         task_config = {}
 
     task_config_env = read_qcengine_task_environment()
-    task_config = {**task_config_env, **task_config}
+    task_config = {**task_config_env, **parse_environment(task_config)}
 
     config = {}
 

--- a/qcengine/config.py
+++ b/qcengine/config.py
@@ -259,11 +259,9 @@ def parse_environment(data: Dict[str, Any]) -> Dict[str, Any]:
     """Collects local environment variable values into ``data`` for any keys with RHS starting with ``$``."""
     ret = {}
     for k, var in data.items():
-        if isinstance(var, str) and var.startswith("$"):
-            var = var.replace("$", "", 1)
-            if var in os.environ:
-                var = os.environ[var]
-            else:
+        if isinstance(var, str):
+            var = os.path.expanduser(os.path.expandvars(var))
+            if var.startswith("$"):
                 var = None
 
         ret[k] = var

--- a/qcengine/tests/test_config.py
+++ b/qcengine/tests/test_config.py
@@ -60,18 +60,25 @@ def test_node_skip_environ():
     assert node.scratch_directory is None
 
 
-@pytest.mark.parametrize("envvars,scr,ans", [
-    ({"SCRATCH": "/my_scratch"}, "$SCRATCH", "/my_scratch"),
-    ({"SCRATCH": "/my_scratch"}, "${SCRATCH}", "/my_scratch"),
-    # ({"SCRATCH": "/my_scratch"}, "%SCRATCH%", "/my_scratch"),  # only valid on Windows
-    ({"PBS_DIR": "/cluster/scr/job", "JOBNUM": "12345"}, "$PBS_DIR/psi_scratch/$JOBNUM", "/cluster/scr/job/psi_scratch/12345"),
-    ({"QCSCR": "qcscr", "USER": "johndoe"}, "/scratch/${USER}/$QCSCR", "/scratch/johndoe/qcscr"),
-    ({}, "~", f"{os.environ.get('HOME')}"),
-    ({"QCSCR": "qcscr"}, "~/scratch/$QCSCR", f"{os.environ.get('HOME')}/scratch/qcscr"),
-    ({}, "$HOME", f"{os.environ.get('HOME')}"),
-    # ({}, "$RANDOM_NOVAR", "$RANDOM_NOVAR"),  # new behavior?
-    ({}, "$RANDOM_NOVAR", None),  # longstanding behavior
-])
+@pytest.mark.parametrize(
+    "envvars,scr,ans",
+    [
+        ({"SCRATCH": "/my_scratch"}, "$SCRATCH", "/my_scratch"),
+        ({"SCRATCH": "/my_scratch"}, "${SCRATCH}", "/my_scratch"),
+        # ({"SCRATCH": "/my_scratch"}, "%SCRATCH%", "/my_scratch"),  # only valid on Windows
+        (
+            {"PBS_DIR": "/cluster/scr/job", "JOBNUM": "12345"},
+            "$PBS_DIR/psi_scratch/$JOBNUM",
+            "/cluster/scr/job/psi_scratch/12345",
+        ),
+        ({"QCSCR": "qcscr", "USER": "johndoe"}, "/scratch/${USER}/$QCSCR", "/scratch/johndoe/qcscr"),
+        ({}, "~", f"{os.environ.get('HOME')}"),
+        ({"QCSCR": "qcscr"}, "~/scratch/$QCSCR", f"{os.environ.get('HOME')}/scratch/qcscr"),
+        ({}, "$HOME", f"{os.environ.get('HOME')}"),
+        # ({}, "$RANDOM_NOVAR", "$RANDOM_NOVAR"),  # new behavior?
+        ({}, "$RANDOM_NOVAR", None),  # longstanding behavior
+    ],
+)
 def test_envvar(envvars, scr, ans):
     with environ_context(env=envvars):
         tc = qcng.get_config(task_config={"scratch_directory": scr})

--- a/qcengine/tests/test_config.py
+++ b/qcengine/tests/test_config.py
@@ -3,6 +3,7 @@ Tests the QCEngine compute module configuration
 """
 
 import copy
+import os
 
 try:
     import pydantic.v1 as pydantic
@@ -57,6 +58,24 @@ def test_node_skip_environ():
 
     node = qcng.config.NodeDescriptor(**description)
     assert node.scratch_directory is None
+
+
+@pytest.mark.parametrize("envvars,scr,ans", [
+    ({"SCRATCH": "/my_scratch"}, "$SCRATCH", "/my_scratch"),
+    ({"SCRATCH": "/my_scratch"}, "${SCRATCH}", "/my_scratch"),
+    # ({"SCRATCH": "/my_scratch"}, "%SCRATCH%", "/my_scratch"),  # only valid on Windows
+    ({"PBS_DIR": "/cluster/scr/job", "JOBNUM": "12345"}, "$PBS_DIR/psi_scratch/$JOBNUM", "/cluster/scr/job/psi_scratch/12345"),
+    ({"QCSCR": "qcscr", "USER": "johndoe"}, "/scratch/${USER}/$QCSCR", "/scratch/johndoe/qcscr"),
+    ({}, "~", f"{os.environ.get('HOME')}"),
+    ({"QCSCR": "qcscr"}, "~/scratch/$QCSCR", f"{os.environ.get('HOME')}/scratch/qcscr"),
+    ({}, "$HOME", f"{os.environ.get('HOME')}"),
+    # ({}, "$RANDOM_NOVAR", "$RANDOM_NOVAR"),  # new behavior?
+    ({}, "$RANDOM_NOVAR", None),  # longstanding behavior
+])
+def test_envvar(envvars, scr, ans):
+    with environ_context(env=envvars):
+        tc = qcng.get_config(task_config={"scratch_directory": scr})
+        assert tc.scratch_directory == ans
 
 
 @pytest.fixture


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->
Fixed a minor bug introduced at #400

Expected behavior
```python
>>> os.environ["SCRATCH"] = "/my_scratch"
>>> qcng.get_config(task_config={"scratch_directory": "$SCRATCH"})
<JobConfig ncores=2 memory=2.506 scratch_directory='/my_scratch'>
```

observed behavior
```python
>>> os.environ["SCRATCH"] = "/my_scratch"
>>> qcng.get_config(task_config={"scratch_directory": "$SCRATCH"})
<JobConfig ncores=2 memory=2.506 scratch_directory='$SCRATCH'>
```

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
