### PR TITLE
Use sys.executable over explicit call to python

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -44,6 +44,7 @@ Enhancements
 
 Bug Fixes
 +++++++++
+- (:pr:`451`, :issue:`450`) Psi4 - Fixes bug in Psi4 detection when command `python` not available. @susilehtola, @topazus
 
 Misc.
 +++++

--- a/qcengine/programs/psi4.py
+++ b/qcengine/programs/psi4.py
@@ -73,7 +73,7 @@ class Psi4Harness(ProgramHarness):
                         psiapi = which_import("psi4", return_bool=True)
 
         if psiapi and not psithon:
-            with popen(["python", "-c", "import psi4; print(psi4.executable)"]) as exc:
+            with popen([sys.executable, "-c", "import psi4; print(psi4.executable)"]) as exc:
                 exc["proc"].wait(timeout=30)
             so, se, rc = exc["stdout"].strip(), exc["stderr"], exc["proc"].returncode
             error_msg = f" In particular, psi4 module found but unable to load psi4 command into PATH. stdout: {so}, stderr: {se}"


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the PR's purpose here. -->
The psi4 frontend calls `python` which may not be available or not have psi4.
This PR replaces the call with `sys.executable`.

closes #450

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
