### PR TITLE
Csse layout opt/td

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -165,7 +165,7 @@ jobs:
       #if: false
       run: |
         conda remove qcelemental --force
-        python -m pip install 'git+https://github.com/loriab/QCElemental.git@csse_layout_536c' --no-deps
+        python -m pip install 'git+https://github.com/loriab/QCElemental.git@csse_layout_536d' --no-deps
 
       # note: conda remove --force, not mamba remove --force b/c https://github.com/mamba-org/mamba/issues/412
       #       alt. is micromamba but not yet ready for setup-miniconda https://github.com/conda-incubator/setup-miniconda/issues/75
@@ -247,7 +247,7 @@ jobs:
       #if: false
       run: |
         conda remove qcelemental --force
-        python -m pip install 'git+https://github.com/loriab/QCElemental.git@csse_layout_536c' --no-deps
+        python -m pip install 'git+https://github.com/loriab/QCElemental.git@csse_layout_536d' --no-deps
 
     - name: Environment Information
       run: |

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -70,7 +70,7 @@ Misc.
 
 MUST (Unmerged)
 +++++++++++++++
-
+torsiondrive rewritten in v2.
 berny harness rewritten in v2. optking and geometric natively speak v1, so adapted as well as can be.
 allow nwchemdriver w/o driver=energy. provenance now nwchemdriver not nwchemrelax
  Optking now fills in ``v2.OptimizationResult.stdout``. Through v2, once can alter gradient protocols in an optimization.

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -70,6 +70,10 @@ Misc.
 
 MUST (Unmerged)
 +++++++++++++++
+
+berny harness rewritten in v2. optking and geometric natively speak v1, so adapted as well as can be.
+allow nwchemdriver w/o driver=energy. provenance now nwchemdriver not nwchemrelax
+ Optking now fills in ``v2.OptimizationResult.stdout``. Through v2, once can alter gradient protocols in an optimization.
 - (:pr:`460`) integrate ``AtomicInput.specification`` into harnesses and show what new inputs look like in tests
 - (:pr:`459`) gcp, mp2d several got properties.return_energy, retunr_gradient
 - (:pr:`460`) If you're missing something from AtomicResult.extras, check AtomicResult.input_data.extras in case it was passed in on input

