### PR TITLE
Csse pyd2 test use multiple schema versions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -157,7 +157,7 @@ jobs:
         echo pup
         docker inspect mtzgroup/terachem
         echo cat
-        docker exec mtzgroup/terachem:latest
+        docker exec mtzgroup/terachem:latest which terachem
         echo mouse
         docker exec terachem cat /usr/local/bin/_entrypoint.sh
         echo bun

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -148,7 +148,7 @@ jobs:
       #if: false
       run: |
         conda remove qcelemental --force
-        python -m pip install 'git+https://github.com/loriab/QCElemental.git@csse_pyd2_shimclasses' --no-deps
+        python -m pip install 'git+https://github.com/loriab/QCElemental.git@csse_pyd2_converterclasses' --no-deps
 
       # note: conda remove --force, not mamba remove --force b/c https://github.com/mamba-org/mamba/issues/412
       #       alt. is micromamba but not yet ready for setup-miniconda https://github.com/conda-incubator/setup-miniconda/issues/75

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -157,11 +157,11 @@ jobs:
         echo pup
         docker inspect mtzgroup/terachem
         echo cat
-        docker run mtzgroup/terachem
+        docker exec mtzgroup/terachem cat /usr/local/bin/_entrypoint.sh
         echo mouse
-        docker run --rm --entrypoint=ls node /bin
+        docker exec mtzgroup/terachem
         echo bun
-        docker run --entrypoint "/bin/bash" mtzgroup/terachem
+        docker run --rm -a stdout --entrypoint cat mtzgroup/terachem /usr/local/bin/_entrypoint.sh
 
     - name: Special Config - QCElemental Dep
       #if: false

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -157,9 +157,15 @@ jobs:
         echo pup
         docker inspect mtzgroup/terachem
         echo cat
-        docker ps -a
+        #ok docker ps -a
+        docker run mtzgroup/terachem terachem
+        #docker exec mtzgroup/terachem cat /usr/local/bin/_entrypoint.sh
+        #docker exec terachem which terachem
         echo mouse
+        #docker exec terachem cat /usr/local/bin/_entrypoint.sh
+        #ok docker run --rm --entrypoint=ls node /bin
         echo bun
+        #docker run --entrypoint "/bin/bash" mtzgroup/terachem
         docker run --rm -a stdout --entrypoint cat mtzgroup/terachem /usr/local/bin/_entrypoint.sh
 
 #docker.io/mtzgroup/terachem:latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -150,23 +150,6 @@ jobs:
       run: |
         qcore --accept-license
 
-    - name: Special Config - Terachem
-      if: "(matrix.cfg.label == 'TeraChem')"
-      run: |
-        docker pull mtzgroup/terachem
-        echo pup
-        docker inspect mtzgroup/terachem
-        echo cat
-        #ok docker ps -a
-        docker run mtzgroup/terachem terachem
-        #docker exec mtzgroup/terachem cat /usr/local/bin/_entrypoint.sh
-        #docker exec terachem which terachem
-        echo mouse
-        #docker exec terachem cat /usr/local/bin/_entrypoint.sh
-        #ok docker run --rm --entrypoint=ls node /bin
-        echo bun
-        #docker run --entrypoint "/bin/bash" mtzgroup/terachem
-        docker run --rm -a stdout --entrypoint cat mtzgroup/terachem /usr/local/bin/_entrypoint.sh
 
 #docker.io/mtzgroup/terachem:latest
 #Usage:  docker exec [OPTIONS] CONTAINER COMMAND [ARG...]

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -78,11 +78,11 @@ jobs:
             runs-on: ubuntu-latest
             pytest: ""
 
-          - conda-env: mrchem
-            python-version: 3.8
-            label: MRChem
-            runs-on: ubuntu-latest
-            pytest: ""
+#          - conda-env: mrchem
+#            python-version: 3.8
+#            label: MRChem
+#            runs-on: ubuntu-latest
+#            pytest: ""
 
           - conda-env: adcc
             python-version: 3.8
@@ -96,11 +96,11 @@ jobs:
             runs-on: ubuntu-latest
             pytest: ""
 
-          - conda-env: opt-disp-cf
-            python-version: 3.11
-            label: optimization-dispersion
-            runs-on: windows-latest
-            pytest: "-k 'not (hes2 or qchem)'"
+#          - conda-env: opt-disp-cf
+#            python-version: 3.11
+#            label: optimization-dispersion
+#            runs-on: windows-latest
+#            pytest: "-k 'not (hes2 or qchem)'"
 
           - conda-env: mace
             python-version: "3.10"
@@ -154,7 +154,9 @@ jobs:
       if: "(matrix.cfg.label == 'TeraChem')"
       run: |
         docker pull mtzgroup/terachem
-        docker run --rm -it --entrypoint=ls node /bin
+        docker run mtzgroup/terachem
+        docker run --rm --entrypoint=ls node /bin
+        docker run --entrypoint "/bin/bash" mtzgroup/terachem
 
     - name: Special Config - QCElemental Dep
       #if: false

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -154,6 +154,7 @@ jobs:
       if: "(matrix.cfg.label == 'TeraChem')"
       run: |
         docker pull mtzgroup/terachem
+        docker run --rm -it --entrypoint=ls node /bin
 
     - name: Special Config - QCElemental Dep
       #if: false

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,97 +28,97 @@ jobs:
           #  pytest: ""
           #  Note: removed Sep 2024 b/c too hard to reconcile w/pyd v2
 
-#          - conda-env: psi-nightly
-#            python-version: "3.10"
-#            label: Psi4-1.6
-#            runs-on: ubuntu-latest
-#            pytest: ""
-#
-#          - conda-env: psi-cf
-#            python-version: "3.12"
-#            label: Psi4-1.8
-#            runs-on: windows-latest
-#            pytest: "-k 'not (hes2 or qchem)'"
-#
-#          - conda-env: torchani
-#            python-version: 3.8
-#            label: ANI
-#            runs-on: ubuntu-latest
-#            pytest: ""
-#
-#          - conda-env: openmm
-#            python-version: 3.8
-#            label: OpenMM
-#            runs-on: ubuntu-latest
-#            pytest: ""
-#
-#          - conda-env: xtb
-#            python-version: "3.10"
-#            label: xTB
-#            runs-on: ubuntu-latest
-#            pytest: ""
-#
-#          #- conda-env: qcore
-#          #  python-version: 3.7
-#          #  label: QCore
-#          #  runs-on: ubuntu-latest
-#          #  pytest: ""
-#          #  Note: removed Sep 2024 b/c too hard to reconcile w/pyd v2. Manby approves.
-#
-#          - conda-env: nwchem
-#            python-version: 3.8
-#            label: NWChem70
-#            runs-on: ubuntu-20.04
-#            pytest: ""
-#            # formerly NWChem v6.6 with python-version: 3.6 & runs-on: ubuntu-16.04 but ubuntu env retired by GH Sep 2021
-#
-#          - conda-env: nwchem-cf
-#            python-version: 3.12
-#            label: NWChem
-#            runs-on: ubuntu-latest
-#            pytest: ""
-#
-#          - conda-env: mrchem
-#            python-version: 3.8
-#            label: MRChem
-#            runs-on: ubuntu-latest
-#            pytest: ""
-#
-#          - conda-env: adcc
-#            python-version: 3.8
-#            label: ADCC
-#            runs-on: ubuntu-latest
-#            pytest: ""
-#
-#          - conda-env: opt-disp
-#            python-version: 3.8
-#            label: optimization-dispersion
-#            runs-on: ubuntu-latest
-#            pytest: ""
-#
-#          - conda-env: opt-disp-cf
-#            python-version: 3.11
-#            label: optimization-dispersion
-#            runs-on: windows-latest
-#            pytest: "-k 'not (hes2 or qchem)'"
-#
-#          - conda-env: mace
-#            python-version: "3.10"
-#            label: MACE
-#            runs-on: ubuntu-latest
-#            pytest: ""
-#
-#          - conda-env: aimnet2
-#            python-version: 3.11
-#            label: AIMNET2
-#            runs-on: ubuntu-latest
-#            pytest: ""
+          - conda-env: psi-nightly
+            python-version: "3.10"
+            label: Psi4-1.6
+            runs-on: ubuntu-latest
+            pytest: ""
+
+          - conda-env: psi-cf
+            python-version: "3.12"
+            label: Psi4-1.8
+            runs-on: windows-latest
+            pytest: "-k 'not (hes2 or qchem)'"
+
+          - conda-env: torchani
+            python-version: 3.8
+            label: ANI
+            runs-on: ubuntu-latest
+            pytest: ""
+
+          - conda-env: openmm
+            python-version: 3.8
+            label: OpenMM
+            runs-on: ubuntu-latest
+            pytest: ""
+
+          - conda-env: xtb
+            python-version: "3.10"
+            label: xTB
+            runs-on: ubuntu-latest
+            pytest: ""
+
+          #- conda-env: qcore
+          #  python-version: 3.7
+          #  label: QCore
+          #  runs-on: ubuntu-latest
+          #  pytest: ""
+          #  Note: removed Sep 2024 b/c too hard to reconcile w/pyd v2. Manby approves.
 
           - conda-env: nwchem
-            python-version: "3.10"
-            label: TeraChem
+            python-version: 3.8
+            label: NWChem70
             runs-on: ubuntu-20.04
             pytest: ""
