### PR TITLE
Add a harness for MACE-OFF23 and local MACE models

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -98,6 +98,12 @@ jobs:
             runs-on: windows-latest
             pytest: "-k 'not (hes2 or qchem)'"
 
+          - conda-env: mace
+            python-version: 3.10
+            label: MACE
+            runs-on: ubuntu-latest
+            pytest: ""
+
     name: "🐍 ${{ matrix.cfg.python-version }} • ${{ matrix.cfg.label }} • ${{ matrix.cfg.runs-on }}"
     runs-on: ${{ matrix.cfg.runs-on }}
 

--- a/devtools/conda-envs/mace.yaml
+++ b/devtools/conda-envs/mace.yaml
@@ -1,0 +1,27 @@
+name: mace
+channels:
+  - conda-forge
+dependencies:
+    # Core
+  - python
+  - pyyaml
+  - py-cpuinfo
+  - psutil
+  - qcelemental >=0.12.0
+  - pydantic>=1.0.0
+
+  # mace deps
+  - pytorch>=2.0.0
+  - numpy
+  - scipy
+  - ase
+  - opt_einsum
+  - e3nn
+
+    # Testing
+  - pytest
+  - pytest-cov
+  - codecov
+
+  - pip:
+    - matscipy

--- a/devtools/conda-envs/mace.yaml
+++ b/devtools/conda-envs/mace.yaml
@@ -25,3 +25,4 @@ dependencies:
 
   - pip:
     - matscipy
+    - git+https://github.com/ACEsuit/mace.git@develop

--- a/qcengine/programs/base.py
+++ b/qcengine/programs/base.py
@@ -28,6 +28,7 @@ from .terachem_pbs import TeraChemPBSHarness
 from .torchani import TorchANIHarness
 from .turbomole import TurbomoleHarness
 from .xtb import XTBHarness
+from .mace import MACEHarness
 
 __all__ = ["register_program", "get_program", "list_all_programs", "list_available_programs"]
 
@@ -125,6 +126,7 @@ register_program(XTBHarness())
 
 # AI
 register_program(TorchANIHarness())
+register_program(MACEHarness())
 
 # Molecular Mechanics
 register_program(RDKitHarness())