--- a/qcengine/compute.py
+++ b/qcengine/compute.py
@@ -123,7 +123,7 @@ def compute(
         if task_config is None:
             task_config = {}
         # TODO generalize when procedures in layout in place
-        if isinstance(input_data, qcelemental.models.v2.AtomicInput):
+        if isinstance(input_data, (qcelemental.models.v2.AtomicInput, qcelemental.models.v2.OptimizationInput)):
             input_engine_options = input_data.specification.extras.pop("_qcengine_local_config", {})
         else:
             input_engine_options = input_data.extras.pop("_qcengine_local_config", {})

--- a/qcengine/compute.py
+++ b/qcengine/compute.py
@@ -115,18 +115,14 @@ def compute(
 
         # Build the model and validate
         # * calls model_wrapper with the (Atomic|Optimization|etc)Input for which the harness was designed
-        # * upon return, input_data is a model of the type (e.g., Atomic) and version (e.g., 1 or 2) the harness prefers. for now, v1.
+        # * upon return, input_data is a model of the type (e.g., Atomic) and version (e.g., 1 or 2) the harness prefers: all v2.
         input_data, input_schema_version = executor.build_input_model(input_data, return_input_schema_version=True)
         return_version = input_schema_version if return_version == -1 else return_version
 
         # Build out task_config
         if task_config is None:
             task_config = {}
-        # TODO generalize when procedures in layout in place
-        if isinstance(input_data, (qcelemental.models.v2.AtomicInput, qcelemental.models.v2.OptimizationInput)):
-            input_engine_options = input_data.specification.extras.pop("_qcengine_local_config", {})
-        else:
-            input_engine_options = input_data.extras.pop("_qcengine_local_config", {})
+        input_engine_options = input_data.specification.extras.pop("_qcengine_local_config", {})
         task_config = {**task_config, **input_engine_options}
         config = get_config(task_config=task_config)
 

--- a/qcengine/procedures/model.py
+++ b/qcengine/procedures/model.py
@@ -70,15 +70,11 @@ class ProcedureHarness(BaseModel, abc.ABC):
         elif isinstance(data, dict):
             # remember these are user-provided dictionaries, so they'll have the mandatory fields,
             #   like driver, not the helpful discriminator fields like schema_version.
+            # so long as versions distinguishable by a *required* field, id by dict is reliable.
 
-            schver = data.get("schema_version")
-            if schver == 1:
-                mdl = model_wrapper(data, v1_model)
-            elif schver == 2:
+            if data.get("specification", False) or data.get("schema_version") == 2:
                 mdl = model_wrapper(data, v2_model)
             else:
-                # for now, the two dictionaries look the same, so cast to the one we want
-                # note that this prevents correctly identifying the user schema version when dict passed in, so either as_v1/None or as_v2 will fail
                 mdl = model_wrapper(data, v1_model)
 
         input_schema_version = mdl.schema_version

--- a/qcengine/procedures/nwchem_opt/harvester.py
+++ b/qcengine/procedures/nwchem_opt/harvester.py
@@ -63,7 +63,7 @@ def harvest_as_atomic_result(input_model: OptimizationInput, nwout: str) -> List
     results = []
     for qcvars, nwgrad, out_mol in zip(out_psivars, out_grads, out_mols):
         if nwgrad is not None:
-            qcvars[f"{input_model.input_specification.model.method.upper()[4:]} TOTAL GRADIENT"] = nwgrad
+            qcvars[f"{input_model.specification.specification.model.method.upper()[4:]} TOTAL GRADIENT"] = nwgrad
             qcvars["CURRENT GRADIENT"] = nwgrad
 
         # Get the formatted properties
@@ -77,7 +77,7 @@ def harvest_as_atomic_result(input_model: OptimizationInput, nwout: str) -> List
         # Format them inout an output
         input_data = {
             "molecule": out_mol,
-            "specification": input_model.input_specification.model_dump(),
+            "specification": input_model.specification.specification.model_dump(),
         }
         input_data["specification"]["driver"] = "gradient"
         input_data["specification"].pop("schema_name", None)

--- a/qcengine/procedures/optking.py
+++ b/qcengine/procedures/optking.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 from io import StringIO
 from typing import Any, ClassVar, Dict, Union
 
@@ -44,8 +45,8 @@ class OptKingProcedure(ProcedureHarness):
             import optking
 
         log_stream = StringIO()
-        log = logging.getLogger(f"{__name__}.{id(self)}")
-        log = logging.getLogger("optking")
+        logname = "psi4.optking" if "psi4" in sys.modules else "optking"
+        log = logging.getLogger(logname)
         log.addHandler(logging.StreamHandler(log_stream))
         log.setLevel("INFO")
 

--- a/qcengine/programs/cfour/runner.py
+++ b/qcengine/programs/cfour/runner.py
@@ -183,10 +183,10 @@ class CFOURHarness(ProgramHarness):
                 qcvars[f"{method.upper()} TOTAL HESSIAN"] = c4hess
                 qcvars["CURRENT HESSIAN"] = c4hess
 
-            if input_model.specification.driver.upper() == "PROPERTIES":
+            if (udriver := input_model.specification.driver.upper()) == "PROPERTIES":
                 retres = qcvars[f"CURRENT ENERGY"]
             else:
-                retres = qcvars[f"CURRENT {input_model.specification.driver.upper()}"]
+                retres = qcvars[f"CURRENT {udriver}"]
         except KeyError:
             raise UnknownError(error_stamp(outfiles["input"], stdout, stderr))
 

--- a/qcengine/programs/mace.py
+++ b/qcengine/programs/mace.py
@@ -136,7 +136,7 @@ class MACEHarness(ProgramHarness):
         ret_data["input_data"] = input_data
         ret_data["molecule"] = input_data.molecule
         ret_data["provenance"] = Provenance(creator="mace", version=mace.__version__, routine="mace")
-        ret_data["schema_name"] = "qcschema_output"
+        ret_data["schema_name"] = "qcschema_atomic_output"
         ret_data["success"] = True
 
         # Form up a dict first, then sent to BaseModel to avoid repeat kwargs which don't override each other

--- a/qcengine/programs/molpro.py
+++ b/qcengine/programs/molpro.py
@@ -443,7 +443,7 @@ class MolproHarness(ProgramHarness):
         # Final output_data assignments needed for the AtomicResult object
         output_data["properties"] = properties
         output_data["extras"] = extras
-        output_data["schema_name"] = "qcschema_output"
+        output_data["schema_name"] = "qcschema_atomic_output"
         output_data["stdout"] = outfiles["dispatch.out"]
         output_data["success"] = True
         output_data["provenance"] = input_model.provenance  # TODO better stamp?

--- a/qcengine/programs/mrchem.py
+++ b/qcengine/programs/mrchem.py
@@ -101,7 +101,7 @@ class MRChemHarness(ProgramHarness):
         input_data = copy.deepcopy(job_input["mrchem_json"])
 
         output_data = {
-            "schema_name": "qcschema_output",
+            "schema_name": "qcschema_atomic_output",
             "schema_version": 2,
             "input_data": input_model,
             "molecule": input_model.molecule,

--- a/qcengine/programs/nwchem/germinate.py
+++ b/qcengine/programs/nwchem/germinate.py
@@ -105,7 +105,13 @@ def muster_modelchem(method: str, derint: int, use_tce: bool) -> Tuple[str, Dict
     opts = {}
 
     # Map the run type to
-    runtyp = {"energy": "energy", "gradient": "gradient", "hessian": "hessian", "properties": "property"}[derint]
+    runtyp = {
+        "energy": "energy",
+        "gradient": "gradient",
+        "hessian": "hessian",
+        "properties": "property",
+        "optimize": "optimize",
+    }[derint]
 
     # Write out the theory directive
     if method == "nwchem":

--- a/qcengine/programs/psi4.py
+++ b/qcengine/programs/psi4.py
@@ -208,7 +208,7 @@ class Psi4Harness(ProgramHarness):
                     error_type = "execution_error"
 
                 # Reset the schema if required
-                output_data["schema_name"] = "qcschema_output"
+                output_data["schema_name"] = "qcschema_atomic_output"
                 output_data.pop("memory", None)
                 output_data.pop("nthreads", None)
                 output_data["stdout"] = output_data.pop("raw_output", None)

--- a/qcengine/programs/qcore.py
+++ b/qcengine/programs/qcore.py
@@ -242,7 +242,7 @@ class QcoreHarness(ProgramHarness):
 
         output_data["properties"] = properties
 
-        output_data["schema_name"] = "qcschema_output"
+        output_data["schema_name"] = "qcschema_atomic_output"
         output_data["success"] = True
 
         return AtomicResult(**output_data)

--- a/qcengine/programs/rdkit.py
+++ b/qcengine/programs/rdkit.py
@@ -140,7 +140,6 @@ class RDKitHarness(ProgramHarness):
             creator="rdkit", version=rdkit.__version__, routine="rdkit.Chem.AllChem.UFFGetMoleculeForceField"
         )
 
-        ret_data["schema_name"] = "qcschema_output"
         ret_data["success"] = True
         ret_data["input_data"] = input_data
         ret_data["molecule"] = jmol

--- a/qcengine/programs/terachem.py
+++ b/qcengine/programs/terachem.py
@@ -182,7 +182,7 @@ class TeraChemHarness(ProgramHarness):
 
         output_data["properties"] = properties
 
-        output_data["schema_name"] = "qcschema_output"
+        output_data["schema_name"] = "qcschema_atomic_output"
         output_data["stdout"] = outfiles["tc.out"]
         # TODO Should only return True if TeraChem calculation terminated properly
         output_data["success"] = True

--- a/qcengine/programs/tests/test_dftd3_mp2d.py
+++ b/qcengine/programs/tests/test_dftd3_mp2d.py
@@ -1562,7 +1562,7 @@ def test_3(schema_versions, request):
 
     if from_v2(request.node.name):
         resinp = {
-            "schema_name": "qcschema_input",
+            "schema_name": "qcschema_atomic_input",
             "schema_version": 2,
             "molecule": qcel.molparse.to_schema(sys, dtype=2),
             "specification": {
@@ -1706,7 +1706,7 @@ def test_mp2d__run_mp2d__2body(inp, subjects, schema_versions, request):
 
     if from_v2(request.node.name):
         resinp = {
-            "schema_name": "qcschema_input",
+            "schema_name": "qcschema_atomic_input",
             "schema_version": 2,
             "molecule": mol,
             "specification": {"driver": "gradient", "model": {"method": inp["name"]}, "keywords": {}},
@@ -1942,7 +1942,7 @@ def test_dftd3__run_dftd3__3body(inp, subjects, schema_versions, request):
 
     if from_v2(request.node.name):
         resinp = {
-            "schema_name": "qcschema_input",
+            "schema_name": "qcschema_atomic_input",
             "schema_version": 2,
             "molecule": mol,
             "specification": {"driver": "gradient", "model": {"method": inp["name"]}, "keywords": {}},
@@ -2092,7 +2092,7 @@ def test_gcp(inp, subjects, program, schema_versions, request):
 
     if from_v2(request.node.name):
         resinp = {
-            "schema_name": "qcschema_input",
+            "schema_name": "qcschema_atomic_input",
             "schema_version": 2,
             "molecule": mol,
             "specification": {

--- a/qcengine/programs/tests/test_dftd4.py
+++ b/qcengine/programs/tests/test_dftd4.py
@@ -208,18 +208,20 @@ def test_dftd4_task_unknown_method(schema_versions, request):
 def test_dftd4_task_cold_fusion(schema_versions, request):
     models, retver, models_out = schema_versions
 
+    li4 = {
+        "symbols": ["Li", "Li", "Li", "Li"],
+        "geometry": [
+            [-1.58746019997201, +1.58746019997201, +1.58746019997201],
+            [-1.58746019997201, +1.58746019997201, +1.58746019997201],
+            [-1.58746019997201, -1.58746019997201, -1.58746019997201],
+            [+1.58746019997201, +1.58746019997201, -1.58746019997201],
+        ],
+        "validated": True,  # Force a nuclear fusion input, to make dftd4 fail
+    }
+
     if from_v2(request.node.name):
         atomic_input = models.AtomicInput(
-            molecule={
-                "symbols": ["Li", "Li", "Li", "Li"],
-                "geometry": [
-                    [-1.58746019997201, +1.58746019997201, +1.58746019997201],
-                    [-1.58746019997201, +1.58746019997201, +1.58746019997201],
-                    [-1.58746019997201, -1.58746019997201, -1.58746019997201],
-                    [+1.58746019997201, +1.58746019997201, -1.58746019997201],
-                ],
-                "validated": True,  # Force a nuclear fusion input, to make dftd4 fail
-            },
+            molecule=li4,
             specification={
                 "keywords": {"level_hint": "D4"},
                 "model": {"method": "pbe"},
@@ -228,16 +230,7 @@ def test_dftd4_task_cold_fusion(schema_versions, request):
         )
     else:
         atomic_input = models.AtomicInput(
-            molecule={
-                "symbols": ["Li", "Li", "Li", "Li"],
-                "geometry": [
-                    [-1.58746019997201, +1.58746019997201, +1.58746019997201],
-                    [-1.58746019997201, +1.58746019997201, +1.58746019997201],
-                    [-1.58746019997201, -1.58746019997201, -1.58746019997201],
-                    [+1.58746019997201, +1.58746019997201, -1.58746019997201],
-                ],
-                "validated": True,  # Force a nuclear fusion input, to make dftd4 fail
-            },
+            molecule=li4,
             keywords={"level_hint": "D4"},
             model={"method": "pbe"},
             driver="energy",

--- a/qcengine/programs/tests/test_programs.py
+++ b/qcengine/programs/tests/test_programs.py
@@ -816,6 +816,7 @@ def test_psi4_properties_driver(schema_versions, request):
         "keywords": {"scf_type": "df", "mp2_type": "df", "e_convergence": 9},
     }
     if from_v2(request.node.name):
+        json_data["schema_name"] = "qcschema_atomic_input"
         json_data["specification"] = {
             "driver": json_data.pop("driver"),
             "model": json_data.pop("model"),
@@ -876,7 +877,8 @@ def test_psi4_properties_driver(schema_versions, request):
     json_ret = checkver_and_convert(json_ret, request.node.name, "post")
 
     assert json_ret.success
-    assert "qcschema_output" == json_ret.schema_name
+    xptd_schema_name = "qcschema_atomic_output" if "v2" in request.node.name else "qcschema_output"
+    assert json_ret.schema_name == xptd_schema_name
     for k in expected_return_result.keys():
         assert compare_values(expected_return_result[k], json_ret.return_result[k], atol=1.0e-5)
     for k in expected_properties.keys():

--- a/qcengine/programs/torchani.py
+++ b/qcengine/programs/torchani.py
@@ -181,7 +181,7 @@ class TorchANIHarness(ProgramHarness):
             creator="torchani", version="unknown", routine="torchani.builtin.aev_computer"
         )
 
-        ret_data["schema_name"] = "qcschema_output"
+        ret_data["schema_name"] = "qcschema_atomic_output"
         ret_data["success"] = True
 
         # Form up a dict first, then sent to BaseModel to avoid repeat kwargs which don't override each other

--- a/qcengine/tests/test_cli.py
+++ b/qcengine/tests/test_cli.py
@@ -110,11 +110,25 @@ def test_run_procedure(tmp_path, schema_versions, request):
         assert output["provenance"]["creator"].lower() == "geometric"
         assert output["success"] is True
 
-    inp = {
-        "keywords": {"coordsys": "tric", "maxiter": 100, "program": "psi4"},
-        "input_specification": {"driver": "gradient", "model": {"method": "HF", "basis": "sto-3g"}, "keywords": {}},
-        "initial_molecule": models.Molecule(**get_molecule("hydrogen", return_dict=True)),
-    }
+    if from_v2(request.node.name):
+        inp = {
+            "specification": {
+                "keywords": {"coordsys": "tric", "maxiter": 100},
+                "specification": {
+                    "driver": "gradient",
+                    "model": {"method": "HF", "basis": "sto-3g"},
+                    "keywords": {},
+                    "program": "psi4",
+                },
+            },
+            "initial_molecule": models.Molecule(**get_molecule("hydrogen", return_dict=True)),
+        }
+    else:
+        inp = {
+            "keywords": {"coordsys": "tric", "maxiter": 100, "program": "psi4"},
+            "input_specification": {"driver": "gradient", "model": {"method": "HF", "basis": "sto-3g"}, "keywords": {}},
+            "initial_molecule": models.Molecule(**get_molecule("hydrogen", return_dict=True)),
+        }
     inp = models.OptimizationInput(**inp)
 
     inp = checkver_and_convert(inp, request.node.name, "pre")

--- a/qcengine/tests/test_procedures.py
+++ b/qcengine/tests/test_procedures.py
@@ -86,11 +86,12 @@ def test_geometric_psi4(input_data, optimizer, ncores, schema_versions, request)
     assert ret.provenance.creator.lower() == optimizer
     assert trajs_tgt[0].provenance.creator.lower() == grad_program
 
-    if optimizer == "optking" and ncores != 1:
-        with pytest.raises(AssertionError):
-            # Optking not passing threads to psi4
-            assert trajs_tgt[0].provenance.nthreads == ncores
-    elif optimizer == "nwchemdriver":
+    # Note: thread passing is semi-implemented in optking and subject to other env factors
+    # if optimizer == "optking" and ncores != 1:
+    #     with pytest.raises(AssertionError):
+    #         # Optking not passing threads to psi4
+    #         assert trajs_tgt[0].provenance.nthreads == ncores
+    if optimizer in ["optking", "nwchemdriver"]:
         pass
         # threading not yet implemented in NWChemDriver
     else:

--- a/qcengine/tests/test_procedures.py
+++ b/qcengine/tests/test_procedures.py
@@ -8,16 +8,25 @@ import pytest
 import qcelemental as qcel
 
 import qcengine as qcng
-from qcengine.testing import checkver_and_convert, failure_engine, schema_versions, using
+from qcengine.testing import checkver_and_convert, failure_engine, from_v2, schema_versions, using
 
 
 @pytest.fixture(scope="function")
-def input_data():
-    return {
-        "keywords": {"coordsys": "tric", "maxiter": 100, "program": None},
-        "input_specification": {"driver": "gradient", "model": None, "keywords": {}},
-        "initial_molecule": None,
-    }
+def input_data(request):
+    if from_v2(request.node.name):
+        return {
+            "specification": {
+                "keywords": {"coordsys": "tric", "maxiter": 100},
+                "specification": {"driver": "gradient", "model": None, "keywords": {}, "program": None},
+            },
+            "initial_molecule": None,
+        }
+    else:
+        return {
+            "keywords": {"coordsys": "tric", "maxiter": 100, "program": None},
+            "input_specification": {"driver": "gradient", "model": None, "keywords": {}},
+            "initial_molecule": None,
+        }
 
 
 @using("psi4")
@@ -28,15 +37,33 @@ def input_data():
         pytest.param("geometric", marks=using("geometric")),
         pytest.param("optking", marks=using("optking")),
         pytest.param("berny", marks=using("berny")),
+        pytest.param("nwchemdriver", marks=using("nwchem")),
     ],
 )
 def test_geometric_psi4(input_data, optimizer, ncores, schema_versions, request):
     models, retver, _ = schema_versions
 
     input_data["initial_molecule"] = models.Molecule(**qcng.get_molecule("hydrogen", return_dict=True))
-    input_data["input_specification"]["model"] = {"method": "HF", "basis": "sto-3g"}
-    input_data["input_specification"]["keywords"] = {"scf_properties": ["wiberg_lowdin_indices"]}
-    input_data["keywords"]["program"] = "psi4"
+    if optimizer == "nwchemdriver":
+        grad_program = "nwchem"
+        grad_kw = {}
+    else:
+        grad_program = "psi4"
+        grad_kw = {"scf_properties": ["wiberg_lowdin_indices"]}
+
+    if from_v2(request.node.name):
+        input_data["specification"]["specification"]["model"] = {"method": "HF", "basis": "sto-3g"}
+        input_data["specification"]["specification"]["keywords"] = grad_kw
+        input_data["specification"]["specification"]["program"] = grad_program
+        input_data["specification"]["specification"]["extras"] = {"myqctag": "hello psi4"}
+        input_data["specification"]["extras"] = {"myopttag": "hello qcengine"}
+
+    else:
+        input_data["input_specification"]["model"] = {"method": "HF", "basis": "sto-3g"}
+        input_data["input_specification"]["keywords"] = grad_kw
+        input_data["keywords"]["program"] = grad_program
+        input_data["input_specification"]["extras"] = {"myqctag": "hello psi4"}
+        input_data["extras"] = {"myopttag": "hello qcengine"}
 
     input_data = models.OptimizationInput(**input_data)
 
@@ -51,87 +78,143 @@ def test_geometric_psi4(input_data, optimizer, ncores, schema_versions, request)
             input_data, optimizer, raise_error=True, task_config=task_config, return_version=retver
         )
     ret = checkver_and_convert(ret, request.node.name, "post")
+    trajs_tgt = ret.trajectory_results if "v2" in request.node.name else ret.trajectory
 
-    assert 10 > len(ret.trajectory) > 1
+    assert 10 > len(trajs_tgt) > 1
 
     assert pytest.approx(ret.final_molecule.measure([0, 1]), 1.0e-4) == 1.3459150737
     assert ret.provenance.creator.lower() == optimizer
-    assert ret.trajectory[0].provenance.creator.lower() == "psi4"
+    assert trajs_tgt[0].provenance.creator.lower() == grad_program
 
-    if optimizer == "optking":
-        pytest.xfail("not passing threads to psi4")
+    if optimizer == "optking" and ncores != 1:
+        with pytest.raises(AssertionError):
+            # Optking not passing threads to psi4
+            assert trajs_tgt[0].provenance.nthreads == ncores
+    elif optimizer == "nwchemdriver":
+        pass
+        # threading not yet implemented in NWChemDriver
     else:
-        assert ret.trajectory[0].provenance.nthreads == ncores
+        assert trajs_tgt[0].provenance.nthreads == ncores
 
     # Check keywords passing
-    for single in ret.trajectory:
-        if "v2" in request.node.name:
-            assert "scf_properties" in single.input_data.specification.keywords
-        else:
-            assert "scf_properties" in single.keywords
-        assert "WIBERG_LOWDIN_INDICES" in single.extras["qcvars"] or "WIBERG LOWDIN INDICES" in single.extras["qcvars"]
-        # TODO: old WIBERG qcvar used underscore; new one uses space. covering bases here but remove someday
+    if optimizer != "nwchemdriver":
+        for single in trajs_tgt:
+            if "v2" in request.node.name:
+                assert "scf_properties" in single.input_data.specification.keywords
+            else:
+                assert "scf_properties" in single.keywords
+            assert (
+                "WIBERG_LOWDIN_INDICES" in single.extras["qcvars"] or "WIBERG LOWDIN INDICES" in single.extras["qcvars"]
+            )
+            # TODO: old WIBERG qcvar used underscore; new one uses space. covering bases here but remove someday
+
+    # Check extras passing
+    if "v2" in request.node.name:
+        assert (
+            "myqctag" in ret.input_data.specification.specification.extras
+        ), ret.input_data.specification.specification.extras.keys()
+        if optimizer != "geometric":
+            # geometric: below can't happen until optimizers call gradients with v2
+            assert "myqctag" not in ret.trajectory_results[0].extras, "input extras wrongly present in sub-result"
+        assert "myopttag" in ret.input_data.specification.extras, ret.input_data.specification.extras.keys()
+        assert "myopttag" not in ret.extras, "input extras wrongly present in top-result"
+    else:
+        if optimizer != "optking":
+            assert "myqctag" in ret.trajectory[0].extras, ret.trajectory[0].extras.keys()
+            assert "myopttag" in ret.extras, ret.extras.keys()
 
 
 @using("psi4")
-@using("geometric")
-def test_geometric_local_options(input_data, schema_versions, request):
+@pytest.mark.parametrize(
+    "optimizer",
+    [
+        pytest.param("geometric", marks=using("geometric")),
+        pytest.param("optking", marks=using("optking")),
+        pytest.param("berny", marks=using("berny")),
+    ],
+)
+def test_geometric_local_options(input_data, schema_versions, request, optimizer):
     models, retver, _ = schema_versions
 
     input_data["initial_molecule"] = models.Molecule(**qcng.get_molecule("hydrogen", return_dict=True))
-    input_data["input_specification"]["model"] = {"method": "HF", "basis": "sto-3g"}
-    input_data["keywords"]["program"] = "psi4"
+
+    if from_v2(request.node.name):
+        input_data["specification"]["specification"]["model"] = {"method": "HF", "basis": "sto-3g"}
+        input_data["specification"]["specification"]["program"] = "psi4"
+    else:
+        input_data["input_specification"]["model"] = {"method": "HF", "basis": "sto-3g"}
+        input_data["keywords"]["program"] = "psi4"
 
     input_data = models.OptimizationInput(**input_data)
 
     # Set some extremely large number to test
     input_data = checkver_and_convert(input_data, request.node.name, "pre")
-    ret = qcng.compute(input_data, "geometric", raise_error=True, task_config={"memory": "5000"}, return_version=retver)
+    ret = qcng.compute(input_data, optimizer, raise_error=True, task_config={"memory": "5000"}, return_version=retver)
     ret = checkver_and_convert(ret, request.node.name, "post")
 
-    assert pytest.approx(ret.trajectory[0].provenance.memory, 1) == 4900
+    trajs_tgt = ret.trajectory_results if "v2" in request.node.name else ret.trajectory
+    atin_tgt = ret.input_data.specification.specification if "v2" in request.node.name else ret.input_specification
+
+    if optimizer == "optking":
+        with pytest.raises(AssertionError):
+            # Optking not passing memory to psi4
+            assert pytest.approx(trajs_tgt[0].provenance.memory, 1) == 4900
+    else:
+        assert pytest.approx(trajs_tgt[0].provenance.memory, 1) == 4900
 
     # Make sure we cleaned up
-    assert "_qcengine_local_config" not in ret.input_specification
-    assert "_qcengine_local_config" not in ret.trajectory[0].extras
+    assert "_qcengine_local_config" not in atin_tgt.extras
+    assert "_qcengine_local_config" not in trajs_tgt[0].extras
+    if "v2" in request.node.name:
+        assert "_qcengine_local_config" not in trajs_tgt[0].input_data.specification.extras
 
 
-@using("rdkit")
-@using("geometric")
-def test_geometric_stdout(input_data, schema_versions, request):
+@pytest.mark.parametrize(
+    "optimizer,converged",
+    [
+        pytest.param("geometric", "Converged!", marks=using("geometric")),
+        pytest.param("optking", "Convergence check returned True", marks=using("optking")),
+        pytest.param("berny", "All criteria matched", marks=using("berny")),
+    ],
+)
+@pytest.mark.parametrize(
+    "gradprog,gradmodel",
+    [
+        pytest.param("rdkit", {"method": "UFF", "basis": ""}, marks=using("rdkit")),
+        pytest.param("psi4", {"method": "HF", "basis": "sto-3g"}, marks=using("psi4")),
+    ],
+)
+def test_optimizer_stdout(optimizer, gradprog, gradmodel, converged, input_data, schema_versions, request):
     models, retver, _ = schema_versions
 
     input_data["initial_molecule"] = models.Molecule(**qcng.get_molecule("water", return_dict=True))
-    input_data["input_specification"]["model"] = {"method": "UFF", "basis": ""}
-    input_data["keywords"]["program"] = "rdkit"
+
+    if from_v2(request.node.name):
+        input_data["specification"]["specification"]["model"] = gradmodel
+        input_data["specification"]["specification"]["program"] = gradprog
+        input_data["specification"]["specification"]["protocols"] = {"stdout": False}
+    else:
+        input_data["input_specification"]["model"] = gradmodel
+        input_data["keywords"]["program"] = gradprog
+        # no way to turn off gradient stdout in v1
 
     input_data = models.OptimizationInput(**input_data)
 
     input_data = checkver_and_convert(input_data, request.node.name, "pre")
-    ret = qcng.compute(input_data, "geometric", raise_error=True, return_version=retver)
+    ret = qcng.compute(input_data, optimizer, raise_error=True, return_version=retver)
     ret = checkver_and_convert(ret, request.node.name, "post")
 
     assert ret.success is True
-    assert "Converged!" in ret.stdout
+    assert converged in ret.stdout
 
-
-@using("psi4")
-@using("berny")
-def test_berny_stdout(input_data, schema_versions, request):
-    models, retver, _ = schema_versions
-
-    input_data["initial_molecule"] = models.Molecule(**qcng.get_molecule("water", return_dict=True))
-    input_data["input_specification"]["model"] = {"method": "HF", "basis": "sto-3g"}
-    input_data["keywords"]["program"] = "psi4"
-
-    input_data = models.OptimizationInput(**input_data)
-
-    input_data = checkver_and_convert(input_data, request.node.name, "pre")
-    ret = qcng.compute(input_data, "berny", raise_error=True, return_version=retver)
-    ret = checkver_and_convert(ret, request.node.name, "post")
-
-    assert ret.success is True
-    assert "All criteria matched" in ret.stdout
+    trajs_tgt = ret.trajectory_results if "v2" in request.node.name else ret.trajectory
+    assert ret.provenance.creator.lower() == optimizer
+    assert trajs_tgt[0].provenance.creator.lower() == gradprog
+    # rdkit does not have stdout, while psi4 does and is suppressed by protocol in v2 but can't be thru v1
+    if from_v2(request.node.name) or gradprog == "rdkit":
+        assert trajs_tgt[0].stdout is None
+    else:
+        assert trajs_tgt[0].stdout is not None
 
 
 @using("psi4")
@@ -140,9 +223,14 @@ def test_berny_failed_gradient_computation(input_data, schema_versions, request)
     models, retver, _ = schema_versions
 
     input_data["initial_molecule"] = models.Molecule(**qcng.get_molecule("water", return_dict=True))
-    input_data["input_specification"]["model"] = {"method": "HF", "basis": "sto-3g"}
-    input_data["input_specification"]["keywords"] = {"badpsi4key": "badpsi4value"}
-    input_data["keywords"]["program"] = "psi4"
+    if from_v2(request.node.name):
+        input_data["specification"]["specification"]["model"] = {"method": "HF", "basis": "sto-3g"}
+        input_data["specification"]["specification"]["keywords"] = {"badpsi4key": "badpsi4value"}
+        input_data["specification"]["specification"]["program"] = "psi4"
+    else:
+        input_data["input_specification"]["model"] = {"method": "HF", "basis": "sto-3g"}
+        input_data["input_specification"]["keywords"] = {"badpsi4key": "badpsi4value"}
+        input_data["keywords"]["program"] = "psi4"
 
     input_data = models.OptimizationInput(**input_data)
 
@@ -163,8 +251,12 @@ def test_geometric_rdkit_error(input_data, schema_versions, request):
     input_data["initial_molecule"] = models.Molecule(**qcng.get_molecule("water", return_dict=True)).copy(
         exclude={"connectivity_"}
     )
-    input_data["input_specification"]["model"] = {"method": "UFF", "basis": ""}
-    input_data["keywords"]["program"] = "rdkit"
+    if from_v2(request.node.name):
+        input_data["specification"]["specification"]["model"] = {"method": "UFF", "basis": ""}
+        input_data["specification"]["specification"]["program"] = "rdkit"
+    else:
+        input_data["input_specification"]["model"] = {"method": "UFF", "basis": ""}
+        input_data["keywords"]["program"] = "rdkit"
 
     input_data = models.OptimizationInput(**input_data)
 
@@ -177,25 +269,59 @@ def test_geometric_rdkit_error(input_data, schema_versions, request):
 
 
 @using("rdkit")
-@using("geometric")
-def test_optimization_protocols(input_data, schema_versions, request):
+@pytest.mark.parametrize(
+    "optimizer",
+    [
+        pytest.param("geometric", marks=using("geometric")),
+        pytest.param("optking", marks=using("optking")),
+        pytest.param("berny", marks=using("berny")),
+        pytest.param("nwchemdriver", marks=using("nwchem")),
+    ],
+)
+def test_optimization_protocols(optimizer, input_data, schema_versions, request):
     models, retver, _ = schema_versions
 
+    if optimizer == "nwchemdriver":
+        grad_program = "nwchem"
+        grad_model = {"method": "HF", "basis": "sto-3g"}
+    else:
+        grad_program = "rdkit"
+        grad_model = {"method": "UFF"}
+
     input_data["initial_molecule"] = models.Molecule(**qcng.get_molecule("water", return_dict=True))
-    input_data["input_specification"]["model"] = {"method": "UFF"}
-    input_data["keywords"]["program"] = "rdkit"
-    input_data["protocols"] = {"trajectory": "initial_and_final"}
+    if from_v2(request.node.name):
+        input_data["specification"]["specification"]["model"] = grad_model
+        input_data["specification"]["specification"]["program"] = grad_program
+        input_data["specification"]["protocols"] = {"trajectory": "initial_and_final"}
+    else:
+        input_data["input_specification"]["model"] = grad_model
+        input_data["keywords"]["program"] = grad_program
+        input_data["protocols"] = {"trajectory": "initial_and_final"}
 
     input_data = models.OptimizationInput(**input_data)
 
     input_data = checkver_and_convert(input_data, request.node.name, "pre")
-    ret = qcng.compute(input_data, "geometric", raise_error=True, return_version=retver)
+    ret = qcng.compute(input_data, optimizer, raise_error=True, return_version=retver)
     ret = checkver_and_convert(ret, request.node.name, "post")
 
+    trajs_tgt = ret.trajectory_results if "v2" in request.node.name else ret.trajectory
+    initmol_tgt = ret.input_data.initial_molecule if "v2" in request.node.name else ret.initial_molecule
+
     assert ret.success, ret.error.error_message
-    assert len(ret.trajectory) == 2
-    assert ret.initial_molecule.get_hash() == ret.trajectory[0].molecule.get_hash()
-    assert ret.final_molecule.get_hash() == ret.trajectory[1].molecule.get_hash()
+    assert len(trajs_tgt) == 2
+    assert (
+        pytest.approx(initmol_tgt.nuclear_repulsion_energy(), 1.0e-4)
+        == trajs_tgt[0].molecule.nuclear_repulsion_energy()
+    )
+    if optimizer != "nwchemdriver":
+        # in internal-opt mode, fix_/orient is not called, so the hash will be different
+        assert initmol_tgt.get_hash() == trajs_tgt[0].molecule.get_hash()
+    assert (
+        pytest.approx(ret.final_molecule.nuclear_repulsion_energy(), 1.0e-4)
+        == trajs_tgt[1].molecule.nuclear_repulsion_energy()
+    )
+    if optimizer != "nwchemdriver":
+        assert ret.final_molecule.get_hash() == trajs_tgt[1].molecule.get_hash()
 
 
 @using("geometric")
@@ -209,9 +335,17 @@ def test_geometric_retries(failure_engine, input_data, schema_versions, request)
         "symbols": ["He", "He"],
         "geometry": [0, 0, 0, 0, 0, failure_engine.start_distance],
     }
-    input_data["input_specification"]["model"] = {"method": "something"}
-    input_data["keywords"]["program"] = failure_engine.name
-    input_data["keywords"]["coordsys"] = "cart"  # needed by geometric v1.0 to play nicely with failure_engine
+
+    if from_v2(request.node.name):
+        input_data["specification"]["specification"]["model"] = {"method": "something"}
+        input_data["specification"]["specification"]["program"] = failure_engine.name
+        input_data["specification"]["keywords"][
+            "coordsys"
+        ] = "cart"  # needed by geometric v1.0 to play nicely with failure_engine
+    else:
+        input_data["input_specification"]["model"] = {"method": "something"}
+        input_data["keywords"]["program"] = failure_engine.name
+        input_data["keywords"]["coordsys"] = "cart"  # needed by geometric v1.0 to play nicely with failure_engine
 
     input_data = models.OptimizationInput(**input_data)
 
@@ -219,12 +353,14 @@ def test_geometric_retries(failure_engine, input_data, schema_versions, request)
     ret = qcng.compute(input_data, "geometric", task_config={"ncores": 13}, raise_error=True, return_version=retver)
     ret = checkver_and_convert(ret, request.node.name, "post")
 
+    trajs_tgt = ret.trajectory_results if "v2" in request.node.name else ret.trajectory
+
     assert ret.success is True
-    assert ret.trajectory[0].provenance.retries == 1
-    assert ret.trajectory[0].provenance.ncores == 13
-    assert ret.trajectory[1].provenance.retries == 2
-    assert ret.trajectory[1].provenance.ncores == 13
-    assert "retries" not in ret.trajectory[2].provenance.dict()
+    assert trajs_tgt[0].provenance.retries == 1
+    assert trajs_tgt[0].provenance.ncores == 13
+    assert trajs_tgt[1].provenance.retries == 2
+    assert trajs_tgt[1].provenance.ncores == 13
+    assert "retries" not in trajs_tgt[2].provenance.dict()
 
     # Ensure we still fail
     failure_engine.iter_modes = ["random_error", "pass", "random_error", "random_error", "pass"]  # Iter 1  # Iter 2
@@ -298,15 +434,24 @@ def test_geometric_generic(input_data, program, model, bench, schema_versions, r
     models, retver, _ = schema_versions
 
     input_data["initial_molecule"] = models.Molecule(**qcng.get_molecule("water", return_dict=True))
-    input_data["input_specification"]["model"] = model
-    input_data["keywords"]["program"] = program
-    input_data["input_specification"]["extras"] = {
-        "_secret_tags": {"mysecret_tag": "data1"}  # pragma: allowlist secret
-    }
+    if from_v2(request.node.name):
+        input_data["specification"]["specification"]["model"] = model
+        input_data["specification"]["specification"]["program"] = program
+        input_data["specification"]["specification"]["extras"] = {
+            "_secret_tags": {"mysecret_tag": "data1"}  # pragma: allowlist secret
+        }
+    else:
+        input_data["input_specification"]["model"] = model
+        input_data["keywords"]["program"] = program
+        input_data["input_specification"]["extras"] = {
+            "_secret_tags": {"mysecret_tag": "data1"}  # pragma: allowlist secret
+        }
 
     input_data = checkver_and_convert(input_data, request.node.name, "pre", cast_dict_as="OptimizationInput")
     ret = qcng.compute(input_data, "geometric", raise_error=True, return_version=retver)
     ret = checkver_and_convert(ret, request.node.name, "post")
+
+    trajs_tgt = ret.trajectory_results if "v2" in request.node.name else ret.trajectory
 
     assert ret.success is True
     assert "Converged!" in ret.stdout
@@ -318,8 +463,9 @@ def test_geometric_generic(input_data, program, model, bench, schema_versions, r
     assert pytest.approx(r12, 1.0e-4) == bench[1]
     assert pytest.approx(a102, 1.0e-4) == bench[2]
 
-    assert "_secret_tags" in ret.trajectory[0].extras
-    assert "data1" == ret.trajectory[0].extras["_secret_tags"]["mysecret_tag"]
+    assert "_secret_tags" in trajs_tgt[0].extras
+    assert "data1" == trajs_tgt[0].extras["_secret_tags"]["mysecret_tag"], trajs_tgt[0].extras["_secret_tags"]
+    # the _secret_tags shows up in Res.extras, not in Res.input_data.extras b/c geometric running v1 internally
 
 
 @using("nwchem")
@@ -328,13 +474,25 @@ def test_nwchem_relax(linopt, schema_versions, request):
     models, retver, _ = schema_versions
 
     # Make the input file
-    input_data = {
-        "input_specification": {
-            "model": {"method": "HF", "basis": "sto-3g"},
-            "keywords": {"set__driver:linopt": linopt},
-        },
-        "initial_molecule": models.Molecule(**qcng.get_molecule("hydrogen", return_dict=True)),
-    }
+    if from_v2(request.node.name):
+        input_data = {
+            "specification": {
+                "specification": {
+                    "model": {"method": "HF", "basis": "sto-3g"},
+                    "keywords": {"set__driver:linopt": linopt},
+                    "driver": "gradient",
+                },
+            },
+            "initial_molecule": models.Molecule(**qcng.get_molecule("hydrogen", return_dict=True)),
+        }
+    else:
+        input_data = {
+            "input_specification": {
+                "model": {"method": "HF", "basis": "sto-3g"},
+                "keywords": {"set__driver:linopt": linopt},
+            },
+            "initial_molecule": models.Molecule(**qcng.get_molecule("hydrogen", return_dict=True)),
+        }
     input_data = models.OptimizationInput(**input_data)
 
     # Run the relaxation
@@ -342,7 +500,9 @@ def test_nwchem_relax(linopt, schema_versions, request):
     ret = qcng.compute(input_data, "nwchemdriver", raise_error=True, return_version=retver)
     ret = checkver_and_convert(ret, request.node.name, "post")
 
-    assert 10 > len(ret.trajectory) > 1
+    trajs_tgt = ret.trajectory_results if "v2" in request.node.name else ret.trajectory
+
+    assert 10 > len(trajs_tgt) > 1
 
     assert pytest.approx(ret.final_molecule.measure([0, 1]), 1.0e-4) == 1.3459150737
 
@@ -352,14 +512,27 @@ def test_nwchem_restart(tmpdir, schema_versions, request):
     models, retver, _ = schema_versions
 
     # Make the input file
-    input_data = {
-        "input_specification": {
-            "model": {"method": "HF", "basis": "sto-3g"},
-            "keywords": {"driver__maxiter": 2, "set__driver:linopt": 0},
-            "extras": {"allow_restarts": True},
-        },
-        "initial_molecule": models.Molecule(**qcng.get_molecule("hydrogen", return_dict=True)),
-    }
+    if from_v2(request.node.name):
+        input_data = {
+            "specification": {
+                "specification": {
+                    "model": {"method": "HF", "basis": "sto-3g"},
+                    "keywords": {"driver__maxiter": 2, "set__driver:linopt": 0},
+                    "driver": "gradient",  # newly req'd by model in v2
+                    "extras": {"allow_restarts": True},
+                },
+            },
+            "initial_molecule": models.Molecule(**qcng.get_molecule("hydrogen", return_dict=True)),
+        }
+    else:
+        input_data = {
+            "input_specification": {
+                "model": {"method": "HF", "basis": "sto-3g"},
+                "keywords": {"driver__maxiter": 2, "set__driver:linopt": 0},
+                "extras": {"allow_restarts": True},
+            },
+            "initial_molecule": models.Molecule(**qcng.get_molecule("hydrogen", return_dict=True)),
+        }
     input_data = models.OptimizationInput(**input_data)
 
     # Run an initial step, which should not converge
@@ -444,9 +617,14 @@ def test_optimization_mrchem(input_data, optimizer, schema_versions, request):
     models, retver, _ = schema_versions
 
     input_data["initial_molecule"] = models.Molecule(**qcng.get_molecule("hydrogen", return_dict=True))
-    input_data["input_specification"]["model"] = {"method": "HF"}
-    input_data["input_specification"]["keywords"] = {"world_prec": 1.0e-4}
-    input_data["keywords"]["program"] = "mrchem"
+    if from_v2(request.node.name):
+        input_data["specification"]["specification"]["model"] = {"method": "HF"}
+        input_data["specification"]["specification"]["keywords"] = {"world_prec": 1.0e-4}
+        input_data["specification"]["specification"]["program"] = "mrchem"
+    else:
+        input_data["input_specification"]["model"] = {"method": "HF"}
+        input_data["input_specification"]["keywords"] = {"world_prec": 1.0e-4}
+        input_data["keywords"]["program"] = "mrchem"
 
     input_data = models.OptimizationInput(**input_data)
 
@@ -454,7 +632,9 @@ def test_optimization_mrchem(input_data, optimizer, schema_versions, request):
     ret = qcng.compute(input_data, optimizer, raise_error=True, return_version=retver)
     ret = checkver_and_convert(ret, request.node.name, "post")
 
-    assert 10 > len(ret.trajectory) > 1
+    trajs_tgt = ret.trajectory_results if "v2" in request.node.name else ret.trajectory
+
+    assert 10 > len(trajs_tgt) > 1
     assert pytest.approx(ret.final_molecule.measure([0, 1]), 1.0e-3) == 1.3860734486984705
     assert ret.provenance.creator.lower() == optimizer
-    assert ret.trajectory[0].provenance.creator.lower() == "mrchem"
+    assert trajs_tgt[0].provenance.creator.lower() == "mrchem"

--- a/qcengine/tests/test_procedures.py
+++ b/qcengine/tests/test_procedures.py
@@ -320,7 +320,8 @@ def test_optimization_protocols(optimizer, input_data, schema_versions, request)
         pytest.approx(ret.final_molecule.nuclear_repulsion_energy(), 1.0e-4)
         == trajs_tgt[1].molecule.nuclear_repulsion_energy()
     )
-    if optimizer != "nwchemdriver":
+    if optimizer not in ["nwchemdriver", "optking"]:
+        # optking would pass if: optking/optimize.py: #computer.update_geometry(o_molsys.geom)
         assert ret.final_molecule.get_hash() == trajs_tgt[1].molecule.get_hash()
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->
- [x] counterpart to MolSSI/QCElemental#363 that implements the v2 Opt and TD schemas in procedure harnesses. pyberny and nwchemopt and torsiondrive get  expressed wholly in v2. optking and geometric are v2 on the outside but then convert to v1 since the external program speaks v1 natively.
- [x] expand some testing of optimization procedures to cover optimizer choices more fully.

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