+            # formerly NWChem v6.6 with python-version: 3.6 & runs-on: ubuntu-16.04 but ubuntu env retired by GH Sep 2021
+
+          - conda-env: nwchem-cf
+            python-version: 3.12
+            label: NWChem
+            runs-on: ubuntu-latest
+            pytest: ""
+
+          - conda-env: mrchem
+            python-version: 3.8
+            label: MRChem
+            runs-on: ubuntu-latest
+            pytest: ""
+
+          - conda-env: adcc
+            python-version: 3.8
+            label: ADCC
+            runs-on: ubuntu-latest
+            pytest: ""
+
+          - conda-env: opt-disp
+            python-version: 3.8
+            label: optimization-dispersion
+            runs-on: ubuntu-latest
+            pytest: ""
+
+          - conda-env: opt-disp-cf
+            python-version: 3.11
+            label: optimization-dispersion
+            runs-on: windows-latest
+            pytest: "-k 'not (hes2 or qchem)'"
+
+          - conda-env: mace
+            python-version: "3.10"
+            label: MACE
+            runs-on: ubuntu-latest
+            pytest: ""
+
+          - conda-env: aimnet2
+            python-version: 3.11
+            label: AIMNET2
+            runs-on: ubuntu-latest
+            pytest: ""
+
+          #- conda-env: nwchem
+          #  python-version: "3.10"
+          #  label: TeraChem
+          #  runs-on: ubuntu-20.04
+          #  pytest: ""
 
     name: "🐍 ${{ matrix.cfg.python-version }} • ${{ matrix.cfg.label }} • ${{ matrix.cfg.runs-on }}"
     runs-on: ${{ matrix.cfg.runs-on }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -157,9 +157,9 @@ jobs:
         echo pup
         docker inspect mtzgroup/terachem
         echo cat
-        docker exec mtzgroup/terachem cat /usr/local/bin/_entrypoint.sh
+        docker exec mtzgroup/terachem:latest
         echo mouse
-        docker exec mtzgroup/terachem
+        docker exec terachem cat /usr/local/bin/_entrypoint.sh
         echo bun
         docker run --rm -a stdout --entrypoint cat mtzgroup/terachem /usr/local/bin/_entrypoint.sh
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -114,6 +114,12 @@ jobs:
             runs-on: ubuntu-latest
             pytest: ""
 
+          - conda-env: nwchem
+            python-version: "3.10"
+            label: TeraChem
+            runs-on: ubuntu-20.04
+            pytest: ""
+
     name: "🐍 ${{ matrix.cfg.python-version }} • ${{ matrix.cfg.label }} • ${{ matrix.cfg.runs-on }}"
     runs-on: ${{ matrix.cfg.runs-on }}
 
@@ -143,6 +149,11 @@ jobs:
       if: "(matrix.cfg.label == 'QCore')"
       run: |
         qcore --accept-license
+
+    - name: Special Config - Terachem
+      if: "(matrix.cfg.label == 'TeraChem')"
+      run: |
+        docker pull mtzgroup/terachem
 
     - name: Special Config - QCElemental Dep
       #if: false

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -155,13 +155,15 @@ jobs:
       run: |
         docker pull mtzgroup/terachem
         echo pup
-        #good docker inspect mtzgroup/terachem
+        docker inspect mtzgroup/terachem
         echo cat
-        docker exec terachem which terachem
+        docker ps -a
         echo mouse
-        docker exec terachem cat /usr/local/bin/_entrypoint.sh
         echo bun
         docker run --rm -a stdout --entrypoint cat mtzgroup/terachem /usr/local/bin/_entrypoint.sh
+
+#docker.io/mtzgroup/terachem:latest
+#Usage:  docker exec [OPTIONS] CONTAINER COMMAND [ARG...]
 
     - name: Special Config - QCElemental Dep
       #if: false

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -154,8 +154,13 @@ jobs:
       if: "(matrix.cfg.label == 'TeraChem')"
       run: |
         docker pull mtzgroup/terachem
+        echo pup
+        docker inspect mtzgroup/terachem
+        echo cat
         docker run mtzgroup/terachem
+        echo mouse
         docker run --rm --entrypoint=ls node /bin
+        echo bun
         docker run --entrypoint "/bin/bash" mtzgroup/terachem
 
     - name: Special Config - QCElemental Dep

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,91 +28,91 @@ jobs:
           #  pytest: ""
           #  Note: removed Sep 2024 b/c too hard to reconcile w/pyd v2
 
-          - conda-env: psi-nightly
-            python-version: "3.10"
-            label: Psi4-1.6
-            runs-on: ubuntu-latest
-            pytest: ""
-
-          - conda-env: psi-cf
-            python-version: "3.12"
-            label: Psi4-1.8
-            runs-on: windows-latest
-            pytest: "-k 'not (hes2 or qchem)'"
-
-          - conda-env: torchani
-            python-version: 3.8
-            label: ANI
-            runs-on: ubuntu-latest
-            pytest: ""
-
-          - conda-env: openmm
-            python-version: 3.8
-            label: OpenMM
-            runs-on: ubuntu-latest
-            pytest: ""
-
-          - conda-env: xtb
-            python-version: "3.10"
-            label: xTB
-            runs-on: ubuntu-latest
-            pytest: ""
-
-          #- conda-env: qcore
-          #  python-version: 3.7
-          #  label: QCore
-          #  runs-on: ubuntu-latest
-          #  pytest: ""
-          #  Note: removed Sep 2024 b/c too hard to reconcile w/pyd v2
-
-          - conda-env: nwchem
-            python-version: 3.8
-            label: NWChem70
-            runs-on: ubuntu-20.04
-            pytest: ""
-            # formerly NWChem v6.6 with python-version: 3.6 & runs-on: ubuntu-16.04 but ubuntu env retired by GH Sep 2021
-
-          - conda-env: nwchem-cf
-            python-version: 3.12
-            label: NWChem
-            runs-on: ubuntu-latest
-            pytest: ""
-
+#          - conda-env: psi-nightly
+#            python-version: "3.10"
+#            label: Psi4-1.6
+#            runs-on: ubuntu-latest
+#            pytest: ""
+#
+#          - conda-env: psi-cf
+#            python-version: "3.12"
+#            label: Psi4-1.8
+#            runs-on: windows-latest
+#            pytest: "-k 'not (hes2 or qchem)'"
+#
+#          - conda-env: torchani
+#            python-version: 3.8
+#            label: ANI
+#            runs-on: ubuntu-latest
+#            pytest: ""
+#
+#          - conda-env: openmm
+#            python-version: 3.8
+#            label: OpenMM
+#            runs-on: ubuntu-latest
+#            pytest: ""
+#
+#          - conda-env: xtb
+#            python-version: "3.10"
+#            label: xTB
+#            runs-on: ubuntu-latest
+#            pytest: ""
+#
+#          #- conda-env: qcore
+#          #  python-version: 3.7
+#          #  label: QCore
+#          #  runs-on: ubuntu-latest
+#          #  pytest: ""
+#          #  Note: removed Sep 2024 b/c too hard to reconcile w/pyd v2. Manby approves.
+#
+#          - conda-env: nwchem
+#            python-version: 3.8
+#            label: NWChem70
+#            runs-on: ubuntu-20.04
+#            pytest: ""
+#            # formerly NWChem v6.6 with python-version: 3.6 & runs-on: ubuntu-16.04 but ubuntu env retired by GH Sep 2021
+#
+#          - conda-env: nwchem-cf
+#            python-version: 3.12
+#            label: NWChem
+#            runs-on: ubuntu-latest
+#            pytest: ""
+#
 #          - conda-env: mrchem
 #            python-version: 3.8
 #            label: MRChem
 #            runs-on: ubuntu-latest
 #            pytest: ""
-
-          - conda-env: adcc
-            python-version: 3.8
-            label: ADCC
-            runs-on: ubuntu-latest
-            pytest: ""
-
-          - conda-env: opt-disp
-            python-version: 3.8
-            label: optimization-dispersion
-            runs-on: ubuntu-latest
-            pytest: ""
-
+#
+#          - conda-env: adcc
+#            python-version: 3.8
+#            label: ADCC
+#            runs-on: ubuntu-latest
+#            pytest: ""
+#
+#          - conda-env: opt-disp
+#            python-version: 3.8
+#            label: optimization-dispersion
+#            runs-on: ubuntu-latest
+#            pytest: ""
+#
 #          - conda-env: opt-disp-cf
 #            python-version: 3.11
 #            label: optimization-dispersion
 #            runs-on: windows-latest
 #            pytest: "-k 'not (hes2 or qchem)'"
-
-          - conda-env: mace
-            python-version: "3.10"
-            label: MACE
-            runs-on: ubuntu-latest
-            pytest: ""
-
-          - conda-env: aimnet2
-            python-version: 3.11
-            label: AIMNET2
-            runs-on: ubuntu-latest
-            pytest: ""
+#
+#          - conda-env: mace
+#            python-version: "3.10"
+#            label: MACE
+#            runs-on: ubuntu-latest
+#            pytest: ""
+#
+#          - conda-env: aimnet2
+#            python-version: 3.11
+#            label: AIMNET2
+#            runs-on: ubuntu-latest
+#            pytest: ""
 
           - conda-env: nwchem
             python-version: "3.10"
@@ -155,9 +155,9 @@ jobs:
       run: |
         docker pull mtzgroup/terachem
         echo pup
-        docker inspect mtzgroup/terachem
+        #good docker inspect mtzgroup/terachem
         echo cat
-        docker exec mtzgroup/terachem:latest which terachem
+        docker exec terachem which terachem
         echo mouse
         docker exec terachem cat /usr/local/bin/_entrypoint.sh
         echo bun

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
       - id: black
         language_version: python3.12
         args: [--line-length=120]
-        exclude: 'test_|versioneer.py|examples/.*|docs/.*|devtools/.*'
+        exclude: 'versioneer.py|examples/.*|docs/.*|devtools/.*'
   - repo: https://github.com/pycqa/isort
     rev: 5.13.2
     hooks:

--- a/qcengine/programs/terachem.py
+++ b/qcengine/programs/terachem.py
@@ -31,7 +31,7 @@ class TeraChemHarness(ProgramHarness):
     @staticmethod
     def found(raise_error: bool = False) -> bool:
         return which(
-            "terachem",
+            "docker run terachem",
             return_bool=True,
             raise_error=raise_error,
             raise_msg="Please install via http://www.petachem.com/index.html",
@@ -40,7 +40,7 @@ class TeraChemHarness(ProgramHarness):
     def get_version(self) -> str:
         self.found(raise_error=True)
 
-        which_prog = which("terachem")
+        which_prog = which("docker run terachem")
         if which_prog not in self.version_cache:
             with popen([which_prog, "--version"]) as exc:
                 exc["proc"].wait(timeout=5)
@@ -106,7 +106,8 @@ class TeraChemHarness(ProgramHarness):
         input_file = "\n".join(input_file)
 
         return {
-            "commands": ["terachem", "tc.in"],
+            # "commands": ["terachem", "tc.in"],
+            "commands": ["docker", "run", "mtzgroup/terachem", "terachem", "tc.in"],
             "infiles": {"tc.in": input_file, "geometry.xyz": xyz_file},
             "scratch_directory": config.scratch_directory,
             "input_result": input_model.copy(deep=True),

--- a/qcengine/programs/terachem.py
+++ b/qcengine/programs/terachem.py
@@ -31,7 +31,7 @@ class TeraChemHarness(ProgramHarness):
     @staticmethod
     def found(raise_error: bool = False) -> bool:
         return which(
-            "docker run terachem",
+            "terachem",
             return_bool=True,
             raise_error=raise_error,
             raise_msg="Please install via http://www.petachem.com/index.html",
@@ -40,7 +40,7 @@ class TeraChemHarness(ProgramHarness):
     def get_version(self) -> str:
         self.found(raise_error=True)
 
-        which_prog = which("docker run terachem")
+        which_prog = which("terachem")
         if which_prog not in self.version_cache:
             with popen([which_prog, "--version"]) as exc:
                 exc["proc"].wait(timeout=5)
@@ -106,8 +106,7 @@ class TeraChemHarness(ProgramHarness):
         input_file = "\n".join(input_file)
 
         return {
-            # "commands": ["terachem", "tc.in"],
-            "commands": ["docker", "run", "mtzgroup/terachem", "terachem", "tc.in"],
+            "commands": ["terachem", "tc.in"],
             "infiles": {"tc.in": input_file, "geometry.xyz": xyz_file},
             "scratch_directory": config.scratch_directory,
             "input_result": input_model.copy(deep=True),

--- a/qcengine/programs/tests/test_alignment.py
+++ b/qcengine/programs/tests/test_alignment.py
@@ -3,21 +3,22 @@ import pytest
 import qcelemental as qcel
 
 from qcengine.programs.tests.standard_suite_ref import std_molecules, std_refs
-from qcengine.testing import using
+from qcengine.testing import schema_versions, using
 
 from .standard_suite_runner import runner_asserter
 from .test_standard_suite import _processor
 
 
 @pytest.fixture
-def clsd_open_pmols():
+def clsd_open_pmols(schema_versions):
+    models, _ = schema_versions
     frame_not_important = {
-        name[:-4]: qcel.models.Molecule.from_data(smol, name=name[:-4])
+        name[:-4]: models.Molecule.from_data(smol, name=name[:-4])
         for name, smol in std_molecules.items()
         if name.endswith("-xyz")
     }
     frame_part_of_spec = {
-        name[:-4] + "-fixed": qcel.models.Molecule.from_data(smol + "\nno_com\nno_reorient\n", name=name[:-4])
+        name[:-4] + "-fixed": models.Molecule.from_data(smol + "\nno_com\nno_reorient\n", name=name[:-4])
         for name, smol in std_molecules.items()
         if name.endswith("-xyz")
     }
@@ -92,7 +93,19 @@ def clsd_open_pmols():
         # yapf: enable
     ],
 )
-def test_hf_alignment(inp, scramble, frame, driver, basis, subjects, clsd_open_pmols, request):
+def test_hf_alignment(inp, scramble, frame, driver, basis, subjects, clsd_open_pmols, request, schema_versions):
     runner_asserter(
-        *_processor(inp, "", basis, subjects, clsd_open_pmols, request, driver, "hf", scramble=scramble, frame=frame)
+        *_processor(
+            inp,
+            "",
+            basis,
+            subjects,
+            clsd_open_pmols,
+            request,
+            schema_versions[0],
+            driver,
+            "hf",
+            scramble=scramble,
+            frame=frame,
+        )
     )

--- a/qcengine/programs/tests/test_mrchem.py
+++ b/qcengine/programs/tests/test_mrchem.py
@@ -5,12 +5,12 @@ import qcelemental as qcel
 from qcelemental.testing import compare_values
 
 import qcengine as qcng
-from qcengine.testing import using
+from qcengine.testing import checkver_and_convert, schema_versions, using
 
 
 @pytest.fixture
-def h2o():
-    return qcel.models.Molecule(
+def h2o(schema_versions):
+    return schema_versions[0].Molecule(
         geometry=[[0, 0, -0.1250], [-1.4375, 0, 1.0250], [1.4375, 0, 1.0250]],
         symbols=["O", "H", "H"],
         connectivity=[[0, 1, 1], [0, 2, 1]],
@@ -29,14 +29,16 @@ def fh():
 
 
 @using("mrchem")
-def test_energy(h2o):
+def test_energy(h2o, schema_versions, request):
+    models, _ = schema_versions
+
     mr_kws = {
         "world_prec": 1.0e-3,
         "world_size": 6,
         "world_unit": "bohr",
     }
 
-    inp = qcel.models.AtomicInput(
+    inp = models.AtomicInput(
         molecule=h2o,
         driver="energy",
         model={
@@ -45,7 +47,9 @@ def test_energy(h2o):
         keywords=mr_kws,
     )
 
+    inp = checkver_and_convert(inp, request.node.name, "pre")
     res = qcng.compute(inp, "mrchem", raise_error=True, return_dict=True)
+    res = checkver_and_convert(res, request.node.name, "post")
 
     # Make sure the calculation completed successfully
     assert compare_values(-76.4546307, res["return_result"], atol=1e-3)
@@ -63,14 +67,16 @@ def test_energy(h2o):
 
 
 @using("mrchem")
-def test_dipole(h2o):
+def test_dipole(h2o, schema_versions, request):
+    models, _ = schema_versions
+
     mr_kws = {
         "world_prec": 1.0e-3,
         "world_size": 6,
         "world_unit": "bohr",
     }
 
-    inp = qcel.models.AtomicInput(
+    inp = models.AtomicInput(
         molecule=h2o,
         driver="properties",
         model={
@@ -79,7 +85,9 @@ def test_dipole(h2o):
         keywords=mr_kws,
     )
 
+    inp = checkver_and_convert(inp, request.node.name, "pre")
     res = qcng.compute(inp, "mrchem", raise_error=True, return_dict=True)
+    res = checkver_and_convert(res, request.node.name, "post")
 
     # Make sure the calculation completed successfully
     assert compare_values([-3.766420e-07, 0.0, 0.720473], res["return_result"]["dipole_moment"]["dip-1"], atol=1e-3)

--- a/qcengine/programs/tests/test_nwchem.py
+++ b/qcengine/programs/tests/test_nwchem.py
@@ -298,6 +298,7 @@ def test_autoz_error(schema_versions, request):
 
     resi = checkver_and_convert(resi, request.node.name, "pre")
     result = qcng.compute(resi, "nwchem", raise_error=False)
+    result = checkver_and_convert(result, request.node.name, "post", vercheck=False)    
 
     assert not result.success
     assert "Error when generating redundant atomic coordinates" in result.error.error_message
@@ -311,6 +312,7 @@ def test_autoz_error(schema_versions, request):
         }
     resi = checkver_and_convert(resi, request.node.name, "pre")
     result = qcng.compute(resi, "nwchem", raise_error=False)
+    result = checkver_and_convert(result, request.node.name, "post",vercheck=False)
 
     # Ok if it crashes for other reasons
     assert "Error when generating redundant atomic coordinates" not in result.error.error_message
@@ -397,6 +399,7 @@ def test_restart(nh2_data, tmpdir, schema_versions, request):
 
     resi = checkver_and_convert(resi, request.node.name, "pre")
     result = qcng.compute(resi, "nwchem", local_options=local_options, raise_error=False)
+    result = checkver_and_convert(result, request.node.name, "post", vercheck=False)
 
     assert not result.success
     assert "computation failed to converge" in str(result.error)

--- a/qcengine/programs/tests/test_programs.py
+++ b/qcengine/programs/tests/test_programs.py
@@ -10,7 +10,7 @@ import qcengine as qcng
 from qcengine.testing import checkver_and_convert, failure_engine, schema_versions, using
 
 
-def test_missing_key(schema_versions,request  ):
+def test_missing_key(schema_versions, request):
 
     ret = qcng.compute({"hello": "hi"}, "bleh")
     ret = checkver_and_convert(ret, request.node.name, "post", vercheck=False)
@@ -19,13 +19,13 @@ def test_missing_key(schema_versions,request  ):
     assert "hello" in ret.input_data
 
 
-def test_missing_key_raises(schema_versions,request):
+def test_missing_key_raises(schema_versions, request):
     with pytest.raises(qcng.exceptions.InputError):
         ret = qcng.compute({"hello": "hi"}, "bleh", raise_error=True)
 
 
 @using("psi4")
-def test_psi4_task(schema_versions,request):
+def test_psi4_task(schema_versions, request):
     models, _ = schema_versions
 
     input_data = {
@@ -51,7 +51,7 @@ def test_psi4_task(schema_versions,request):
 
 @using("psi4")
 @using("gcp")
-def test_psi4_hf3c_task(schema_versions,request):
+def test_psi4_hf3c_task(schema_versions, request):
     models, _ = schema_versions
     input_data = {
         "molecule": models.Molecule(**qcng.get_molecule("water", return_dict=True)),
@@ -69,7 +69,7 @@ def test_psi4_hf3c_task(schema_versions,request):
 
 
 @using("psi4_runqcsk")
-def test_psi4_interactive_task(schema_versions,request):
+def test_psi4_interactive_task(schema_versions, request):
     models, _ = schema_versions
 
     input_data = {
@@ -91,7 +91,7 @@ def test_psi4_interactive_task(schema_versions,request):
 
 
 @using("psi4_runqcsk")
-def test_psi4_wavefunction_task(schema_versions,request):
+def test_psi4_wavefunction_task(schema_versions, request):
     models, _ = schema_versions
 
     input_data = {
@@ -111,7 +111,7 @@ def test_psi4_wavefunction_task(schema_versions,request):
 
 
 @using("psi4")
-def test_psi4_internal_failure(schema_versions,request):
+def test_psi4_internal_failure(schema_versions, request):
     models, _ = schema_versions
 
     mol = models.Molecule.from_data(
@@ -134,7 +134,7 @@ def test_psi4_internal_failure(schema_versions,request):
 
 
 @using("psi4")
-def test_psi4_ref_switch(schema_versions,request):
+def test_psi4_ref_switch(schema_versions, request):
     models, _ = schema_versions
 
     inp = models.AtomicInput(
@@ -157,7 +157,7 @@ def test_psi4_ref_switch(schema_versions,request):
 
 @using("rdkit")
 @pytest.mark.parametrize("method", ["UFF", "MMFF94", "MMFF94s"])
-def test_rdkit_task(method, schema_versions,request):
+def test_rdkit_task(method, schema_versions, request):
     models, _ = schema_versions
 
     input_data = {
@@ -175,7 +175,7 @@ def test_rdkit_task(method, schema_versions,request):
 
 
 @using("rdkit")
-def test_rdkit_connectivity_error(schema_versions,request):
+def test_rdkit_connectivity_error(schema_versions, request):
     models, _ = schema_versions
 
     input_data = {
@@ -198,7 +198,7 @@ def test_rdkit_connectivity_error(schema_versions,request):
 
 
 @using("torchani")
-def test_torchani_task(schema_versions,request):
+def test_torchani_task(schema_versions, request):
     models, _ = schema_versions
 
     input_data = {
@@ -217,7 +217,7 @@ def test_torchani_task(schema_versions,request):
 
 
 @using("mopac")
-def test_mopac_task(schema_versions,request):
+def test_mopac_task(schema_versions, request):
     input_data = {
         "molecule": qcng.get_molecule("water", return_dict=True),
         "driver": "gradient",
@@ -251,7 +251,7 @@ def test_mopac_task(schema_versions,request):
     assert "== MOPAC DONE ==" in ret.stdout
 
 
-def test_random_failure_no_retries(failure_engine, schema_versions,request):
+def test_random_failure_no_retries(failure_engine, schema_versions, request):
     failure_engine.iter_modes = ["input_error"]
     ret = qcng.compute(failure_engine.get_job(), failure_engine.name, raise_error=False)
     ret = checkver_and_convert(ret, request.node.name, "post", vercheck=False)
@@ -267,7 +267,7 @@ def test_random_failure_no_retries(failure_engine, schema_versions,request):
     assert "retries" not in ret.input_data["provenance"].keys()
 
 
-def test_random_failure_with_retries(failure_engine, schema_versions,request):
+def test_random_failure_with_retries(failure_engine, schema_versions, request):
     failure_engine.iter_modes = ["random_error", "random_error", "random_error"]
     ret = qcng.compute(failure_engine.get_job(), failure_engine.name, raise_error=False, task_config={"retries": 2})
     ret = checkver_and_convert(ret, request.node.name, "post", vercheck=False)
@@ -283,7 +283,7 @@ def test_random_failure_with_retries(failure_engine, schema_versions,request):
     assert ret.error.error_type == "input_error"
 
 
-def test_random_failure_with_success(failure_engine, schema_versions,request):
+def test_random_failure_with_success(failure_engine, schema_versions, request):
     failure_engine.iter_modes = ["random_error", "pass"]
     failure_engine.ncalls = 0
     ret = qcng.compute(failure_engine.get_job(), failure_engine.name, raise_error=False, task_config={"retries": 1})
@@ -295,7 +295,7 @@ def test_random_failure_with_success(failure_engine, schema_versions,request):
 
 
 @using("openmm")
-def test_openmm_task_smirnoff(schema_versions,request):
+def test_openmm_task_smirnoff(schema_versions, request):
     models, _ = schema_versions
 
     from qcengine.programs.openmm import OpenMMHarness
@@ -326,7 +326,7 @@ def test_openmm_task_smirnoff(schema_versions,request):
 
 @pytest.mark.skip("`basis` must be explicitly specified at this time")
 @using("openmm")
-def test_openmm_task_url_basis(schema_versions,request):
+def test_openmm_task_url_basis(schema_versions, request):
     models, _ = schema_versions
 
     from qcengine.programs.openmm import OpenMMHarness
@@ -360,7 +360,7 @@ def test_openmm_task_url_basis(schema_versions,request):
 
 
 @using("openmm")
-def test_openmm_cmiles_gradient(schema_versions,request):
+def test_openmm_cmiles_gradient(schema_versions, request):
     models, _ = schema_versions
 
     program = "openmm"
@@ -385,7 +385,7 @@ def test_openmm_cmiles_gradient(schema_versions,request):
 
 
 @using("openmm")
-def test_openmm_cmiles_gradient_nomatch(schema_versions,request):
+def test_openmm_cmiles_gradient_nomatch(schema_versions, request):
     models, _ = schema_versions
 
     program = "openmm"
@@ -432,7 +432,7 @@ def test_openmm_cmiles_gradient_nomatch(schema_versions,request):
         pytest.param(({"nonbondedMethod": "badmethod"}, ValueError, 0), id="incorrect nonbondedmethod"),
     ],
 )
-def test_openmm_gaff_keywords(gaff_settings, schema_versions,request):
+def test_openmm_gaff_keywords(gaff_settings, schema_versions, request):
     """
     Test the different running settings with gaff.
     """
@@ -463,7 +463,7 @@ def test_openmm_gaff_keywords(gaff_settings, schema_versions,request):
 
 
 @using("mace")
-def test_mace_energy(schema_versions,request):
+def test_mace_energy(schema_versions, request):
     """
     Test calculating the energy with mace
     """
@@ -480,7 +480,7 @@ def test_mace_energy(schema_versions,request):
 
 
 @using("mace")
-def test_mace_gradient(schema_versions,request):
+def test_mace_gradient(schema_versions, request):
     """
     Test calculating the gradient with mace
     """
@@ -513,7 +513,7 @@ def test_mace_gradient(schema_versions,request):
         pytest.param("wb97m-d3", -76.47412023758551, id="wb97m-d3"),
     ],
 )
-def test_aimnet2_energy(model, expected_energy, schema_versions,request):
+def test_aimnet2_energy(model, expected_energy, schema_versions, request):
     """Test computing the energies of water with two aimnet2 models."""
     models, _ = schema_versions
 
@@ -532,14 +532,14 @@ def test_aimnet2_energy(model, expected_energy, schema_versions,request):
 
 
 @using("aimnet2")
-def test_aimnet2_gradient(schema_versions,request):
+def test_aimnet2_gradient(schema_versions, request):
     """Test computing the gradient of water using one aimnet2 model."""
     models, _ = schema_versions
 
     water = models.Molecule(**qcng.get_molecule("water", return_dict=True))
     atomic_input = models.AtomicInput(molecule=water, model={"method": "wb97m-d3", "basis": None}, driver="gradient")
 
-    atomic_input = checkver_and_convert(atomic_input, request.node.name, "pre") 
+    atomic_input = checkver_and_convert(atomic_input, request.node.name, "pre")
     result = qcng.compute(atomic_input, "aimnet2")
     result = checkver_and_convert(result, request.node.name, "post")
 

--- a/qcengine/programs/tests/test_programs.py
+++ b/qcengine/programs/tests/test_programs.py
@@ -5,33 +5,39 @@ Tests the DQM compute dispatch module
 
 import numpy as np
 import pytest
-from qcelemental.models import AtomicInput, Molecule
 
 import qcengine as qcng
-from qcengine.testing import failure_engine, schema_versions, using
+from qcengine.testing import checkver_and_convert, failure_engine, schema_versions, using
 
 
-def test_missing_key():
+def test_missing_key(schema_versions,request  ):
+
     ret = qcng.compute({"hello": "hi"}, "bleh")
+    ret = checkver_and_convert(ret, request.node.name, "post", vercheck=False)
+
     assert ret.success is False
     assert "hello" in ret.input_data
 
 
-def test_missing_key_raises():
+def test_missing_key_raises(schema_versions,request):
     with pytest.raises(qcng.exceptions.InputError):
         ret = qcng.compute({"hello": "hi"}, "bleh", raise_error=True)
 
 
 @using("psi4")
-def test_psi4_task():
+def test_psi4_task(schema_versions,request):
+    models, _ = schema_versions
+
     input_data = {
-        "molecule": qcng.get_molecule("water"),
+        "molecule": models.Molecule(**qcng.get_molecule("water", return_dict=True)),
         "driver": "energy",
         "model": {"method": "SCF", "basis": "sto-3g"},
         "keywords": {"scf_type": "df"},
     }
 
+    input_data = checkver_and_convert(input_data, request.node.name, "pre")
     ret = qcng.compute(input_data, "psi4", raise_error=True)
+    ret = checkver_and_convert(ret, request.node.name, "post")
 
     assert ret.driver == "energy"
     assert "Final Energy" in ret.stdout
@@ -45,31 +51,38 @@ def test_psi4_task():
 
 @using("psi4")
 @using("gcp")
-def test_psi4_hf3c_task():
+def test_psi4_hf3c_task(schema_versions,request):
+    models, _ = schema_versions
     input_data = {
-        "molecule": qcng.get_molecule("water"),
+        "molecule": models.Molecule(**qcng.get_molecule("water", return_dict=True)),
         "driver": "energy",
         "model": {"method": "HF3c"},
         "keywords": {"scf_type": "df"},
     }
 
+    input_data = checkver_and_convert(input_data, request.node.name, "pre")
     ret = qcng.compute(input_data, "psi4", raise_error=True)
+    ret = checkver_and_convert(ret, request.node.name, "post")
 
     assert ret.success is True
     assert ret.model.basis is None
 
 
 @using("psi4_runqcsk")
-def test_psi4_interactive_task():
+def test_psi4_interactive_task(schema_versions,request):
+    models, _ = schema_versions
+
     input_data = {
-        "molecule": qcng.get_molecule("water"),
+        "molecule": models.Molecule(**qcng.get_molecule("water", return_dict=True)),
         "driver": "energy",
         "model": {"method": "SCF", "basis": "sto-3g"},
         "keywords": {"scf_type": "df"},
         "extras": {"psiapi": True},
     }
 
+    input_data = checkver_and_convert(input_data, request.node.name, "pre")
     ret = qcng.compute(input_data, "psi4", raise_error=True)
+    ret = checkver_and_convert(ret, request.node.name, "post")
 
     assert "Final Energy" in ret.stdout
     assert ret.success
@@ -78,23 +91,30 @@ def test_psi4_interactive_task():
 
 
 @using("psi4_runqcsk")
-def test_psi4_wavefunction_task():
+def test_psi4_wavefunction_task(schema_versions,request):
+    models, _ = schema_versions
+
     input_data = {
-        "molecule": qcng.get_molecule("water"),
+        "molecule": models.Molecule(**qcng.get_molecule("water", return_dict=True)),
         "driver": "energy",
         "model": {"method": "SCF", "basis": "sto-3g"},
         "keywords": {"scf_type": "df"},
         "protocols": {"wavefunction": "orbitals_and_eigenvalues"},
     }
 
+    input_data = checkver_and_convert(input_data, request.node.name, "pre")
     ret = qcng.compute(input_data, "psi4", raise_error=True)
+    ret = checkver_and_convert(ret, request.node.name, "post")
+
     assert ret.success, ret.error.error_message
     assert ret.wavefunction.scf_orbitals_a.shape == (7, 7)
 
 
 @using("psi4")
-def test_psi4_internal_failure():
-    mol = Molecule.from_data(
+def test_psi4_internal_failure(schema_versions,request):
+    models, _ = schema_versions
+
+    mol = models.Molecule.from_data(
         """0 3
      O    0.000000000000     0.000000000000    -0.068516245955
     """
@@ -107,14 +127,17 @@ def test_psi4_internal_failure():
         "keywords": {"reference": "rhf"},
     }
     with pytest.raises(qcng.exceptions.InputError) as exc:
+        psi4_task = checkver_and_convert(psi4_task, request.node.name, "pre")
         ret = qcng.compute(psi4_task, "psi4", raise_error=True)
 
     assert "reference is only" in str(exc.value)
 
 
 @using("psi4")
-def test_psi4_ref_switch():
-    inp = AtomicInput(
+def test_psi4_ref_switch(schema_versions,request):
+    models, _ = schema_versions
+
+    inp = models.AtomicInput(
         **{
             "molecule": {"symbols": ["Li"], "geometry": [0, 0, 0], "molecular_multiplicity": 2},
             "driver": "energy",
@@ -123,7 +146,9 @@ def test_psi4_ref_switch():
         }
     )
 
+    inp = checkver_and_convert(inp, request.node.name, "pre")
     ret = qcng.compute(inp, "psi4", raise_error=True, return_dict=False)
+    ret = checkver_and_convert(ret, request.node.name, "post")
 
     assert ret.success is True
     assert ret.properties.calcinfo_nalpha == 2
@@ -132,30 +157,39 @@ def test_psi4_ref_switch():
 
 @using("rdkit")
 @pytest.mark.parametrize("method", ["UFF", "MMFF94", "MMFF94s"])
-def test_rdkit_task(method):
+def test_rdkit_task(method, schema_versions,request):
+    models, _ = schema_versions
+
     input_data = {
-        "molecule": qcng.get_molecule("water"),
+        "molecule": models.Molecule(**qcng.get_molecule("water", return_dict=True)),
         "driver": "gradient",
         "model": {"method": method},
         "keywords": {},
     }
 
+    input_data = checkver_and_convert(input_data, request.node.name, "pre")
     ret = qcng.compute(input_data, "rdkit", raise_error=True)
+    ret = checkver_and_convert(ret, request.node.name, "post")
 
     assert ret.success is True
 
 
 @using("rdkit")
-def test_rdkit_connectivity_error():
+def test_rdkit_connectivity_error(schema_versions,request):
+    models, _ = schema_versions
+
     input_data = {
-        "molecule": qcng.get_molecule("water").dict(),
+        "molecule": qcng.get_molecule("water", return_dict=True),
         "driver": "energy",
         "model": {"method": "UFF", "basis": ""},
         "keywords": {},
     }
     del input_data["molecule"]["connectivity"]
 
+    input_data = checkver_and_convert(input_data, request.node.name, "pre")
     ret = qcng.compute(input_data, "rdkit")
+    ret = checkver_and_convert(ret, request.node.name, "post", vercheck=False)
+
     assert ret.success is False
     assert "connectivity" in ret.error.error_message
 
@@ -164,74 +198,96 @@ def test_rdkit_connectivity_error():
 
 
 @using("torchani")
-def test_torchani_task():
+def test_torchani_task(schema_versions,request):
+    models, _ = schema_versions
+
     input_data = {
-        "molecule": qcng.get_molecule("water"),
+        "molecule": models.Molecule(**qcng.get_molecule("water", return_dict=True)),
         "driver": "gradient",
         "model": {"method": "ANI1x", "basis": None},
         "keywords": {},
     }
 
+    input_data = checkver_and_convert(input_data, request.node.name, "pre")
     ret = qcng.compute(input_data, "torchani", raise_error=True)
+    ret = checkver_and_convert(ret, request.node.name, "post")
 
     assert ret.success is True
     assert ret.driver == "gradient"
 
 
 @using("mopac")
-def test_mopac_task():
+def test_mopac_task(schema_versions,request):
     input_data = {
-        "molecule": qcng.get_molecule("water"),
+        "molecule": qcng.get_molecule("water", return_dict=True),
         "driver": "gradient",
         "model": {"method": "PM6", "basis": None},
         "keywords": {"pulay": False},
     }
 
-    ret = qcng.compute(input_data, "mopac", raise_error=True)
+    input_data1 = checkver_and_convert(input_data.copy(), request.node.name, "pre")
+    ret = qcng.compute(input_data1, "mopac", raise_error=True)
+    ret = checkver_and_convert(ret, request.node.name, "post")
+
     assert ret.extras.keys() >= {"heat_of_formation", "dip_vec"}
     energy = pytest.approx(-0.08474117913025125, rel=1.0e-5)
 
     # Check gradient
-    ret = qcng.compute(input_data, "mopac", raise_error=True)
+    input_data2 = checkver_and_convert(input_data.copy(), request.node.name, "pre")
+    ret = qcng.compute(input_data2, "mopac", raise_error=True)
+    ret = checkver_and_convert(ret, request.node.name, "post")
+
     assert ret.extras.keys() >= {"heat_of_formation", "dip_vec"}
     assert np.linalg.norm(ret.return_result) == pytest.approx(0.03543560156912385, rel=3.0e-4)
     assert ret.properties.return_energy == energy
 
     # Check energy
-    input_data["driver"] = "energy"
-    ret = qcng.compute(input_data, "mopac", raise_error=True)
+    input_data3 = input_data.copy()
+    input_data3["driver"] = "energy"
+    ret = qcng.compute(input_data3, "mopac", raise_error=True)
+    ret = checkver_and_convert(ret, request.node.name, "post")
+
     assert ret.return_result == energy
     assert "== MOPAC DONE ==" in ret.stdout
 
 
-def test_random_failure_no_retries(failure_engine):
+def test_random_failure_no_retries(failure_engine, schema_versions,request):
     failure_engine.iter_modes = ["input_error"]
     ret = qcng.compute(failure_engine.get_job(), failure_engine.name, raise_error=False)
+    ret = checkver_and_convert(ret, request.node.name, "post", vercheck=False)
+
     assert ret.error.error_type == "input_error"
     assert "retries" not in ret.input_data["provenance"].keys()
 
     failure_engine.iter_modes = ["random_error"]
     ret = qcng.compute(failure_engine.get_job(), failure_engine.name, raise_error=False)
+    ret = checkver_and_convert(ret, request.node.name, "post", vercheck=False)
+
     assert ret.error.error_type == "random_error"
     assert "retries" not in ret.input_data["provenance"].keys()
 
 
-def test_random_failure_with_retries(failure_engine):
+def test_random_failure_with_retries(failure_engine, schema_versions,request):
     failure_engine.iter_modes = ["random_error", "random_error", "random_error"]
     ret = qcng.compute(failure_engine.get_job(), failure_engine.name, raise_error=False, task_config={"retries": 2})
+    ret = checkver_and_convert(ret, request.node.name, "post", vercheck=False)
+
     assert ret.input_data["provenance"]["retries"] == 2
     assert ret.error.error_type == "random_error"
 
     failure_engine.iter_modes = ["random_error", "input_error"]
     ret = qcng.compute(failure_engine.get_job(), failure_engine.name, raise_error=False, task_config={"retries": 4})
+    ret = checkver_and_convert(ret, request.node.name, "post", vercheck=False)
+
     assert ret.input_data["provenance"]["retries"] == 1
     assert ret.error.error_type == "input_error"
 
 
-def test_random_failure_with_success(failure_engine):
+def test_random_failure_with_success(failure_engine, schema_versions,request):
     failure_engine.iter_modes = ["random_error", "pass"]
     failure_engine.ncalls = 0
     ret = qcng.compute(failure_engine.get_job(), failure_engine.name, raise_error=False, task_config={"retries": 1})
+    ret = checkver_and_convert(ret, request.node.name, "post")
 
     assert ret.success, ret.error.error_message
     assert ret.provenance.retries == 1
@@ -239,17 +295,21 @@ def test_random_failure_with_success(failure_engine):
 
 
 @using("openmm")
-def test_openmm_task_smirnoff():
+def test_openmm_task_smirnoff(schema_versions,request):
+    models, _ = schema_versions
+
     from qcengine.programs.openmm import OpenMMHarness
 
     input_data = {
-        "molecule": qcng.get_molecule("water"),
+        "molecule": models.Molecule(**qcng.get_molecule("water", return_dict=True)),
         "driver": "energy",
         "model": {"method": "openff-1.0.0", "basis": "smirnoff"},
         "keywords": {},
     }
 
+    input_data = checkver_and_convert(input_data, request.node.name, "pre")
     ret = qcng.compute(input_data, "openmm", raise_error=True)
+    ret = checkver_and_convert(ret, request.node.name, "post")
 
     cachelength = len(OpenMMHarness._CACHE)
 
@@ -257,6 +317,7 @@ def test_openmm_task_smirnoff():
     assert ret.success is True
 
     ret = qcng.compute(input_data, "openmm", raise_error=True)
+    ret = checkver_and_convert(ret, request.node.name, "post")
 
     # ensure cache has not grown
     assert len(OpenMMHarness._CACHE) == cachelength
@@ -265,11 +326,13 @@ def test_openmm_task_smirnoff():
 
 @pytest.mark.skip("`basis` must be explicitly specified at this time")
 @using("openmm")
-def test_openmm_task_url_basis():
+def test_openmm_task_url_basis(schema_versions,request):
+    models, _ = schema_versions
+
     from qcengine.programs.openmm import OpenMMHarness
 
     input_data = {
-        "molecule": qcng.get_molecule("water"),
+        "molecule": models.Molecule(**qcng.get_molecule("water", return_dict=True)),
         "driver": "energy",
         "model": {
             "method": "openmm",
@@ -279,7 +342,9 @@ def test_openmm_task_url_basis():
         "keywords": {},
     }
 
+    input_data = checkver_and_convert(input_data, request.node.name, "pre")
     ret = qcng.compute(input_data, "openmm", raise_error=True)
+    ret = checkver_and_convert(ret, request.node.name, "post")
 
     cachelength = len(OpenMMHarness._CACHE)
 
@@ -287,6 +352,7 @@ def test_openmm_task_url_basis():
     assert ret.success is True
 
     ret = qcng.compute(input_data, "openmm", raise_error=True)
+    ret = checkver_and_convert(ret, request.node.name, "post")
 
     # ensure cache has not grown
     assert len(OpenMMHarness._CACHE) == cachelength
@@ -294,30 +360,37 @@ def test_openmm_task_url_basis():
 
 
 @using("openmm")
-def test_openmm_cmiles_gradient():
+def test_openmm_cmiles_gradient(schema_versions,request):
+    models, _ = schema_versions
+
     program = "openmm"
 
-    water = qcng.get_molecule("water")
+    water = models.Molecule(**qcng.get_molecule("water", return_dict=True))
 
     water_dict = water.dict()
     # add water cmiles to the molecule
     water_dict["extras"] = {"cmiles": {"canonical_isomeric_explicit_hydrogen_mapped_smiles": "[H:2][O:1][H:3]"}}
 
-    molecule = Molecule.from_data(water_dict)
+    molecule = models.Molecule.from_data(water_dict)
 
     model = {"method": "openff-1.0.0", "basis": "smirnoff"}
 
-    inp = AtomicInput(molecule=molecule, driver="gradient", model=model)
+    inp = models.AtomicInput(molecule=molecule, driver="gradient", model=model)
+
+    inp = checkver_and_convert(inp, request.node.name, "pre")
     ret = qcng.compute(inp, program, raise_error=False)
+    ret = checkver_and_convert(ret, request.node.name, "post")
 
     assert ret.success is True
 
 
 @using("openmm")
-def test_openmm_cmiles_gradient_nomatch():
+def test_openmm_cmiles_gradient_nomatch(schema_versions,request):
+    models, _ = schema_versions
+
     program = "openmm"
 
-    water = qcng.get_molecule("water")
+    water = models.Molecule(**qcng.get_molecule("water", return_dict=True))
 
     water_dict = water.dict()
     # add ethane cmiles to the molecule
@@ -327,12 +400,14 @@ def test_openmm_cmiles_gradient_nomatch():
         }
     }
 
-    molecule = Molecule.from_data(water_dict)
+    molecule = models.Molecule.from_data(water_dict)
 
     model = {"method": "openff-1.0.0", "basis": "smirnoff"}
+    inp = models.AtomicInput(molecule=molecule, driver="gradient", model=model)
 
-    inp = AtomicInput(molecule=molecule, driver="gradient", model=model)
+    inp = checkver_and_convert(inp, request.node.name, "pre")
     ret = qcng.compute(inp, program, raise_error=False)
+    ret = checkver_and_convert(ret, request.node.name, "post", vercheck=False)
 
     # if we correctly find the cmiles this should fail as the molecule and cmiles are different
     assert ret.success is False
@@ -357,49 +432,61 @@ def test_openmm_cmiles_gradient_nomatch():
         pytest.param(({"nonbondedMethod": "badmethod"}, ValueError, 0), id="incorrect nonbondedmethod"),
     ],
 )
-def test_openmm_gaff_keywords(gaff_settings):
+def test_openmm_gaff_keywords(gaff_settings, schema_versions,request):
     """
     Test the different running settings with gaff.
     """
+    models, _ = schema_versions
+
     program = "openmm"
-    water = qcng.get_molecule("water")
+    water = models.Molecule(**qcng.get_molecule("water", return_dict=True))
 
     water_dict = water.dict()
     # add water cmiles to the molecule
     water_dict["extras"] = {"cmiles": {"canonical_isomeric_explicit_hydrogen_mapped_smiles": "[H:2][O:1][H:3]"}}
 
-    molecule = Molecule.from_data(water_dict)
+    molecule = models.Molecule.from_data(water_dict)
     keywords, error, expected_result = gaff_settings
     model = {"method": "gaff-2.1", "basis": "antechamber"}
-    inp = AtomicInput(molecule=molecule, driver="energy", model=model, keywords=keywords)
+    inp = models.AtomicInput(molecule=molecule, driver="energy", model=model, keywords=keywords)
     if error is not None:
         with pytest.raises(error):
+            inp = checkver_and_convert(inp, request.node.name, "pre")
             _ = qcng.compute(inp, program, raise_error=True)
     else:
+        inp = checkver_and_convert(inp, request.node.name, "pre")
         ret = qcng.compute(inp, program, raise_error=False)
+        ret = checkver_and_convert(ret, request.node.name, "post")
+
         assert ret.success is True
         assert ret.return_result == pytest.approx(expected_result, rel=1e-6)
 
 
 @using("mace")
-def test_mace_energy():
+def test_mace_energy(schema_versions,request):
     """
     Test calculating the energy with mace
     """
-    water = qcng.get_molecule("water")
-    atomic_input = AtomicInput(molecule=water, model={"method": "small", "basis": None}, driver="energy")
+    models, _ = schema_versions
+    water = models.Molecule(**qcng.get_molecule("water", return_dict=True))
+    atomic_input = models.AtomicInput(molecule=water, model={"method": "small", "basis": None}, driver="energy")
 
+    atomic_input = checkver_and_convert(atomic_input, request.node.name, "pre")
     result = qcng.compute(atomic_input, "mace")
+    result = checkver_and_convert(result, request.node.name, "post")
+
     assert result.success
     assert pytest.approx(result.return_result) == -76.47683956098838
 
 
 @using("mace")
-def test_mace_gradient():
+def test_mace_gradient(schema_versions,request):
     """
     Test calculating the gradient with mace
     """
-    water = qcng.get_molecule("water")
+    models, _ = schema_versions
+
+    water = models.Molecule(**qcng.get_molecule("water", return_dict=True))
     expected_result = np.array(
         [
             [0.0, -2.1590400539385646e-18, -0.04178551770271103],
@@ -408,9 +495,12 @@ def test_mace_gradient():
         ]
     )
 
-    atomic_input = AtomicInput(molecule=water, model={"method": "small", "basis": None}, driver="gradient")
+    atomic_input = models.AtomicInput(molecule=water, model={"method": "small", "basis": None}, driver="gradient")
 
+    atomic_input = checkver_and_convert(atomic_input, request.node.name, "pre")
     result = qcng.compute(atomic_input, "mace")
+    result = checkver_and_convert(result, request.node.name, "post")
+
     assert result.success
     assert pytest.approx(result.return_result) == expected_result
 
@@ -423,13 +513,17 @@ def test_mace_gradient():
         pytest.param("wb97m-d3", -76.47412023758551, id="wb97m-d3"),
     ],
 )
-def test_aimnet2_energy(model, expected_energy):
+def test_aimnet2_energy(model, expected_energy, schema_versions,request):
     """Test computing the energies of water with two aimnet2 models."""
+    models, _ = schema_versions
 
-    water = qcng.get_molecule("water")
-    atomic_input = AtomicInput(molecule=water, model={"method": model, "basis": None}, driver="energy")
+    water = models.Molecule(**qcng.get_molecule("water", return_dict=True))
+    atomic_input = models.AtomicInput(molecule=water, model={"method": model, "basis": None}, driver="energy")
 
+    atomic_input = checkver_and_convert(atomic_input, request.node.name, "pre")
     result = qcng.compute(atomic_input, "aimnet2")
+    result = checkver_and_convert(result, request.node.name, "post")
+
     assert result.success
     assert pytest.approx(result.return_result) == expected_energy
     assert "charges" in result.extras["aimnet2"]
@@ -438,13 +532,17 @@ def test_aimnet2_energy(model, expected_energy):
 
 
 @using("aimnet2")
-def test_aimnet2_gradient():
+def test_aimnet2_gradient(schema_versions,request):
     """Test computing the gradient of water using one aimnet2 model."""
+    models, _ = schema_versions
 
-    water = qcng.get_molecule("water")
-    atomic_input = AtomicInput(molecule=water, model={"method": "wb97m-d3", "basis": None}, driver="gradient")
+    water = models.Molecule(**qcng.get_molecule("water", return_dict=True))
+    atomic_input = models.AtomicInput(molecule=water, model={"method": "wb97m-d3", "basis": None}, driver="gradient")
 
+    atomic_input = checkver_and_convert(atomic_input, request.node.name, "pre") 
     result = qcng.compute(atomic_input, "aimnet2")
+    result = checkver_and_convert(result, request.node.name, "post")
+
     assert result.success
     # make sure the gradient is now the return result
     assert np.allclose(

--- a/qcengine/programs/tests/test_programs.py
+++ b/qcengine/programs/tests/test_programs.py
@@ -8,7 +8,7 @@ import pytest
 from qcelemental.models import AtomicInput, Molecule
 
 import qcengine as qcng
-from qcengine.testing import failure_engine, using
+from qcengine.testing import failure_engine, schema_versions, using
 
 
 def test_missing_key():

--- a/qcengine/programs/tests/test_standard_suite.py
+++ b/qcengine/programs/tests/test_standard_suite.py
@@ -38,7 +38,7 @@ import qcelemental as qcel
 
 import qcengine as qcng
 from qcengine.programs.tests.standard_suite_ref import std_molecules, std_refs
-from qcengine.testing import using
+from qcengine.testing import schema_versions, using
 
 from .standard_suite_runner import runner_asserter
 
@@ -46,9 +46,10 @@ _basis_keywords = ["cfour_basis", "basis"]
 
 
 @pytest.fixture
-def clsd_open_pmols():
+def clsd_open_pmols(schema_versions):
+    models, _ = schema_versions
     return {
-        name[:-4]: qcel.models.Molecule.from_data(smol, name=name[:-4])
+        name[:-4]: models.Molecule.from_data(smol, name=name[:-4])
         for name, smol in std_molecules.items()
         if name.endswith("-xyz")
     }
@@ -158,8 +159,10 @@ def _trans_key(qc, bas, key):
         # yapf: enable
     ],
 )
-def test_hf_energy_module(inp, dertype, basis, subjects, clsd_open_pmols, request):
-    runner_asserter(*_processor(inp, dertype, basis, subjects, clsd_open_pmols, request, "energy", "hf"))
+def test_hf_energy_module(inp, dertype, basis, subjects, clsd_open_pmols, request, schema_versions):
+    runner_asserter(
+        *_processor(inp, dertype, basis, subjects, clsd_open_pmols, request, schema_versions[0], "energy", "hf")
+    )
 
 
 #
@@ -210,8 +213,10 @@ def test_hf_energy_module(inp, dertype, basis, subjects, clsd_open_pmols, reques
         # yapf: enable
     ],
 )
-def test_hf_gradient_module(inp, dertype, basis, subjects, clsd_open_pmols, request):
-    runner_asserter(*_processor(inp, dertype, basis, subjects, clsd_open_pmols, request, "gradient", "hf"))
+def test_hf_gradient_module(inp, dertype, basis, subjects, clsd_open_pmols, request, schema_versions):
+    runner_asserter(
+        *_processor(inp, dertype, basis, subjects, clsd_open_pmols, request, schema_versions[0], "gradient", "hf")
+    )
 
 
 #
@@ -261,8 +266,10 @@ def test_hf_gradient_module(inp, dertype, basis, subjects, clsd_open_pmols, requ
         # yapf: enable
     ],
 )
-def test_hf_hessian_module(inp, dertype, basis, subjects, clsd_open_pmols, request):
-    runner_asserter(*_processor(inp, dertype, basis, subjects, clsd_open_pmols, request, "hessian", "hf"))
+def test_hf_hessian_module(inp, dertype, basis, subjects, clsd_open_pmols, request, schema_versions):
+    runner_asserter(
+        *_processor(inp, dertype, basis, subjects, clsd_open_pmols, request, schema_versions[0], "hessian", "hf")
+    )
 
 
 #
@@ -338,8 +345,10 @@ def test_hf_hessian_module(inp, dertype, basis, subjects, clsd_open_pmols, reque
         # yapf: enable
     ],
 )
-def test_mp2_energy_module(inp, dertype, basis, subjects, clsd_open_pmols, request):
-    runner_asserter(*_processor(inp, dertype, basis, subjects, clsd_open_pmols, request, "energy", "mp2"))
+def test_mp2_energy_module(inp, dertype, basis, subjects, clsd_open_pmols, request, schema_versions):
+    runner_asserter(
+        *_processor(inp, dertype, basis, subjects, clsd_open_pmols, request, schema_versions[0], "energy", "mp2")
+    )
 
 
 #
@@ -424,8 +433,10 @@ def test_mp2_energy_module(inp, dertype, basis, subjects, clsd_open_pmols, reque
         # yapf: enable
     ],
 )
-def test_ccsd_energy_module(inp, dertype, basis, subjects, clsd_open_pmols, request):
-    runner_asserter(*_processor(inp, dertype, basis, subjects, clsd_open_pmols, request, "energy", "ccsd"))
+def test_ccsd_energy_module(inp, dertype, basis, subjects, clsd_open_pmols, request, schema_versions):
+    runner_asserter(
+        *_processor(inp, dertype, basis, subjects, clsd_open_pmols, request, schema_versions[0], "energy", "ccsd")
+    )
 
 
 ###################
@@ -474,7 +485,9 @@ def test_ccsd_energy_module(inp, dertype, basis, subjects, clsd_open_pmols, requ
 #        atol = 2.e-5
 
 
-def _processor(inp, dertype, basis, subjects, clsd_open_pmols, request, driver, method, *, scramble=None, frame=""):
+def _processor(
+    inp, dertype, basis, subjects, clsd_open_pmols, request, models, driver, method, *, scramble=None, frame=""
+):
     method = method
     qcprog = inp["call"]
     tnm = request.node.name
@@ -506,4 +519,4 @@ def _processor(inp, dertype, basis, subjects, clsd_open_pmols, request, driver, 
         ]
     ).strip("-")
 
-    return inpcopy, subject, method, basis, tnm, scramble, frame
+    return inpcopy, subject, method, basis, tnm, scramble, frame, models

--- a/qcengine/programs/tests/test_standard_suite_hf.py
+++ b/qcengine/programs/tests/test_standard_suite_hf.py
@@ -3,24 +3,23 @@ import qcelemental as qcel
 from qcelemental.testing import compare_values
 
 import qcengine as qcng
-from qcengine.testing import using
+from qcengine.testing import checkver_and_convert, schema_versions, using
 
 
 @pytest.fixture
-def h2o():
-    smol = """
+def h2o_data():
+    return """
  # R=0.958 A=104.5
  H                  0.000000000000     1.431430901356     0.984293362719
  O                  0.000000000000     0.000000000000    -0.124038860300
  H                  0.000000000000    -1.431430901356     0.984293362719
  units au
 """
-    return qcel.models.Molecule.from_data(smol)
 
 
 @pytest.fixture
-def nh2():
-    smol = """
+def nh2_data():
+    return """
  # R=1.008 #A=105.0
  0 2
  N   0.000000000000000   0.000000000000000  -0.145912918634892
@@ -29,7 +28,6 @@ def nh2():
  units au
  symmetry c1
 """
-    return qcel.models.Molecule.from_data(smol)
 
 
 @pytest.mark.parametrize(
@@ -53,14 +51,19 @@ def nh2():
         pytest.param("terachem_pbs", "aug-cc-pvdz", {}, marks=using("terachem_pbs")),
     ],
 )
-def test_sp_hf_rhf(program, basis, keywords, h2o):
+def test_sp_hf_rhf(program, basis, keywords, h2o_data, schema_versions, request):
     """cfour/sp-rhf-hf/input.dat
     #! single point HF/adz on water
 
     """
+    models, models_out = schema_versions
+    h2o = models.Molecule.from_data(h2o_data)
+
     resi = {"molecule": h2o, "driver": "energy", "model": {"method": "hf", "basis": basis}, "keywords": keywords}
 
+    resi = checkver_and_convert(resi, request.node.name, "pre")
     res = qcng.compute(resi, program, raise_error=True, return_dict=True)
+    res = checkver_and_convert(res, request.node.name, "post")
 
     assert res["driver"] == "energy"
     assert "provenance" in res
@@ -103,10 +106,15 @@ def test_sp_hf_rhf(program, basis, keywords, h2o):
         pytest.param("turbomole", "aug-cc-pVDZ", {}, marks=using("turbomole")),
     ],
 )
-def test_sp_hf_uhf(program, basis, keywords, nh2):
+def test_sp_hf_uhf(program, basis, keywords, nh2_data, schema_versions, request):
+    models, models_out = schema_versions
+
+    nh2 = models.Molecule.from_data(nh2_data)
     resi = {"molecule": nh2, "driver": "energy", "model": {"method": "hf", "basis": basis}, "keywords": keywords}
 
+    resi = checkver_and_convert(resi, request.node.name, "pre")
     res = qcng.compute(resi, program, raise_error=True, return_dict=True)
+    res = checkver_and_convert(res, request.node.name, "post")
 
     assert res["driver"] == "energy"
     assert "provenance" in res
@@ -142,10 +150,15 @@ def test_sp_hf_uhf(program, basis, keywords, nh2):
         pytest.param("qchem", "aug-cc-pvdz", {"UNRESTRICTED": False}, marks=using("qchem")),
     ],
 )
-def test_sp_hf_rohf(program, basis, keywords, nh2):
+def test_sp_hf_rohf(program, basis, keywords, nh2_data, schema_versions, request):
+    models, models_out = schema_versions
+
+    nh2 = models.Molecule.from_data(nh2_data)
     resi = {"molecule": nh2, "driver": "energy", "model": {"method": "hf", "basis": basis}, "keywords": keywords}
 
+    resi = checkver_and_convert(resi, request.node.name, "pre")
     res = qcng.compute(resi, program, raise_error=True, return_dict=True)
+    res = checkver_and_convert(res, request.node.name, "post")
 
     assert res["driver"] == "energy"
     assert "provenance" in res

--- a/qcengine/programs/tests/test_xtb.py
+++ b/qcengine/programs/tests/test_xtb.py
@@ -11,12 +11,12 @@ import qcelemental as qcel
 from qcelemental.testing import compare_recursive
 
 import qcengine as qcng
-from qcengine.testing import using
+from qcengine.testing import checkver_and_convert, schema_versions, using
 
 
 @using("xtb")
-def test_xtb_task_gfn1xtb_m01():
-
+def test_xtb_task_gfn1xtb_m01(schema_versions, request):
+    models, _ = schema_versions
     thr = 1.0e-7
 
     return_result = np.array(
@@ -40,20 +40,23 @@ def test_xtb_task_gfn1xtb_m01():
         ]
     )
 
