### PR TITLE
QCEngine/NWChem interface minor update

### DIFF
--- a/qcengine/programs/nwchem/runner.py
+++ b/qcengine/programs/nwchem/runner.py
@@ -184,6 +184,12 @@ class NWChemHarness(ErrorCorrectionProgramHarness):
             val = opts.pop("geometry__autosym")
             molcmd = re.sub(r"geometry ([^\n]*)", rf"geometry \1 autosym {val}", molcmd)
 
+        # Added these keywords so that coordinates (and gradients) are not shifted or reoriented
+        if opts.get("geometry__noautosym", False):
+            molcmd = re.sub(r"geometry ([^\n]*)", r"geometry \1 noautosym", molcmd)
+        if opts.pop("geometry__nocenter", False):
+            molcmd = re.sub(r"geometry ([^\n]*)", r"geometry \1 nocenter", molcmd)
+
         # Handle calc type and quantum chemical method
         mdccmd, mdcopts = muster_modelchem(input_model.model.method, input_model.driver, opts.pop("qc_module", False))
         opts.update(mdcopts)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
A minor update to make it so that the keywords "noautosym" and "nocenter" can be passed to NWChem

## Changelog description
Added a few lines in "build_input" in "runner.py" which can take some input keywords and change the NWChem input file to add them.

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [ ] Code base linted
- [ ] Ready to go

I've tested these changes on a personal installation of QCEngine/NWChem (for preparation for NWChemEx...)