--- a/qcengine/programs/mace.py
+++ b/qcengine/programs/mace.py
@@ -1,0 +1,146 @@
+from typing import TYPE_CHECKING, Dict, Union
+from qcelemental.models import AtomicResult, Provenance, FailedOperation
+from qcelemental.util import safe_version, which_import
+from qcengine.exceptions import InputError
+from qcengine.programs.model import ProgramHarness
+from qcengine.units import ureg
+
+if TYPE_CHECKING:
+    from qcelemental.models import AtomicInput, FailedOperation
+    from qcengine.config import TaskConfig
+
+
+class MACEHarness(ProgramHarness):
+    """Can be used to execute a published MACE-OFF23 model or local mace model.
+    For more info on the MACE-OFF23 models see <https://doi.org/10.48550/arXiv.2312.15211>.
+    The models can be found at <https://github.com/ACEsuit/mace-off>
+    """
+
+    _CACHE = {}
+
+    _defaults = {
+        "name": "MACE",
+        "scratch": False,
+        "thread_safe": True,
+        "thread_parallel": False,
+        "node_parallel": False,
+        "managed_memory": False,
+    }
+    version_cache: Dict[str, str] = {}
+
+    def found(self, raise_error: bool = False) -> bool:
+        return which_import(
+            "mace",
+            return_bool=True,
+            raise_error=raise_error,
+            raise_msg="Please install via github ",
+        )
+
+    def get_version(self) -> str:
+        self.found(raise_error=True)
+
+        which_prog = which_import("mace")
+        if which_prog not in self.version_cache:
+            import mace
+
+            self.version_cache[which_prog] = safe_version(mace.__version__)
+
+        return self.version_cache[which_prog]
+
+    def load_model(self, name: str):
+        """Compile and cache the model to make it faster when calling many times in serial"""
+        model_name = name.lower()
+        if model_name in self._CACHE:
+            return self._CACHE[model_name]
+
+        import torch
+        from e3nn.util import jit
+        if model_name in ["small", "medium", "large"]:
+            from mace.calculators.foundations_models import mace_off
+            model = mace_off(model=model_name, return_raw_model=True)
+        else:
+            model = torch.load(name, map_location=torch.device("cpu"))
+        comp_mod = jit.compile(model)
+        self._CACHE[model_name] = (comp_mod, float(model.r_max), model.atomic_numbers)
+        return self._CACHE[model_name]
+
+    def compute(
+        self, input_data: "AtomicInput", config: "TaskConfig"
+    ) -> Union["AtomicResult", "FailedOperation"]:
+
+        self.found(raise_error=True)
+
+        import mace
+        import numpy as np
+        import torch
+        from mace.data import AtomicData
+        from mace.data.utils import AtomicNumberTable, Configuration
+        from mace.tools.torch_geometric import DataLoader
+
+        torch.set_default_dtype(torch.float64)
+
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        # Failure flag
+        ret_data = {"success": False}
+
+        # Build model
+        method = input_data.model.method
+
+        # load the torch model which can be a MACE-OFF23 or local model
+        model, r_max, atomic_numbers = self.load_model(name=method)
+
+        z_table = AtomicNumberTable([int(z) for z in atomic_numbers])
+        atomic_numbers = input_data.molecule.atomic_numbers
+        pbc = (False, False, False)
+        # create some large cell, is this needed?
+        cell = np.array([[100.0, 0.0, 0.0], [0.0, 100.0, 0.0], [0.0, 0.0, 100.0]])
+
+        config = Configuration(
+            atomic_numbers=atomic_numbers,
+            positions=input_data.molecule.geometry
+            * ureg.conversion_factor("bohr", "angstrom"),
+            pbc=pbc,
+            cell=cell,
+        )
+
+        data_loader = DataLoader(
+            dataset=[AtomicData.from_config(config, z_table=z_table, cutoff=r_max)],
+            batch_size=1,
+            shuffle=False,
+            drop_last=False,
+        )
+        input_dict = next(iter(data_loader)).to_dict()
+        model.to(device)
+        mace_data = model(input_dict, compute_force=True)
+        ret_data["properties"] = {
+            "return_energy": mace_data["energy"]
+            * ureg.conversion_factor("eV", "hartree")
+        }
+
+        if input_data.driver == "energy":
+            ret_data["return_result"] = ret_data["properties"]["return_energy"]
+        elif input_data.driver == "gradient":
+            ret_data["return_result"] = (
+                np.asarray(
+                    -1.0
+                    * mace_data["forces"]
+                    * ureg.conversion_factor("eV / angstrom", "hartree / bohr")
+                )
+                .ravel()
+                .tolist()
+            )
+
+        else:
+            raise InputError(
+                "MACE only supports the energy and gradient driver methods."
+            )
+
+        ret_data["extras"] = input_data.extras.copy()
+        ret_data["provenance"] = Provenance(
+            creator="mace", version=mace.__version__, routine="mace"
+        )
+        ret_data["schema_name"] = "qcschema_output"
+        ret_data["success"] = True
+
+        # Form up a dict first, then sent to BaseModel to avoid repeat kwargs which don't override each other
+        return AtomicResult(**{**input_data.dict(), **ret_data})

--- a/qcengine/testing.py
+++ b/qcengine/testing.py
@@ -185,6 +185,7 @@ _programs = {
     "turbomole": which("define", return_bool=True),
     "xtb": which_import("xtb", return_bool=True),
     "mrchem": is_program_new_enough("mrchem", "1.0.0"),
+    "mace": is_program_new_enough("mace", "0.3.2")
 }
 _programs["openmm"] = _programs["rdkit"] and which_import(".openmm", package="simtk", return_bool=True)
 

--- a/qcengine/testing.py
+++ b/qcengine/testing.py
@@ -185,7 +185,7 @@ _programs = {
     "turbomole": which("define", return_bool=True),
     "xtb": which_import("xtb", return_bool=True),
     "mrchem": is_program_new_enough("mrchem", "1.0.0"),
-    "mace": is_program_new_enough("mace", "0.3.2")
+    "mace": is_program_new_enough("mace", "0.3.2"),
 }
 _programs["openmm"] = _programs["rdkit"] and which_import(".openmm", package="simtk", return_bool=True)
 


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
This PR adds a new harness for ML models based on the MACE architecture, supporting local models and three general organic force field published models (MACE-OFF23) which can be found [here](https://github.com/ACEsuit/mace-off). More information about the performance can be found [here](https://doi.org/10.48550/arXiv.2312.15211).

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->
Add new harness for MACE ML models supporting local and the general MACE-OFF23 models.

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [ ] Code base linted
- [ ] Ready to go