-    atomic_input = qcel.models.AtomicInput(
-        molecule=qcng.get_molecule("mindless-01"),
+    atomic_input = models.AtomicInput(
+        molecule=models.Molecule(**qcng.get_molecule("mindless-01", return_dict=True)),
         model={"method": "GFN1-xTB"},
         driver="gradient",
     )
 
+    atomic_input = checkver_and_convert(atomic_input, request.name, "pre")
     atomic_result = qcng.compute(atomic_input, "xtb")
+    atomic_result = checkver_and_convert(atomic_result, request.name, "post")
 
     assert atomic_result.success
     assert pytest.approx(atomic_result.return_result, abs=thr) == return_result
 
 
 @using("xtb")
-def test_xtb_task_gfn1xtb_m02():
+def test_xtb_task_gfn1xtb_m02(schema_versions, request):
+    models, _ = schema_versions
 
     thr = 1.0e-8
 
@@ -78,8 +81,8 @@ def test_xtb_task_gfn1xtb_m02():
         ]
     )
 
-    atomic_input = qcel.models.AtomicInput(
-        molecule=qcng.get_molecule("mindless-02"),
+    atomic_input = models.AtomicInput(
+        molecule=models.Molecule(**qcng.get_molecule("mindless-02", return_dict=True)),
         model={"method": "GFN1-xTB"},
         driver="gradient",
         keywords={
@@ -88,14 +91,17 @@ def test_xtb_task_gfn1xtb_m02():
         },
     )
 
+    atomic_input = checkver_and_convert(atomic_input, request.name, "pre")
     atomic_result = qcng.compute(atomic_input, "xtb")
+    atomic_result = checkver_and_convert(atomic_result, request.name, "post")
 
     assert atomic_result.success
     assert pytest.approx(atomic_result.return_result, abs=thr) == return_result
 
 
 @using("xtb")
-def test_xtb_task_gfn1xtb_m03():
+def test_xtb_task_gfn1xtb_m03(schema_versions, request):
+    models, _ = schema_versions
 
     thr = 1.0e-8
 
@@ -120,8 +126,8 @@ def test_xtb_task_gfn1xtb_m03():
         ]
     )
 
-    atomic_input = qcel.models.AtomicInput(
-        molecule=qcng.get_molecule("mindless-03"),
+    atomic_input = models.AtomicInput(
+        molecule=models.Molecule(**qcng.get_molecule("mindless-03", return_dict=True)),
         model={"method": "GFN1-xTB"},
         driver="gradient",
         keywords={
@@ -129,14 +135,17 @@ def test_xtb_task_gfn1xtb_m03():
         },
     )
 
+    atomic_input = checkver_and_convert(atomic_input, request.name, "pre")
     atomic_result = qcng.compute(atomic_input, "xtb")
+    atomic_result = checkver_and_convert(atomic_result, request.name, "post")
 
     assert atomic_result.success
     assert pytest.approx(atomic_result.return_result, abs=thr) == return_result
 
 
 @using("xtb")
-def test_xtb_task_gfn1xtb_m04():
+def test_xtb_task_gfn1xtb_m04(schema_versions, request):
+    models, _ = schema_versions
 
     thr = 1.0e-6
 
@@ -164,13 +173,15 @@ def test_xtb_task_gfn1xtb_m04():
         ),
     }
 
-    atomic_input = qcel.models.AtomicInput(
-        molecule=qcng.get_molecule("mindless-04"),
+    atomic_input = models.AtomicInput(
+        molecule=models.Molecule(**qcng.get_molecule("mindless-04", return_dict=True)),
         model={"method": "GFN1-xTB"},
         driver="properties",
     )
 
+    atomic_input = checkver_and_convert(atomic_input, request.name, "pre")
     atomic_result = qcng.compute(atomic_input, "xtb")
+    atomic_result = checkver_and_convert(atomic_result, request.name, "post")
 
     assert atomic_result.success
     assert pytest.approx(atomic_result.return_result["dipole"], abs=thr) == return_result["dipole"]
@@ -179,19 +190,22 @@ def test_xtb_task_gfn1xtb_m04():
 
 
 @using("xtb")
-def test_xtb_task_gfn1xtb_m05():
+def test_xtb_task_gfn1xtb_m05(schema_versions, request):   
+    models, _ = schema_versions
 
     thr = 1.0e-8
 
     return_result = -29.038403257613453
 
-    atomic_input = qcel.models.AtomicInput(
-        molecule=qcng.get_molecule("mindless-05"),
+    atomic_input = models.AtomicInput(
+        molecule=models.Molecule(**qcng.get_molecule("mindless-05", return_dict=True)),
         model={"method": "GFN1-xTB"},
         driver="energy",
     )
 
+    atomic_input = checkver_and_convert(atomic_input, request.name, "pre")
     atomic_result = qcng.compute(atomic_input, "xtb")
+    atomic_result = checkver_and_convert(atomic_result, request.name, "post")
 
     assert atomic_result.success
     assert pytest.approx(atomic_result.return_result, abs=thr) == return_result
@@ -199,7 +213,8 @@ def test_xtb_task_gfn1xtb_m05():
 
 
 @using("xtb")
-def test_xtb_task_gfn2xtb_m01():
+def test_xtb_task_gfn2xtb_m01(schema_versions, request):
+    models, _ = schema_versions
 
     thr = 1.0e-7
 
@@ -224,13 +239,15 @@ def test_xtb_task_gfn2xtb_m01():
         ]
     )
 
-    atomic_input = qcel.models.AtomicInput(
-        molecule=qcng.get_molecule("mindless-01"),
+    atomic_input = models.AtomicInput(
+        molecule=models.Molecule(**qcng.get_molecule("mindless-01", return_dict=True)),
         model={"method": "GFN2-xTB"},
         driver="gradient",
     )
 
+    atomic_input = checkver_and_convert(atomic_input, request.name, "pre")
     atomic_result = qcng.compute(atomic_input, "xtb")
+    atomic_result = checkver_and_convert(atomic_result, request.name, "post")
 
     assert atomic_result.success
     assert pytest.approx(atomic_result.return_result, abs=thr) == return_result

--- a/qcengine/programs/tests/test_xtb.py
+++ b/qcengine/programs/tests/test_xtb.py
@@ -254,7 +254,8 @@ def test_xtb_task_gfn2xtb_m01(schema_versions, request):
 
 
 @using("xtb")
-def test_xtb_task_gfn2xtb_m02():
+def test_xtb_task_gfn2xtb_m02(schema_versions, request):
+    models, _ = schema_versions
 
     thr = 1.0e-8
 
@@ -279,8 +280,8 @@ def test_xtb_task_gfn2xtb_m02():
         ]
     )
 
-    atomic_input = qcel.models.AtomicInput(
-        molecule=qcng.get_molecule("mindless-02"),
+    atomic_input = models.AtomicInput(
+        molecule=models.Molecule(**qcng.get_molecule("mindless-02", return_dict=True)),
         model={"method": "GFN2-xTB"},
         driver="gradient",
         keywords={
@@ -289,14 +290,17 @@ def test_xtb_task_gfn2xtb_m02():
         },
     )
 
+    atomic_input = checkver_and_convert(atomic_input, request.node.name, "pre")
     atomic_result = qcng.compute(atomic_input, "xtb")
+    atomic_result = checkver_and_convert(atomic_result, request.node.name, "post")
 
     assert atomic_result.success
     assert pytest.approx(atomic_result.return_result, abs=thr) == return_result
 
 
 @using("xtb")
-def test_xtb_task_gfn2xtb_m03():
+def test_xtb_task_gfn2xtb_m03(schema_versions, request):    
+    models, _ = schema_versions
 
     thr = 1.0e-8
 
@@ -321,8 +325,8 @@ def test_xtb_task_gfn2xtb_m03():
         ]
     )
 
-    atomic_input = qcel.models.AtomicInput(
-        molecule=qcng.get_molecule("mindless-03"),
+    atomic_input = models.AtomicInput(
+        molecule=models.Molecule(**qcng.get_molecule("mindless-03",return_dict=True)),
         model={"method": "GFN2-xTB"},
         driver="gradient",
         keywords={
@@ -330,14 +334,17 @@ def test_xtb_task_gfn2xtb_m03():
         },
     )
 
+    atomic_input = checkver_and_convert(atomic_input, request.node.name, "pre")
     atomic_result = qcng.compute(atomic_input, "xtb")
+    atomic_result = checkver_and_convert(atomic_result, request.node.name, "post")
 
     assert atomic_result.success
     assert pytest.approx(atomic_result.return_result, abs=thr) == return_result
 
 
 @using("xtb")
-def test_xtb_task_gfn2xtb_m04():
+def test_xtb_task_gfn2xtb_m04(schema_versions, request):
+    models, _ = schema_versions
 
     thr = 1.0e-6
 
@@ -365,13 +372,15 @@ def test_xtb_task_gfn2xtb_m04():
         ),
     }
 
-    atomic_input = qcel.models.AtomicInput(
-        molecule=qcng.get_molecule("mindless-04"),
+    atomic_input = models.AtomicInput(
+        molecule=models.Molecule(**qcng.get_molecule("mindless-04", return_dict=True)),
         model={"method": "GFN2-xTB"},
         driver="properties",
     )
 
+    atomic_input = checkver_and_convert(atomic_input, request.node.name, "pre")
     atomic_result = qcng.compute(atomic_input, "xtb")
+    atomic_result = checkver_and_convert(atomic_result, request.node.name, "post")
 
     assert atomic_result.success
     assert pytest.approx(atomic_result.return_result["dipole"], abs=thr) == return_result["dipole"]
@@ -380,19 +389,22 @@ def test_xtb_task_gfn2xtb_m04():
 
 
 @using("xtb")
-def test_xtb_task_gfn2xtb_m05():
+def test_xtb_task_gfn2xtb_m05(schema_versions, request):
+    models, _ = schema_versions
 
     thr = 1.0e-8
 
     return_result = -27.73598761779656
 
-    atomic_input = qcel.models.AtomicInput(
-        molecule=qcng.get_molecule("mindless-05"),
+    atomic_input = models.AtomicInput(
+        molecule=models.Molecule(**qcng.get_molecule("mindless-05", return_dict=True)),
         model={"method": "GFN2-xTB"},
         driver="energy",
     )
 
+    atomic_input = checkver_and_convert(atomic_input, request.node.name, "pre")
     atomic_result = qcng.compute(atomic_input, "xtb")
+    atomic_result = checkver_and_convert(atomic_result, request.node.name, "post")
 
     assert atomic_result.success
     assert pytest.approx(atomic_result.return_result, abs=thr) == return_result
@@ -400,43 +412,50 @@ def test_xtb_task_gfn2xtb_m05():
 
 
 @using("xtb")
-def test_xtb_task_unknown_method():
+def test_xtb_task_unknown_method(schema_versions, request):
+    models, models_out = schema_versions
 
-    atomic_input = qcel.models.AtomicInput(
-        molecule=qcng.get_molecule("water"),
+    atomic_input = models.AtomicInput(
+        molecule=models.Molecule(**qcng.get_molecule("water", return_dict=True)),
         model={"method": "GFN-xTB"},
         driver="energy",
     )
-    error = qcel.models.ComputeError(error_type="input_error", error_message="Invalid method GFN-xTB provided in model")
+    error = models_out.ComputeError(error_type="input_error", error_message="Invalid method GFN-xTB provided in model")
 
+    atomic_input = checkver_and_convert(atomic_input, request.node.name, "pre")
     atomic_result = qcng.compute(atomic_input, "xtb")
+    atomic_result = checkver_and_convert(atomic_result, request.node.name, "post", vercheck=False)
 
     assert not atomic_result.success
     assert atomic_result.error == error
 
 
 @using("xtb")
-def test_xtb_task_unsupported_driver():
+def test_xtb_task_unsupported_driver(schema_versions, request):
+    models, models_out = schema_versions
 
-    atomic_input = qcel.models.AtomicInput(
-        molecule=qcng.get_molecule("water"),
+    atomic_input = models.AtomicInput(
+        molecule=models.Molecule(**qcng.get_molecule("water", return_dict=True)),
         model={"method": "GFN2-xTB"},
         driver="hessian",
     )
-    error = qcel.models.ComputeError(
+    error = models_out.ComputeError(
         error_type="input_error", error_message="Calculation succeeded but invalid driver request provided"
     )
 
+    atomic_input = checkver_and_convert(atomic_input, request.node.name, "pre")
     atomic_result = qcng.compute(atomic_input, "xtb")
+    atomic_result = checkver_and_convert(atomic_result, request.node.name, "post", vercheck=False)
 
     assert not atomic_result.success
     assert atomic_result.error == error
 
 
 @using("xtb")
-def test_xtb_task_cold_fusion():
+def test_xtb_task_cold_fusion(schema_versions, request):
+    models, models_out = schema_versions
 
-    atomic_input = qcel.models.AtomicInput(
+    atomic_input = models.AtomicInput(
         molecule={
             "symbols": ["Li", "Li", "Li", "Li"],
             "geometry": [
@@ -450,12 +469,14 @@ def test_xtb_task_cold_fusion():
         model={"method": "GFN2-xTB"},
         driver="energy",
     )
-    error = qcel.models.ComputeError(
+    error = models_out.ComputeError(
         error_type="runtime_error",
         error_message="Setup of molecular structure failed:\n-1- xtb_api_newMolecule: Could not generate molecular structure",
     )
 
+    atomic_input = checkver_and_convert(atomic_input, request.node.name, "pre")
     atomic_result = qcng.compute(atomic_input, "xtb")
+    atomic_result = checkver_and_convert(atomic_result, request.node.name, "post", vercheck=False)
 
     assert not atomic_result.success
     assert atomic_result.error == error

--- a/qcengine/programs/tests/test_xtb.py
+++ b/qcengine/programs/tests/test_xtb.py
@@ -46,9 +46,9 @@ def test_xtb_task_gfn1xtb_m01(schema_versions, request):
         driver="gradient",
     )
 
-    atomic_input = checkver_and_convert(atomic_input, request.name, "pre")
+    atomic_input = checkver_and_convert(atomic_input, request.node.name, "pre")
     atomic_result = qcng.compute(atomic_input, "xtb")
-    atomic_result = checkver_and_convert(atomic_result, request.name, "post")
+    atomic_result = checkver_and_convert(atomic_result, request.node.name, "post")
 
     assert atomic_result.success
     assert pytest.approx(atomic_result.return_result, abs=thr) == return_result
@@ -91,9 +91,9 @@ def test_xtb_task_gfn1xtb_m02(schema_versions, request):
         },
     )
 
-    atomic_input = checkver_and_convert(atomic_input, request.name, "pre")
+    atomic_input = checkver_and_convert(atomic_input, request.node.name, "pre")
     atomic_result = qcng.compute(atomic_input, "xtb")
-    atomic_result = checkver_and_convert(atomic_result, request.name, "post")
+    atomic_result = checkver_and_convert(atomic_result, request.node.name, "post")
 
     assert atomic_result.success
     assert pytest.approx(atomic_result.return_result, abs=thr) == return_result
@@ -135,9 +135,9 @@ def test_xtb_task_gfn1xtb_m03(schema_versions, request):
         },
     )
 
-    atomic_input = checkver_and_convert(atomic_input, request.name, "pre")
+    atomic_input = checkver_and_convert(atomic_input, request.node.name, "pre")
     atomic_result = qcng.compute(atomic_input, "xtb")
-    atomic_result = checkver_and_convert(atomic_result, request.name, "post")
+    atomic_result = checkver_and_convert(atomic_result, request.node.name, "post")
 
     assert atomic_result.success
     assert pytest.approx(atomic_result.return_result, abs=thr) == return_result
@@ -179,9 +179,9 @@ def test_xtb_task_gfn1xtb_m04(schema_versions, request):
         driver="properties",
     )
 
-    atomic_input = checkver_and_convert(atomic_input, request.name, "pre")
+    atomic_input = checkver_and_convert(atomic_input, request.node.name, "pre")
     atomic_result = qcng.compute(atomic_input, "xtb")
-    atomic_result = checkver_and_convert(atomic_result, request.name, "post")
+    atomic_result = checkver_and_convert(atomic_result, request.node.name, "post")
 
     assert atomic_result.success
     assert pytest.approx(atomic_result.return_result["dipole"], abs=thr) == return_result["dipole"]
@@ -203,9 +203,9 @@ def test_xtb_task_gfn1xtb_m05(schema_versions, request):
         driver="energy",
     )
 
-    atomic_input = checkver_and_convert(atomic_input, request.name, "pre")
+    atomic_input = checkver_and_convert(atomic_input, request.node.name, "pre")
     atomic_result = qcng.compute(atomic_input, "xtb")
-    atomic_result = checkver_and_convert(atomic_result, request.name, "post")
+    atomic_result = checkver_and_convert(atomic_result, request.node.name, "post")
 
     assert atomic_result.success
     assert pytest.approx(atomic_result.return_result, abs=thr) == return_result
@@ -245,9 +245,9 @@ def test_xtb_task_gfn2xtb_m01(schema_versions, request):
         driver="gradient",
     )
 
-    atomic_input = checkver_and_convert(atomic_input, request.name, "pre")
+    atomic_input = checkver_and_convert(atomic_input, request.node.name, "pre")
     atomic_result = qcng.compute(atomic_input, "xtb")
-    atomic_result = checkver_and_convert(atomic_result, request.name, "post")
+    atomic_result = checkver_and_convert(atomic_result, request.node.name, "post")
 
     assert atomic_result.success
     assert pytest.approx(atomic_result.return_result, abs=thr) == return_result

--- a/qcengine/stock_mols.py
+++ b/qcengine/stock_mols.py
@@ -189,11 +189,14 @@ _test_mols = {
 }
 
 
-def get_molecule(name):
+def get_molecule(name, *, return_dict: bool = False):
     """
     Returns a QC JSON representation of a test molecule.
     """
     if name not in _test_mols:
         raise KeyError("Molecule name '{}' not found".format(name))
 
-    return Molecule(**copy.deepcopy(_test_mols[name]))
+    if return_dict:
+        return copy.deepcopy(_test_mols[name])
+    else:
+        return Molecule(**copy.deepcopy(_test_mols[name]))

--- a/qcengine/testing.py
+++ b/qcengine/testing.py
@@ -253,11 +253,17 @@ def checkver_and_convert(mdl, tnm, prepost, vercheck: bool = True, cast_dict_as=
         dict_in = isinstance(mdl, dict)
         if "as_v1" in tnm or "to_v2" in tnm or "None" in tnm:
             if dict_in:
-                mdl = qcel.models.v1.AtomicInput(**mdl)
+                if cast_dict_as:
+                    mdl = getattr(qcel.models.v1, cast_dict_as)(**mdl)
+                else:
+                    mdl = qcel.models.v1.AtomicInput(**mdl)
             check_model_v1(mdl)
         elif "as_v2" in tnm or "to_v1" in tnm:
             if dict_in:
-                mdl = qcel.models.v2.AtomicInput(**mdl)
+                if cast_dict_as:
+                    mdl = getattr(qcel.models.v2, cast_dict_as)(**mdl)
+                else:
+                    mdl = qcel.models.v2.AtomicInput(**mdl)
             check_model_v2(mdl)
             mdl = mdl.convert_v(1)
 

--- a/qcengine/testing.py
+++ b/qcengine/testing.py
@@ -116,7 +116,8 @@ def failure_engine(schema_versions):
             grad = [0, 0, -grad_value, 0, 0, grad_value]
 
             if mode == "pass":
-                return schema_versions[0].AtomicResult(
+                # TODO return schema_versions[0].AtomicResult(
+                return qcel.models.v1.AtomicResult(
                     **{
                         **input_data.dict(),
                         **{

--- a/qcengine/testing.py
+++ b/qcengine/testing.py
@@ -211,3 +211,70 @@ def using(program):
         _using_cache[program] = skip
 
     return _using_cache[program]
+
+
+@pytest.fixture(scope="function", params=[None, "as_v1", "as_v2", "to_v1", "to_v2"])
+def schema_versions(request):
+    if request.param == "as_v1":
+        return qcel.models.v1, qcel.models.v1
+    elif request.param == "to_v2":
+        return qcel.models.v1, qcel.models.v2
+    elif request.param == "as_v2":
+        return qcel.models.v2, qcel.models.v2
+    elif request.param == "to_v1":
+        return qcel.models.v2, qcel.models.v1
+    else:
+        return qcel.models, qcel.models
+
+
+def checkver_and_convert(mdl, tnm, prepost):
+    import json
+
+    import pydantic
+
+    def check_model_v1(m):
+        assert isinstance(m, pydantic.v1.BaseModel), f"type({m.__class__.__name__}) = {type(m)} !⊆ v1.BaseModel"
+        assert isinstance(
+            m, qcel.models.v1.basemodels.ProtoModel
+        ), f"type({m.__class__.__name__}) = {type(m)} !⊆ v1.ProtoModel"
+        assert m.schema_version == 1, f"{m.__class__.__name__}.schema_version = {m.schema_version} != 1"
+
+    def check_model_v2(m):
+        assert isinstance(m, pydantic.BaseModel), f"type({m.__class__.__name__}) = {type(m)} !⊆ BaseModel"
+        assert isinstance(
+            m, qcel.models.v2.basemodels.ProtoModel
+        ), f"type({m.__class__.__name__}) = {type(m)} !⊆ v2.ProtoModel"
+        assert m.schema_version == 2, f"{m.__class__.__name__}.schema_version = {m.schema_version} != 2"
+
+    if prepost == "pre":
+        dict_in = isinstance(mdl, dict)
+        if "as_v1" in tnm or "to_v2" in tnm or "None" in tnm:
+            if dict_in:
+                mdl = qcel.models.v1.AtomicInput(**mdl)
+            check_model_v1(mdl)
+        elif "as_v2" in tnm or "to_v1" in tnm:
+            if dict_in:
+                mdl = qcel.models.v2.AtomicInput(**mdl)
+            check_model_v2(mdl)
+            mdl = mdl.convert_v(1)
+
+        if dict_in:
+            mdl = mdl.model_dump()
+
+    elif prepost == "post":
+        dict_in = isinstance(mdl, dict)
+        if "as_v1" in tnm or "to_v1" in tnm or "None" in tnm:
+            if dict_in:
+                mdl = qcel.models.v1.AtomicResult(**mdl)
+            check_model_v1(mdl)
+        elif "as_v2" in tnm or "to_v2" in tnm:
+            if dict_in:
+                mdl = qcel.models.v2.AtomicResult(**mdl)
+            mdl = mdl.convert_v(2)
+            check_model_v2(mdl)
+
+        if dict_in:
+            # imitates compute(..., return_dict=True)
+            mdl = json.loads(mdl.json())
+
+    return mdl

--- a/qcengine/testing.py
+++ b/qcengine/testing.py
@@ -78,7 +78,7 @@ def is_mdi_new_enough(version_feature_introduced):
 
 
 @pytest.fixture(scope="function")
-def failure_engine():
+def failure_engine(schema_versions):
     unique_name = "testing_random_name"
 
     class FailEngine(qcng.programs.ProgramHarness):
@@ -116,7 +116,7 @@ def failure_engine():
             grad = [0, 0, -grad_value, 0, 0, grad_value]
 
             if mode == "pass":
-                return qcel.models.AtomicResult(
+                return schema_versions[0].AtomicResult(
                     **{
                         **input_data.dict(),
                         **{
@@ -233,17 +233,17 @@ def checkver_and_convert(mdl, tnm, prepost):
     import pydantic
 
     def check_model_v1(m):
-        assert isinstance(m, pydantic.v1.BaseModel), f"type({m.__class__.__name__}) = {type(m)} !⊆ v1.BaseModel"
+        assert isinstance(m, pydantic.v1.BaseModel), f"type({m.__class__.__name__}) = {type(m)} ⊄ v1.BaseModel"
         assert isinstance(
             m, qcel.models.v1.basemodels.ProtoModel
-        ), f"type({m.__class__.__name__}) = {type(m)} !⊆ v1.ProtoModel"
+        ), f"type({m.__class__.__name__}) = {type(m)} ⊄ v1.ProtoModel"
         assert m.schema_version == 1, f"{m.__class__.__name__}.schema_version = {m.schema_version} != 1"
 
     def check_model_v2(m):
-        assert isinstance(m, pydantic.BaseModel), f"type({m.__class__.__name__}) = {type(m)} !⊆ BaseModel"
+        assert isinstance(m, pydantic.BaseModel), f"type({m.__class__.__name__}) = {type(m)} ⊄ BaseModel"
         assert isinstance(
             m, qcel.models.v2.basemodels.ProtoModel
-        ), f"type({m.__class__.__name__}) = {type(m)} !⊆ v2.ProtoModel"
+        ), f"type({m.__class__.__name__}) = {type(m)} ⊄ v2.ProtoModel"
         assert m.schema_version == 2, f"{m.__class__.__name__}.schema_version = {m.schema_version} != 2"
 
     if prepost == "pre":
@@ -275,6 +275,6 @@ def checkver_and_convert(mdl, tnm, prepost):
 
         if dict_in:
             # imitates compute(..., return_dict=True)
-            mdl = json.loads(mdl.json())
+            mdl = json.loads(mdl.model_dump_json())
 
     return mdl

--- a/qcengine/tests/test_cli.py
+++ b/qcengine/tests/test_cli.py
@@ -4,7 +4,7 @@ import subprocess
 import sys
 from typing import List
 
-from qcelemental.models import AtomicInput, OptimizationInput
+import qcelemental
 
 from qcengine import cli, get_molecule, util
 from qcengine.testing import using
@@ -56,16 +56,22 @@ def test_info():
         assert output in default_output
 
 
+# TODO add schema_versions when psi4 can handle v2
 @using("psi4")
 def test_run_psi4(tmp_path):
     """Tests qcengine run with psi4 and JSON input"""
+    models = qcelemental.models.v1
 
     def check_result(stdout):
         output = json.loads(stdout)
         assert output["provenance"]["creator"].lower() == "psi4"
         assert output["success"] is True
 
-    inp = AtomicInput(molecule=get_molecule("hydrogen"), driver="energy", model={"method": "hf", "basis": "6-31G"})
+    inp = models.AtomicInput(
+        molecule=models.Molecule(**get_molecule("hydrogen", return_dict=True)),
+        driver="energy",
+        model={"method": "hf", "basis": "6-31G"},
+    )
 
     args = ["run", "psi4", inp.json()]
     check_result(run_qcengine_cli(args))
@@ -82,6 +88,7 @@ def test_run_psi4(tmp_path):
 @using("psi4")
 def test_run_procedure(tmp_path):
     """Tests qcengine run-procedure with geometric, psi4, and JSON input"""
+    models = qcelemental.models.v1
 
     def check_result(stdout):
         output = json.loads(stdout)
@@ -91,9 +98,9 @@ def test_run_procedure(tmp_path):
     inp = {
         "keywords": {"coordsys": "tric", "maxiter": 100, "program": "psi4"},
         "input_specification": {"driver": "gradient", "model": {"method": "HF", "basis": "sto-3g"}, "keywords": {}},
-        "initial_molecule": get_molecule("hydrogen"),
+        "initial_molecule": models.Molecule(**get_molecule("hydrogen", return_dict=True)),
     }
-    inp = OptimizationInput(**inp)
+    inp = models.OptimizationInput(**inp)
 
     args = ["run-procedure", "geometric", inp.json()]
     check_result(run_qcengine_cli(args))

--- a/qcengine/tests/test_harness_canonical.py
+++ b/qcengine/tests/test_harness_canonical.py
@@ -1,6 +1,8 @@
 """
 Tests the DQM compute dispatch module
 """
+import copy
+
 import msgpack
 import numpy as np
 import pytest
@@ -91,6 +93,7 @@ def test_compute_gradient(program, model, keywords, schema_versions, request):
         molecule=molecule, driver="gradient", model=model, extras={"mytag": "something"}, keywords=keywords
     )
     if program in ["adcc"]:
+        inp = checkver_and_convert(inp, request.node.name, "pre")
         with pytest.raises(qcng.exceptions.InputError) as e:
             qcng.compute(inp, program, raise_error=True)
 
@@ -161,8 +164,8 @@ def test_compute_bad_models(program, model, schema_versions, request):
     if not has_program(program):
         pytest.skip("Program '{}' not found.".format(program))
 
-    adriver = model.pop("driver", "energy")
-    amodel = model
+    amodel = copy.deepcopy(model)
+    adriver = amodel.pop("driver", "energy")
     inp = models.AtomicInput(molecule=models.Molecule(**qcng.get_molecule("hydrogen",return_dict=True)), driver=adriver, model=amodel)
 
     inp = checkver_and_convert(inp, request.node.name, "pre")

--- a/qcengine/tests/test_procedures.py
+++ b/qcengine/tests/test_procedures.py
@@ -148,7 +148,7 @@ def test_berny_failed_gradient_computation(input_data, schema_versions, request)
 
 @using("geometric")
 @using("rdkit")
-def test_geometric_rdkit_error(input_data, schema_Verisons, request):
+def test_geometric_rdkit_error(input_data, schema_versions, request):
     models, _ = schema_versions
 
     input_data["initial_molecule"] = models.Molecule(**qcng.get_molecule("water", return_dict=True)).copy(exclude={"connectivity_"})

--- a/qcengine/tests/test_procedures.py
+++ b/qcengine/tests/test_procedures.py
@@ -467,6 +467,7 @@ def checkver_and_convert_proc(mdl, tnm, prepost):
         dict_in = isinstance(mdl, dict)
         if "as_v1" in tnm or "to_v2" in tnm or "None" in tnm:
             if dict_in:
+                # TODO this only works for TD b/c none are dicts. probably discarded when conversions in the compute()
                 mdl = qcel.models.v1.OptimizationInput(**mdl)
             check_model_v1(mdl)
         elif "as_v2" in tnm or "to_v1" in tnm:

--- a/qcengine/tests/test_procedures.py
+++ b/qcengine/tests/test_procedures.py
@@ -3,6 +3,7 @@ Tests the DQM compute dispatch module
 """
 
 import pytest
+import qcelemental as qcel
 
 import qcengine as qcng
 from qcengine.testing import failure_engine, schema_versions, using
@@ -140,7 +141,7 @@ def test_berny_failed_gradient_computation(input_data, schema_versions, request)
     ret = qcng.compute_procedure(input_data, "berny", raise_error=False)
     # TODO ret = checkver_and_convert_proc(ret, request.node.name, "post")
 
-    assert isinstance(ret, models.FailedOperation)
+    assert isinstance(ret, (qcel.models.v1.FailedOperation, qcel.models.v2.FailedOperation))
     assert ret.success is False
     assert ret.error.error_type == qcng.exceptions.InputError.error_type
 
@@ -366,9 +367,9 @@ def test_nwchem_restart(tmpdir, schema_versions, request):
 def test_torsiondrive_generic(schema_versions, request):
     models, _ = schema_versions
     TorsionDriveInput = models.TorsionDriveInput
-    TDKeywords = models.TDKeywords
-    OptimizationSpecification = models.OptimizationSpecification
-    QCInputSpecification = models.QCInputSpecification
+    TDKeywords = models.procedures.TDKeywords
+    OptimizationSpecification = models.procedures.OptimizationSpecification
+    QCInputSpecification = models.procedures.QCInputSpecification
     DriverEnum = models.DriverEnum
     Model = models.Model
     Molecule = models.Molecule
@@ -447,7 +448,6 @@ def checkver_and_convert_proc(mdl, tnm, prepost):
     import json
 
     import pydantic
-    import qcelemental as qcel
 
     def check_model_v1(m):
         assert isinstance(m, pydantic.v1.BaseModel), f"type({m.__class__.__name__}) = {type(m)} ⊄ v1.BaseModel"

--- a/qcengine/tests/test_utils.py
+++ b/qcengine/tests/test_utils.py
@@ -3,17 +3,18 @@ import sys
 import time
 
 import pytest
-from qcelemental.models import AtomicInput
+import qcelemental
 
 from qcengine import util
 from qcengine.exceptions import InputError
 
 
+# TODO add schema_versions when change model_wrapper
 def test_model_wrapper():
 
     with pytest.raises(InputError):
-#pydantic.v1.error_wrappers.ValidationError
-        util.model_wrapper({"bad": "yup"}, AtomicInput)
+        # pydantic.v1.error_wrappers.ValidationError
+        util.model_wrapper({"bad": "yup"}, qcelemental.models.AtomicInput)
 
 
 def test_compute_wrapper_capture():

--- a/qcengine/util.py
+++ b/qcengine/util.py
@@ -55,6 +55,7 @@ def create_mpi_invocation(executable: str, task_config: TaskConfig) -> List[str]
     return command
 
 
+# TODO v1.BaseModel
 def model_wrapper(input_data: Dict[str, Any], model: BaseModel) -> BaseModel:
     """
     Wrap input data in the given model, or return a controlled error
@@ -64,6 +65,7 @@ def model_wrapper(input_data: Dict[str, Any], model: BaseModel) -> BaseModel:
         try:
             input_data = model(**input_data)
         except (pydantic.v1.ValidationError) as exc:
+            # TODO except (pydantic.v1.ValidationError, pydantic.ValidationError) as exc:
             raise InputError(
                 f"Error creating '{model.__name__}', data could not be correctly parsed:\n{str(exc)}"
             ) from None


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->
~currently atop #453~

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->
- [x] adapted all test cases running `qcengine.compute` or `qcengine.compute_procedure` to have their commands sandwiched by `checkver_and_convert`, which runs through the 5 `schema_versions` cases: `as_v1` (longstanding), `as_v2`, `to_v1` (user presents a v2 Input and wants a v1 Result back), `to_v2` (reverse of previous), and `None` (default). Tests presently use `schema_versions` to create inputs of the correct version, then the checkver converts them to v1 (since that's what the harnesses use), compute runs and returns them as v1, then checkver converts them to the stated return version, and existing test checks are run. This verifies the qcel conversion functions are working well and that all the tests aren't hardcoded to versions and can run with v2.
- [x] added a less exotic example of an uncommon calc type (driver=properties) since v1 and v2 in qcelemental were handling types differently
- [x] `checkver_and_convert`'s role will be reduced in future when conversion is handled w/i `qcengine.compute`, but it will retain its usefulness as a check of models inheriting from appropriate pydantic and qcschema base classes.
- test suite is 5x longer, but that's temporary. in the end, we'll run `as_v1` and `as_v2` and spot-check the others.

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
