### PR TITLE
Implementation of a Gaussian Harness

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,7 @@ markers = [
     "dftd4: tests using DFTD4 software; skip if unavailable",
     "dftd4_350: tests using DFTD4 >=3.5.0 software; skip if unavailable",
     "gamess: tests using GAMESS-US software; skip if unavailable",
+    "gaussian: tests using Gaussian software; skip if unavailable",
     "mctc-gcp: tests using modern mctc-gcp software; skip if unavailable",
     "classic-gcp: tests using GCP executable software; skip if unavailable",
     "geometric: tests using geomeTRIC software; skip if unavailable",

--- a/qcengine/programs/base.py
+++ b/qcengine/programs/base.py
@@ -11,6 +11,7 @@ from .cfour import CFOURHarness
 from .dftd3 import DFTD3Harness
 from .dftd_ng import DFTD4Harness, SDFTD3Harness
 from .gamess import GAMESSHarness
+from .gaussian import GaussianHarness
 from .gcp import GCPHarness, MCTCGCPHarness
 from .mace import MACEHarness
 from .model import ProgramHarness
@@ -110,6 +111,7 @@ register_program(AdccHarness())
 register_program(CFOURHarness())
 register_program(EntosHarness())  # Duplicate of Qcore harness to transition the namespace, to be deprecated
 register_program(GAMESSHarness())
+register_program(GaussianHarness())
 register_program(MRChemHarness())
 register_program(MolproHarness())
 register_program(NWChemHarness())

--- a/qcengine/programs/gaussian/__init__.py
+++ b/qcengine/programs/gaussian/__init__.py
@@ -1,0 +1,3 @@
+from .runner import GaussianHarness
+
+__all__ = ["GaussianHarness"]

--- a/qcengine/programs/gaussian/germinate.py
+++ b/qcengine/programs/gaussian/germinate.py
@@ -1,0 +1,83 @@
+"""Map QCSchema method/driver/multiplicity to Gaussian route-section components."""
+
+from typing import Any, Dict
+
+from qcengine.exceptions import InputError
+
+# rq-ef62979b rq-a88c706f rq-b49bb2a2 rq-4d763c6d
+_SUPPORTED_DRIVERS = {"energy", "gradient", "hessian", "properties"}
+
+# rq-ef62979b
+_METHOD_MAP = {
+    "hf": "HF",
+    "scf": "HF",
+    "mp2": "MP2",
+    "ccsd": "CCSD",
+    "ccsd(t)": "CCSD(T)",
+}
+
+# rq-ef62979b rq-c266b9bb rq-f1c116db rq-82942b90 rq-f512b60b
+_DRIVER_JOB_TYPE = {
+    "energy": "",
+    "gradient": "Force=NoStep",
+    "hessian": "Freq",
+    "properties": "",
+}
+
+
+def muster_modelchem(method: str, driver: str, multiplicity: int) -> Dict[str, Any]:
+    """Convert QCSchema method, driver, and multiplicity to Gaussian route keywords.
+
+    Parameters
+    ----------
+    method:
+        Method string from AtomicInput.model.method (case-insensitive).
+    driver:
+        One of "energy", "gradient", "hessian", "properties".
+    multiplicity:
+        Molecular spin multiplicity from AtomicInput.molecule.molecular_multiplicity.
+
+    Returns
+    -------
+    dict with keys:
+        "method_string": Gaussian method token (e.g. "HF", "UB3LYP").
+        "job_type":      Gaussian job-type keyword (e.g. "Force=NoStep", "Freq").
+        "extra_keywords": Dict of additional route tokens (e.g. {"Pop": "Full"}).
+
+    Raises
+    ------
+    InputError
+        If driver is not one of the four supported values.
+    """
+    # rq-b49bb2a2 rq-e008c6fe
+    driver = driver.lower()
+    if driver not in _SUPPORTED_DRIVERS:
+        raise InputError(
+            f"Driver '{driver}' is not supported by the Gaussian harness. "
+            f"Supported drivers: {sorted(_SUPPORTED_DRIVERS)}"
+        )
+
+    # rq-a88c706f
+    method_lower = method.lower()
+    # rq-ef62979b rq-0199bb02 rq-7049aaa5 rq-546faafb rq-2052a2fa rq-92492893 rq-851d782c rq-079b1e22
+    method_string = _METHOD_MAP.get(method_lower, method.upper())
+
+    # rq-4d763c6d rq-972b6470 rq-6d73bb9e rq-c946c285 rq-25c4ad49 rq-fe13245b
+    if multiplicity > 1:
+        upper = method_string.upper()
+        if not (upper.startswith("U") or upper.startswith("RO")):
+            method_string = "U" + method_string
+
+    # rq-c266b9bb rq-f1c116db rq-82942b90 rq-f512b60b
+    job_type = _DRIVER_JOB_TYPE[driver]
+
+    # rq-f512b60b
+    extra_keywords: Dict[str, str] = {}
+    if driver == "properties":
+        extra_keywords["Pop"] = "Full"
+
+    return {
+        "method_string": method_string,
+        "job_type": job_type,
+        "extra_keywords": extra_keywords,
+    }

--- a/qcengine/programs/gaussian/germinate.py
+++ b/qcengine/programs/gaussian/germinate.py
@@ -14,6 +14,7 @@ _METHOD_MAP = {
     "mp2": "MP2",
     "ccsd": "CCSD",
     "ccsd(t)": "CCSD(T)",
+    "ccsd(t,full)": "CCSD(T,Full)",
 }
 
 # rq-ef62979b rq-c266b9bb rq-f1c116db rq-82942b90 rq-f512b60b

--- a/qcengine/programs/gaussian/germinate.py
+++ b/qcengine/programs/gaussian/germinate.py
@@ -12,6 +12,10 @@ _METHOD_MAP = {
     "hf": "HF",
     "scf": "HF",
     "mp2": "MP2",
+    # rq-2cb2c5c0 — Gaussian's analytic MP2 gradient requires the Full
+    # option be attached to the method spec (e.g. "MP2(Full)/basis"); the
+    # alternative "MP2=Full" route keyword works for energy only.
+    "mp2(full)": "MP2(Full)",
     "ccsd": "CCSD",
     "ccsd(t)": "CCSD(T)",
     "ccsd(t,full)": "CCSD(T,Full)",

--- a/qcengine/programs/gaussian/germinate.py
+++ b/qcengine/programs/gaussian/germinate.py
@@ -1,8 +1,9 @@
 """Map QCSchema method/driver/multiplicity to Gaussian route-section components."""
 
-from typing import Any, Dict
+from typing import Any, Dict, Optional, Tuple
 
 from qcengine.exceptions import InputError
+from qcengine.programs.empirical_dispersion_resources import get_dispersion_aliases
 
 # rq-ef62979b rq-a88c706f rq-b49bb2a2 rq-4d763c6d
 _SUPPORTED_DRIVERS = {"energy", "gradient", "hessian", "properties"}
@@ -28,6 +29,56 @@ _DRIVER_JOB_TYPE = {
     "hessian": "Freq",
     "properties": "",
 }
+
+# rq-0c1b5066 — canonical-dashlevel-key → (Gaussian EmpiricalDispersion value, formal label).
+# Only the levels Gaussian natively supports via its EmpiricalDispersion keyword
+# are listed here; other dispersion levels in QCEngine's alias table (D3M, D3OP,
+# D4, NL, etc.) trigger an InputError.
+_GAUSSIAN_DISPERSION_MAP = {
+    "d2":       ("GD2",   "D2"),
+    "d3zero2b": ("GD3",   "D3"),
+    "d3bj2b":   ("GD3BJ", "D3(BJ)"),
+}
+
+
+# rq-0c1b5066 rq-f357f8db
+def recognize_dispersion(method: str) -> Tuple[str, Optional[str], Optional[str], Optional[str]]:
+    """Strip a recognised dispersion suffix from a method string.
+
+    Returns ``(functional, gaussian_keyword, formal_label, canonical_key)``:
+
+    - ``functional``     — the method with any dispersion suffix removed
+      (original casing preserved). Equal to ``method`` if no suffix found.
+    - ``gaussian_keyword`` — Gaussian ``EmpiricalDispersion`` value (e.g.
+      ``"GD3"``), or ``None`` if no suffix found.
+    - ``formal_label``   — formal dispersion label (e.g. ``"D3(BJ)"``), or
+      ``None`` if no suffix found.
+    - ``canonical_key``  — QCEngine canonical dashlevel key (e.g. ``"d3bj2b"``),
+      or ``None`` if no suffix found.
+
+    Raises ``InputError`` when the method ends in a recognised dispersion suffix
+    that Gaussian does not natively support (e.g. D3M, D3OP, D4, NL).
+    """
+    method_lower = method.lower()
+    aliases = get_dispersion_aliases()
+
+    # Longest alias wins so that "d3bj" matches before "d3" + stray "bj".
+    for alias in sorted(aliases, key=len, reverse=True):
+        suffix = f"-{alias}"
+        if method_lower.endswith(suffix):
+            canonical_key = aliases[alias]
+            if canonical_key not in _GAUSSIAN_DISPERSION_MAP:
+                supported = sorted({fmt for _, fmt in _GAUSSIAN_DISPERSION_MAP.values()})
+                raise InputError(
+                    f"Dispersion level '-{alias}' (canonical: '{canonical_key}') is not "
+                    f"natively supported by the Gaussian harness. "
+                    f"Supported dispersion levels: {supported}."
+                )
+            gaussian_keyword, formal_label = _GAUSSIAN_DISPERSION_MAP[canonical_key]
+            functional = method[: -len(suffix)]
+            return functional, gaussian_keyword, formal_label, canonical_key
+
+    return method, None, None, None
 
 
 def muster_modelchem(method: str, driver: str, multiplicity: int) -> Dict[str, Any]:
@@ -62,10 +113,15 @@ def muster_modelchem(method: str, driver: str, multiplicity: int) -> Dict[str, A
             f"Supported drivers: {sorted(_SUPPORTED_DRIVERS)}"
         )
 
+    # rq-0c1b5066 — split off any empirical-dispersion suffix BEFORE mapping
+    # the functional to a Gaussian route token. recognize_dispersion raises
+    # InputError on unsupported dispersion levels.
+    functional, emp_disp_value, dispersion_level, _ = recognize_dispersion(method)
+
     # rq-a88c706f
-    method_lower = method.lower()
+    functional_lower = functional.lower()
     # rq-ef62979b rq-0199bb02 rq-7049aaa5 rq-546faafb rq-2052a2fa rq-92492893 rq-851d782c rq-079b1e22
-    method_string = _METHOD_MAP.get(method_lower, method.upper())
+    method_string = _METHOD_MAP.get(functional_lower, functional.upper())
 
     # rq-4d763c6d rq-972b6470 rq-6d73bb9e rq-c946c285 rq-25c4ad49 rq-fe13245b
     if multiplicity > 1:
@@ -81,8 +137,17 @@ def muster_modelchem(method: str, driver: str, multiplicity: int) -> Dict[str, A
     if driver == "properties":
         extra_keywords["Pop"] = "Full"
 
-    return {
+    # rq-0c1b5066 — empirical dispersion: emit the Gaussian route keyword and
+    # surface dispersion_level/functional_name so downstream code (harvester,
+    # conflict detection) can use them.
+    result: Dict[str, Any] = {
         "method_string": method_string,
         "job_type": job_type,
         "extra_keywords": extra_keywords,
     }
+    if emp_disp_value is not None:
+        extra_keywords["EmpiricalDispersion"] = emp_disp_value
+        result["dispersion_level"] = dispersion_level
+        result["functional_name"] = functional.upper()
+
+    return result

--- a/qcengine/programs/gaussian/harvester.py
+++ b/qcengine/programs/gaussian/harvester.py
@@ -1,0 +1,172 @@
+"""Parse Gaussian log output using cclib with regex fallback."""
+
+import io
+import re
+from typing import Optional, Tuple
+
+import numpy as np
+import qcelemental as qcel
+from qcelemental.models import Molecule
+
+from ..util import PreservingDict
+
+# rq-bb0a5d96 rq-c20746b1
+_NORMAL_TERMINATION_RE = re.compile(r"Normal termination of Gaussian")
+_VERSION_RE = re.compile(r"Gaussian\s+(\d+),\s+Revision\s+([\w.]+),")
+
+# eV → Hartree conversion factor
+# rq-bb0a5d96
+_EV_TO_HARTREE = qcel.constants.conversion_factor("eV", "hartree")
+
+
+# rq-d9434480
+def harvest(
+    in_mol: Molecule,
+    method: str,
+    log_content: str,
+) -> Tuple[PreservingDict, Optional[np.ndarray], Optional[np.ndarray], Molecule]:
+    """Parse a Gaussian log file and return QC data for building an AtomicResult.
+
+    Parameters
+    ----------
+    in_mol:
+        The input molecule used for geometry alignment and NRE cross-check.
+    method:
+        Lowercase QCSchema method string (e.g. "hf", "mp2", "b3lyp").
+    log_content:
+        Full text of gaussian.log.
+
+    Returns
+    -------
+    (qcvars, grad, hess, out_mol)
+        qcvars:  PreservingDict of QC variables (energies, charges, etc.).
+        grad:    Gradient array shape (3*natoms,) in Hartree/Bohr, or None.
+        hess:    Hessian matrix shape (3*natoms, 3*natoms) in Hartree/Bohr², or None.
+        out_mol: Output molecule aligned to in_mol.
+
+    Raises
+    ------
+    ValueError
+        If no coordinate information can be extracted from the log.
+    ValueError
+        If the parsed geometry's NRE deviates from in_mol's by more than 1e-3 Hartree.
+    """
+    # rq-bb0a5d96 — parse with cclib; exceptions propagate to caller (rq-bb775969)
+    import cclib
+
+    ccdata = cclib.io.ccopen(io.StringIO(log_content)).parse()
+
+    qcvars = PreservingDict()
+    method_lower = method.lower()
+
+    # --- Geometry and output molecule ---
+    # rq-8d6fc024 rq-a76c3d7b rq-b7c7b8cb
+    if not hasattr(ccdata, "atomcoords") or len(ccdata.atomcoords) == 0:
+        raise ValueError("No coordinate information could be extracted from the Gaussian log.")
+
+    # atomcoords in Ångström → convert to Bohr for QCElemental
+    angstrom_to_bohr = qcel.constants.conversion_factor("angstrom", "bohr")
+    coords_bohr = ccdata.atomcoords[-1] * angstrom_to_bohr  # shape (natoms, 3)
+
+    symbols = [qcel.periodictable.to_symbol(z) for z in ccdata.atomnos]
+
+    calc_mol = Molecule(
+        symbols=symbols,
+        geometry=coords_bohr.flatten(),
+        fix_com=True,
+        fix_orientation=True,
+    )
+
+    natoms = len(ccdata.atomnos)
+    qcvars["N ATOMS"] = str(natoms)
+
+    # rq-0753cd03
+    qcvars["NUCLEAR REPULSION ENERGY"] = str(round(calc_mol.nuclear_repulsion_energy(), 10))
+
+    # rq-90604835 — cross-check NRE against input molecule
+    if abs(calc_mol.nuclear_repulsion_energy() - in_mol.nuclear_repulsion_energy()) > 1.0e-3:
+        raise ValueError(
+            f"Gaussian output geometry (NRE: {calc_mol.nuclear_repulsion_energy():.6f}) "
+            f"is inconsistent with the input molecule (NRE: {in_mol.nuclear_repulsion_energy():.6f})."
+        )
+
+    # Align output molecule to input molecule (same pattern as GAMESS harvester)
+    # rq-8d6fc024
+    return_mol, _ = in_mol.align(calc_mol, atoms_map=False, mols_align=True, run_mirror=True, verbose=0)
+
+    # --- Energies ---
+    # rq-37f40e92 — HF/SCF energy is always extracted from scfenergies
+    scf_hartree = float(ccdata.scfenergies[-1]) * _EV_TO_HARTREE
+    qcvars["HF TOTAL ENERGY"] = str(scf_hartree)
+
+    # rq-929a262a rq-c5165f1f — method-specific variables
+    if method_lower in ("hf", "scf") or _is_dft(method_lower):
+        qcvars["CURRENT ENERGY"] = str(scf_hartree)
+
+    elif method_lower == "mp2":
+        # rq-578bb785
+        mp2_hartree = float(ccdata.mpenergies[-1][-1]) * _EV_TO_HARTREE
+        qcvars["MP2 TOTAL ENERGY"] = str(mp2_hartree)
+        qcvars["MP2 CORRELATION ENERGY"] = str(mp2_hartree - scf_hartree)
+        qcvars["CURRENT ENERGY"] = str(mp2_hartree)
+
+    elif method_lower == "ccsd":
+        # rq-1b7ae62e
+        ccsd_hartree = float(ccdata.ccenergies[-1]) * _EV_TO_HARTREE
+        qcvars["CCSD TOTAL ENERGY"] = str(ccsd_hartree)
+        qcvars["CCSD CORRELATION ENERGY"] = str(ccsd_hartree - scf_hartree)
+        qcvars["CURRENT ENERGY"] = str(ccsd_hartree)
+
+    elif method_lower == "ccsd(t)":
+        # rq-eddef743
+        # cclib stores CCSD(T) energy in ccenergies for Gaussian
+        ccsdt_hartree = float(ccdata.ccenergies[-1]) * _EV_TO_HARTREE
+        qcvars["CCSD(T) TOTAL ENERGY"] = str(ccsdt_hartree)
+        qcvars["CCSD(T) CORRELATION ENERGY"] = str(ccsdt_hartree - scf_hartree)
+        # Also populate CCSD energy if cclib exposes it separately
+        # (cclib may not separate CCSD and CCSD(T) — use what we have)
+        qcvars["CURRENT ENERGY"] = str(ccsdt_hartree)
+
+    else:
+        # Unknown method: fall back to SCF energy
+        qcvars["CURRENT ENERGY"] = str(scf_hartree)
+
+    # --- Gradient (forces → negate for gradient) ---
+    # rq-36736115 rq-3b0adf96
+    grad: Optional[np.ndarray] = None
+    if hasattr(ccdata, "grads") and ccdata.grads is not None and len(ccdata.grads) > 0:
+        # ccdata.grads shape: (nsteps, natoms, 3) in Hartree/Bohr (forces = -dE/dR)
+        # Gradient = -forces
+        grad = (-ccdata.grads[-1]).flatten()
+
+    # --- Hessian ---
+    # rq-f2e32162 rq-344f3432
+    hess: Optional[np.ndarray] = None
+    if hasattr(ccdata, "hessian") and ccdata.hessian is not None:
+        hess = np.array(ccdata.hessian)
+
+    # --- Properties: dipole and Mulliken charges ---
+    # rq-c7fd08b5 rq-943856cc rq-53f8ed12 rq-4c4a1542 rq-ffae3fa6
+    if hasattr(ccdata, "moments") and ccdata.moments is not None and len(ccdata.moments) > 1:
+        dipole_vec = np.array(ccdata.moments[1])
+        qcvars["DIPOLE MOMENT"] = str(float(np.linalg.norm(dipole_vec)))
+
+    if hasattr(ccdata, "atomcharges") and ccdata.atomcharges:
+        mulliken = ccdata.atomcharges.get("mulliken")
+        if mulliken is not None:
+            qcvars["MULLIKEN CHARGES"] = list(mulliken)
+
+    return qcvars, grad, hess, return_mol
+
+
+def is_normal_termination(log_content: str) -> bool:
+    """Return True if the log contains a normal termination marker.
+
+    rq-90141f40 rq-12c41d5e rq-c20746b1
+    """
+    return bool(_NORMAL_TERMINATION_RE.search(log_content))
+
+
+def _is_dft(method_lower: str) -> bool:
+    """Return True for method strings that are not recognised wavefunction methods."""
+    return method_lower not in ("hf", "scf", "mp2", "ccsd", "ccsd(t)")

--- a/qcengine/programs/gaussian/harvester.py
+++ b/qcengine/programs/gaussian/harvester.py
@@ -27,6 +27,10 @@ _SCF_DONE_RE = re.compile(r"SCF Done:\s+E\(\S+\)\s*=\s*([-\d.]+)")
 _MP2_ENERGY_RE = re.compile(r"EUMP2\s*=\s*([-\d.DE+]+)")
 _CCSD_T_ENERGY_RE = re.compile(r"CCSD\(T\)=\s*([-\d.DE+]+)")
 _CCSD_ENERGY_RE = re.compile(r"DE\(Corr\)=\s*[-\d.]+\s+E\(CORR\)=\s*([-\d.]+)")
+# rq-1d5da737 — Gaussian writes "Dispersion energy=  <value> Hartrees." in the
+# log when EmpiricalDispersion is active. Direct regex parsing avoids cclib's
+# eV round-trip.
+_DISPERSION_ENERGY_RE = re.compile(r"Dispersion energy=\s*([-\d.]+)\s*Hartrees?")
 
 
 def _fortran_float(s: str) -> float:
@@ -120,6 +124,16 @@ def harvest(
 
     qcvars = PreservingDict()
     method_lower = method.lower()
+
+    # rq-1d5da737 — Strip an empirical-dispersion suffix from the method so the
+    # existing per-method energy extraction below sees just the functional name.
+    # The stripped suffix is retained as `dispersion_level` / `functional_label`
+    # so the qcvars at the end of this function can be tagged correctly.
+    from .germinate import recognize_dispersion
+
+    functional, _emp_disp_value, dispersion_level, _ = recognize_dispersion(method)
+    method_lower = functional.lower()
+    functional_label = functional.upper() if dispersion_level is not None else None
 
     # Normalise method variants: strip Gaussian-specific sub-options like ",full"
     # so that energy-extraction logic sees the canonical method name.
@@ -268,6 +282,37 @@ def harvest(
     else:
         # Unknown method: fall back to SCF energy
         qcvars["CURRENT ENERGY"] = str(scf_hartree)
+
+    # --- Empirical dispersion correction ---
+    # rq-1d5da737 — Gaussian writes the dispersion contribution on a separate
+    # "Dispersion energy=" line; cclib keeps it out of `scfenergies` and stores
+    # it in `dispersionenergies`. Add it to the SCF total when present.
+    disp_hartree: Optional[float] = None
+    disp_match = _DISPERSION_ENERGY_RE.search(log_content)
+    if disp_match:
+        disp_hartree = float(disp_match.group(1))
+    elif (
+        hasattr(ccdata, "dispersionenergies")
+        and ccdata.dispersionenergies is not None
+        and len(ccdata.dispersionenergies) > 0
+    ):
+        disp_hartree = float(ccdata.dispersionenergies[-1]) * _EV_TO_HARTREE
+
+    if disp_hartree is not None:
+        qcvars["DISPERSION CORRECTION ENERGY"] = str(disp_hartree)
+        # Only emit the dispersion-corrected DFT total when this was a DFT
+        # branch (i.e. CURRENT ENERGY currently == SCF). Post-HF branches
+        # (MP2/CCSD/CCSD(T)) handle their own totals.
+        if method_lower in ("hf", "scf") or _is_dft(method_lower):
+            qcvars["CURRENT ENERGY"] = str(scf_hartree + disp_hartree)
+        # Functional-specific qcvars (Psi4 convention) are emitted only when
+        # the input method carried a recognised dispersion suffix, so we know
+        # the formal dash label.
+        if dispersion_level is not None and functional_label is not None:
+            tag = f"{functional_label}-{dispersion_level}"
+            qcvars[f"{tag} DISPERSION CORRECTION ENERGY"] = str(disp_hartree)
+            qcvars[f"{tag} TOTAL ENERGY"] = str(scf_hartree + disp_hartree)
+            qcvars[f"{functional_label} FUNCTIONAL TOTAL ENERGY"] = str(scf_hartree)
 
     # --- Gradient (forces → negate for gradient) ---
     # rq-36736115 rq-3b0adf96

--- a/qcengine/programs/gaussian/harvester.py
+++ b/qcengine/programs/gaussian/harvester.py
@@ -126,6 +126,8 @@ def harvest(
     # e.g. "ccsd(t,full)" → "ccsd(t)"
     _METHOD_NORMALISE = {
         "ccsd(t,full)": "ccsd(t)",
+        # rq-2cb2c5c0
+        "mp2(full)": "mp2",
     }
     method_lower = _METHOD_NORMALISE.get(method_lower, method_lower)
 

--- a/qcengine/programs/gaussian/harvester.py
+++ b/qcengine/programs/gaussian/harvester.py
@@ -138,14 +138,35 @@ def harvest(
     angstrom_to_bohr = qcel.constants.conversion_factor("angstrom", "bohr")
     coords_bohr = ccdata.atomcoords[-1] * angstrom_to_bohr  # shape (natoms, 3)
 
-    symbols = [qcel.periodictable.to_symbol(z) for z in ccdata.atomnos]
+    # rq-f1d712bb rq-66067019 rq-7411efa0 — cclib cannot distinguish ghost atoms
+    # from real ones in Gaussian output (Gaussian marks ghosts via the "Atomic Type"
+    # column = 1000, which cclib does not expose). Trust in_mol.real as the sole
+    # source of ghost designation; sanity-check only that the parsed atom count
+    # matches in_mol when ghosts are present.
+    in_real = list(in_mol.real)
+    has_ghosts = not all(in_real)
+    if has_ghosts:
+        if len(ccdata.atomnos) != len(in_mol.symbols):
+            raise ValueError(
+                f"Gaussian log atom count ({len(ccdata.atomnos)}) does not match the "
+                f"input molecule's atom count ({len(in_mol.symbols)})."
+            )
+        symbols = list(in_mol.symbols)
+        real_flags = in_real
+    else:
+        symbols = [qcel.periodictable.to_symbol(z) for z in ccdata.atomnos]
+        real_flags = None
 
-    calc_mol = Molecule(
+    # rq-f1d712bb — preserve ghost designation on calc_mol so its NRE excludes ghosts
+    calc_mol_kwargs = dict(
         symbols=symbols,
         geometry=coords_bohr.flatten(),
         fix_com=True,
         fix_orientation=True,
     )
+    if real_flags is not None:
+        calc_mol_kwargs["real"] = real_flags
+    calc_mol = Molecule(**calc_mol_kwargs)
 
     natoms = len(ccdata.atomnos)
     qcvars["N ATOMS"] = str(natoms)
@@ -163,7 +184,9 @@ def harvest(
     # rq-0753cd03
     qcvars["NUCLEAR REPULSION ENERGY"] = str(round(calc_mol.nuclear_repulsion_energy(), 10))
 
-    # rq-90604835 — cross-check NRE against input molecule
+    # rq-90604835 rq-a69d0898 rq-e5a98119 — cross-check NRE against input molecule.
+    # Molecule.nuclear_repulsion_energy() excludes ghost atoms (zero Z), so when
+    # calc_mol.real mirrors in_mol.real both NREs sum over real atoms only.
     if abs(calc_mol.nuclear_repulsion_energy() - in_mol.nuclear_repulsion_energy()) > 1.0e-3:
         raise ValueError(
             f"Gaussian output geometry (NRE: {calc_mol.nuclear_repulsion_energy():.6f}) "
@@ -171,14 +194,17 @@ def harvest(
         )
 
     # Frame considerations (same pattern as GAMESS harvester)
-    # rq-8d6fc024
+    # rq-8d6fc024 rq-f8ce079b
+    align_kwargs = dict(atoms_map=False, mols_align=True, run_mirror=True, verbose=0)
+    if has_ghosts:
+        align_kwargs["generic_ghosts"] = True
     if in_mol.fix_com and in_mol.fix_orientation:
         # Impose input frame if important as signalled by fix_*=True
         return_mol = in_mol
-        _, data = calc_mol.align(in_mol, atoms_map=False, mols_align=True, run_mirror=True, verbose=0)
+        _, data = calc_mol.align(in_mol, **align_kwargs)
         mill = data["mill"]
     else:
-        return_mol, _ = in_mol.align(calc_mol, atoms_map=False, mols_align=True, run_mirror=True, verbose=0)
+        return_mol, _ = in_mol.align(calc_mol, **align_kwargs)
         mill = qcel.molutil.compute_scramble(
             len(in_mol.symbols), do_resort=False, do_shift=False, do_rotate=False, do_mirror=False
         )  # identity AlignmentMill
@@ -269,7 +295,8 @@ def harvest(
                 # return_mol is in calc/standard frame; need to transform
                 # hessian from input→standard. The mill from calc_mol.align(in_mol)
                 # transforms calc→input, so we need input→calc.
-                _, data = in_mol.align(calc_mol, atoms_map=False, mols_align=True, run_mirror=True, verbose=0)
+                # rq-f8ce079b
+                _, data = in_mol.align(calc_mol, **align_kwargs)
                 input_to_calc_mill = data["mill"]
                 hess = input_to_calc_mill.align_hessian(parsed_hess)
 

--- a/qcengine/programs/gaussian/harvester.py
+++ b/qcengine/programs/gaussian/harvester.py
@@ -1,4 +1,4 @@
-"""Parse Gaussian log output using cclib with regex fallback."""
+"""Parse Gaussian log output using cclib for energies + regex for the few items cclib doesn't expose."""
 
 import io
 import re
@@ -10,34 +10,20 @@ from qcelemental.models import Molecule
 
 from ..util import PreservingDict
 
-# rq-bb0a5d96 rq-c20746b1
+# rq-0743e952
 _NORMAL_TERMINATION_RE = re.compile(r"Normal termination of Gaussian")
 _VERSION_RE = re.compile(r"Gaussian\s+(\d+),\s+Revision\s+([\w.]+),")
 
 
-# rq-bb0a5d96 — eV → Hartree fallback converter.
-# Uses cclib's own conversion factor (via cclib.parser.utils.convertor) rather
-# than qcelemental's: cclib stores ccdata.scfenergies / mpenergies / ccenergies
-# / dispersionenergies in eV using its internal Hartree↔eV factor (27.21138505).
-# Reversing with cclib's factor is an exact round-trip; reversing with qcel's
-# factor (27.21138602) introduces a ~3.6e-6 Ha bias that exceeds the
-# cross-program tolerances. This also keeps the fallback forward-compatible
-# with any future CODATA refresh in cclib.
+# rq-f6537c40 — eV → Hartree converter for cclib-stored energies.
+# cclib stores ccdata.scfenergies / mpenergies / ccenergies / dispersionenergies
+# in eV using its internal Hartree↔eV factor (27.21138505). Reversing with
+# cclib's own factor (via cclib.parser.utils.convertor) is a structurally exact
+# round-trip (≤ 1 ULP); reversing with qcel's factor (27.21138602) introduces a
+# ~3.6e-6 Ha bias that exceeds cross-program tolerances.
 def _cclib_ev_to_hartree(value_ev: float) -> float:
     from cclib.parser.utils import convertor
     return convertor(value_ev, "eV", "hartree")
-
-# Regex patterns for parsing energies directly from Gaussian log in Hartree.
-# These bypass cclib's eV round-trip which causes ~1e-6 precision loss due to
-# a conversion-factor mismatch between cclib and qcelemental.
-_SCF_DONE_RE = re.compile(r"SCF Done:\s+E\(\S+\)\s*=\s*([-\d.]+)")
-_MP2_ENERGY_RE = re.compile(r"EUMP2\s*=\s*([-\d.DE+]+)")
-_CCSD_T_ENERGY_RE = re.compile(r"CCSD\(T\)=\s*([-\d.DE+]+)")
-_CCSD_ENERGY_RE = re.compile(r"DE\(Corr\)=\s*[-\d.]+\s+E\(CORR\)=\s*([-\d.]+)")
-# rq-1d5da737 — Gaussian writes "Dispersion energy=  <value> Hartrees." in the
-# log when EmpiricalDispersion is active. Direct regex parsing avoids cclib's
-# eV round-trip.
-_DISPERSION_ENERGY_RE = re.compile(r"Dispersion energy=\s*([-\d.]+)\s*Hartrees?")
 
 
 def _fortran_float(s: str) -> float:
@@ -233,18 +219,14 @@ def harvest(
         )  # identity AlignmentMill
 
     # --- Energies ---
-    # Parse energies directly from the Gaussian log in Hartree as the primary
-    # path; this preserves Gaussian's full printed precision. Fall back to
-    # cclib's stored value (in eV) only if the regex fails, converting via
-    # cclib.parser.utils.convertor so the eV→Ha reversal uses cclib's own
-    # factor and is exact relative to how cclib stored the quantity.
+    # Read all SCF, MP*, and CC energies from cclib's parsed attributes,
+    # converting eV→Hartree via cclib's own converter (structurally exact;
+    # ≤ 1 ULP round-trip).
 
-    # rq-37f40e92 — HF/SCF energy
-    scf_match = _SCF_DONE_RE.search(log_content)
-    if scf_match:
-        scf_hartree = float(scf_match.group(1))
-    else:
-        scf_hartree = _cclib_ev_to_hartree(float(ccdata.scfenergies[-1]))
+    # rq-37f40e92 — HF/SCF energy from cclib.
+    if not hasattr(ccdata, "scfenergies") or ccdata.scfenergies is None or len(ccdata.scfenergies) == 0:
+        raise ValueError("cclib did not populate `scfenergies` for this Gaussian log.")
+    scf_hartree = _cclib_ev_to_hartree(float(ccdata.scfenergies[-1]))
     qcvars["HF TOTAL ENERGY"] = str(scf_hartree)
     qcvars["SCF TOTAL ENERGY"] = str(scf_hartree)
     qcvars["CURRENT REFERENCE ENERGY"] = str(scf_hartree)
@@ -255,34 +237,29 @@ def harvest(
 
     elif method_lower == "mp2":
         # rq-578bb785
-        mp2_match = _MP2_ENERGY_RE.search(log_content)
-        if mp2_match:
-            mp2_hartree = _fortran_float(mp2_match.group(1))
-        else:
-            mp2_hartree = _cclib_ev_to_hartree(float(ccdata.mpenergies[-1][-1]))
+        if not hasattr(ccdata, "mpenergies") or ccdata.mpenergies is None or len(ccdata.mpenergies) == 0:
+            raise ValueError("cclib did not populate `mpenergies` for this MP2 Gaussian log.")
+        mp2_hartree = _cclib_ev_to_hartree(float(ccdata.mpenergies[-1][-1]))
         qcvars["MP2 TOTAL ENERGY"] = str(mp2_hartree)
         qcvars["MP2 CORRELATION ENERGY"] = str(mp2_hartree - scf_hartree)
         qcvars["CURRENT ENERGY"] = str(mp2_hartree)
 
     elif method_lower == "ccsd":
         # rq-1b7ae62e
-        # Find the last converged CCSD energy from the iteration lines
-        ccsd_matches = list(_CCSD_ENERGY_RE.finditer(log_content))
-        if ccsd_matches:
-            ccsd_hartree = float(ccsd_matches[-1].group(1))
-        else:
-            ccsd_hartree = _cclib_ev_to_hartree(float(ccdata.ccenergies[-1]))
+        if not hasattr(ccdata, "ccenergies") or ccdata.ccenergies is None or len(ccdata.ccenergies) == 0:
+            raise ValueError("cclib did not populate `ccenergies` for this CCSD Gaussian log.")
+        ccsd_hartree = _cclib_ev_to_hartree(float(ccdata.ccenergies[-1]))
         qcvars["CCSD TOTAL ENERGY"] = str(ccsd_hartree)
         qcvars["CCSD CORRELATION ENERGY"] = str(ccsd_hartree - scf_hartree)
         qcvars["CURRENT ENERGY"] = str(ccsd_hartree)
 
     elif method_lower == "ccsd(t)":
-        # rq-eddef743
-        ccsdt_match = _CCSD_T_ENERGY_RE.search(log_content)
-        if ccsdt_match:
-            ccsdt_hartree = _fortran_float(ccsdt_match.group(1))
-        else:
-            ccsdt_hartree = _cclib_ev_to_hartree(float(ccdata.ccenergies[-1]))
+        # rq-eddef743 — cclib's ccenergies for a CCSD(T) job holds only the
+        # CCSD(T) total (the intermediate CCSD value is not separately stored),
+        # so no CCSD qcvar is emitted here.
+        if not hasattr(ccdata, "ccenergies") or ccdata.ccenergies is None or len(ccdata.ccenergies) == 0:
+            raise ValueError("cclib did not populate `ccenergies` for this CCSD(T) Gaussian log.")
+        ccsdt_hartree = _cclib_ev_to_hartree(float(ccdata.ccenergies[-1]))
         qcvars["CCSD(T) TOTAL ENERGY"] = str(ccsdt_hartree)
         qcvars["CCSD(T) CORRELATION ENERGY"] = str(ccsdt_hartree - scf_hartree)
         qcvars["CURRENT ENERGY"] = str(ccsdt_hartree)
@@ -293,13 +270,11 @@ def harvest(
 
     # --- Empirical dispersion correction ---
     # rq-1d5da737 — Gaussian writes the dispersion contribution on a separate
-    # "Dispersion energy=" line; cclib keeps it out of `scfenergies` and stores
-    # it in `dispersionenergies`. Add it to the SCF total when present.
+    # "Dispersion energy=" line; cclib keeps it out of `scfenergies` and
+    # stores it (in eV) in `dispersionenergies`. Add it to the SCF total when
+    # present.
     disp_hartree: Optional[float] = None
-    disp_match = _DISPERSION_ENERGY_RE.search(log_content)
-    if disp_match:
-        disp_hartree = float(disp_match.group(1))
-    elif (
+    if (
         hasattr(ccdata, "dispersionenergies")
         and ccdata.dispersionenergies is not None
         and len(ccdata.dispersionenergies) > 0

--- a/qcengine/programs/gaussian/harvester.py
+++ b/qcengine/programs/gaussian/harvester.py
@@ -14,9 +14,71 @@ from ..util import PreservingDict
 _NORMAL_TERMINATION_RE = re.compile(r"Normal termination of Gaussian")
 _VERSION_RE = re.compile(r"Gaussian\s+(\d+),\s+Revision\s+([\w.]+),")
 
-# eV → Hartree conversion factor
+# eV → Hartree conversion factor (only used as fallback for cclib quantities
+# that have no direct Hartree regex; direct log parsing is preferred for
+# energies to avoid precision loss from cclib's slightly different eV factor).
 # rq-bb0a5d96
 _EV_TO_HARTREE = qcel.constants.conversion_factor("eV", "hartree")
+
+# Regex patterns for parsing energies directly from Gaussian log in Hartree.
+# These bypass cclib's eV round-trip which causes ~1e-6 precision loss due to
+# a conversion-factor mismatch between cclib and qcelemental.
+_SCF_DONE_RE = re.compile(r"SCF Done:\s+E\(\S+\)\s*=\s*([-\d.]+)")
+_MP2_ENERGY_RE = re.compile(r"EUMP2\s*=\s*([-\d.DE+]+)")
+_CCSD_T_ENERGY_RE = re.compile(r"CCSD\(T\)=\s*([-\d.DE+]+)")
+_CCSD_ENERGY_RE = re.compile(r"DE\(Corr\)=\s*[-\d.]+\s+E\(CORR\)=\s*([-\d.]+)")
+
+
+def _fortran_float(s: str) -> float:
+    """Convert a Fortran-style D-exponent string (e.g. '-0.76D+02') to float."""
+    return float(s.replace("D", "E").replace("d", "e"))
+
+
+def _parse_force_constants(log_content: str, ndim: int) -> Optional[np.ndarray]:
+    """Parse the lower-triangle 'Force constants in Cartesian coordinates' block
+    from a Gaussian Freq log into a full symmetric (ndim, ndim) matrix.
+
+    Returns None if the block is not found.
+    """
+    marker = "Force constants in Cartesian coordinates:"
+    idx = log_content.find(marker)
+    if idx == -1:
+        return None
+
+    # Extract the block: starts after marker, ends at "Leave Link"
+    block_start = idx + len(marker)
+    block_end = log_content.find("Leave Link", block_start)
+    if block_end == -1:
+        block_end = len(log_content)
+    block = log_content[block_start:block_end]
+
+    hess = np.zeros((ndim, ndim))
+    # Parse lower-triangle entries: row lines have format "  <row>  <val1> <val2> ..."
+    # Column header lines have format "       <col1>  <col2>  ..."
+    col_offset = 0
+    for line in block.splitlines():
+        tokens = line.split()
+        if not tokens:
+            continue
+        # Column header line: all tokens are integers
+        try:
+            cols = [int(t) for t in tokens]
+            col_offset = cols[0] - 1  # 1-based → 0-based
+            continue
+        except ValueError:
+            pass
+        # Data line: first token is row index, rest are Fortran D-exponents
+        try:
+            row = int(tokens[0]) - 1  # 1-based → 0-based
+            vals = [_fortran_float(t) for t in tokens[1:]]
+        except (ValueError, IndexError):
+            continue
+        for j, val in enumerate(vals):
+            c = col_offset + j
+            hess[row, c] = val
+            hess[c, row] = val  # symmetric
+
+    return hess
 
 
 # rq-d9434480
@@ -88,6 +150,16 @@ def harvest(
     natoms = len(ccdata.atomnos)
     qcvars["N ATOMS"] = str(natoms)
 
+    if hasattr(ccdata, "nbasis") and ccdata.nbasis is not None:
+        qcvars["N BASIS FUNCTIONS"] = str(ccdata.nbasis)
+    if hasattr(ccdata, "nmo") and ccdata.nmo is not None:
+        qcvars["N MOLECULAR ORBITALS"] = str(ccdata.nmo)
+    # cclib doesn't have nalpha/nbeta directly; derive from homos array
+    if hasattr(ccdata, "homos") and ccdata.homos is not None:
+        qcvars["N ALPHA ELECTRONS"] = str(ccdata.homos[0] + 1)
+        nbeta = ccdata.homos[-1] + 1 if len(ccdata.homos) > 1 else ccdata.homos[0] + 1
+        qcvars["N BETA ELECTRONS"] = str(nbeta)
+
     # rq-0753cd03
     qcvars["NUCLEAR REPULSION ENERGY"] = str(round(calc_mol.nuclear_repulsion_energy(), 10))
 
@@ -112,9 +184,20 @@ def harvest(
         )  # identity AlignmentMill
 
     # --- Energies ---
-    # rq-37f40e92 — HF/SCF energy is always extracted from scfenergies
-    scf_hartree = float(ccdata.scfenergies[-1]) * _EV_TO_HARTREE
+    # Parse energies directly from the Gaussian log in Hartree to avoid
+    # precision loss from cclib's eV round-trip (cclib and qcelemental use
+    # slightly different Hartree↔eV conversion factors, causing ~1e-6 error).
+    # Fall back to cclib values if regex fails.
+
+    # rq-37f40e92 — HF/SCF energy
+    scf_match = _SCF_DONE_RE.search(log_content)
+    if scf_match:
+        scf_hartree = float(scf_match.group(1))
+    else:
+        scf_hartree = float(ccdata.scfenergies[-1]) * _EV_TO_HARTREE
     qcvars["HF TOTAL ENERGY"] = str(scf_hartree)
+    qcvars["SCF TOTAL ENERGY"] = str(scf_hartree)
+    qcvars["CURRENT REFERENCE ENERGY"] = str(scf_hartree)
 
     # rq-929a262a rq-c5165f1f — method-specific variables
     if method_lower in ("hf", "scf") or _is_dft(method_lower):
@@ -122,26 +205,36 @@ def harvest(
 
     elif method_lower == "mp2":
         # rq-578bb785
-        mp2_hartree = float(ccdata.mpenergies[-1][-1]) * _EV_TO_HARTREE
+        mp2_match = _MP2_ENERGY_RE.search(log_content)
+        if mp2_match:
+            mp2_hartree = _fortran_float(mp2_match.group(1))
+        else:
+            mp2_hartree = float(ccdata.mpenergies[-1][-1]) * _EV_TO_HARTREE
         qcvars["MP2 TOTAL ENERGY"] = str(mp2_hartree)
         qcvars["MP2 CORRELATION ENERGY"] = str(mp2_hartree - scf_hartree)
         qcvars["CURRENT ENERGY"] = str(mp2_hartree)
 
     elif method_lower == "ccsd":
         # rq-1b7ae62e
-        ccsd_hartree = float(ccdata.ccenergies[-1]) * _EV_TO_HARTREE
+        # Find the last converged CCSD energy from the iteration lines
+        ccsd_matches = list(_CCSD_ENERGY_RE.finditer(log_content))
+        if ccsd_matches:
+            ccsd_hartree = float(ccsd_matches[-1].group(1))
+        else:
+            ccsd_hartree = float(ccdata.ccenergies[-1]) * _EV_TO_HARTREE
         qcvars["CCSD TOTAL ENERGY"] = str(ccsd_hartree)
         qcvars["CCSD CORRELATION ENERGY"] = str(ccsd_hartree - scf_hartree)
         qcvars["CURRENT ENERGY"] = str(ccsd_hartree)
 
     elif method_lower == "ccsd(t)":
         # rq-eddef743
-        # cclib stores CCSD(T) energy in ccenergies for Gaussian
-        ccsdt_hartree = float(ccdata.ccenergies[-1]) * _EV_TO_HARTREE
+        ccsdt_match = _CCSD_T_ENERGY_RE.search(log_content)
+        if ccsdt_match:
+            ccsdt_hartree = _fortran_float(ccsdt_match.group(1))
+        else:
+            ccsdt_hartree = float(ccdata.ccenergies[-1]) * _EV_TO_HARTREE
         qcvars["CCSD(T) TOTAL ENERGY"] = str(ccsdt_hartree)
         qcvars["CCSD(T) CORRELATION ENERGY"] = str(ccsdt_hartree - scf_hartree)
-        # Also populate CCSD energy if cclib exposes it separately
-        # (cclib may not separate CCSD and CCSD(T) — use what we have)
         qcvars["CURRENT ENERGY"] = str(ccsdt_hartree)
 
     else:
@@ -161,7 +254,24 @@ def harvest(
     # rq-f2e32162 rq-344f3432
     hess: Optional[np.ndarray] = None
     if hasattr(ccdata, "hessian") and ccdata.hessian is not None:
+        # cclib hessian would be in standard orientation → transform with mill
         hess = mill.align_hessian(np.array(ccdata.hessian))
+    else:
+        # cclib does not parse force constants from Gaussian Freq output;
+        # fall back to direct log parsing. Gaussian's "Force constants in
+        # Cartesian coordinates" are in the INPUT orientation.
+        parsed_hess = _parse_force_constants(log_content, 3 * natoms)
+        if parsed_hess is not None:
+            if in_mol.fix_com and in_mol.fix_orientation:
+                # return_mol = in_mol (input frame), hessian already in input frame
+                hess = parsed_hess
+            else:
+                # return_mol is in calc/standard frame; need to transform
+                # hessian from input→standard. The mill from calc_mol.align(in_mol)
+                # transforms calc→input, so we need input→calc.
+                _, data = in_mol.align(calc_mol, atoms_map=False, mols_align=True, run_mirror=True, verbose=0)
+                input_to_calc_mill = data["mill"]
+                hess = input_to_calc_mill.align_hessian(parsed_hess)
 
     # --- Properties: dipole and Mulliken charges ---
     # rq-c7fd08b5 rq-943856cc rq-53f8ed12 rq-4c4a1542 rq-ffae3fa6

--- a/qcengine/programs/gaussian/harvester.py
+++ b/qcengine/programs/gaussian/harvester.py
@@ -14,11 +14,18 @@ from ..util import PreservingDict
 _NORMAL_TERMINATION_RE = re.compile(r"Normal termination of Gaussian")
 _VERSION_RE = re.compile(r"Gaussian\s+(\d+),\s+Revision\s+([\w.]+),")
 
-# eV → Hartree conversion factor (only used as fallback for cclib quantities
-# that have no direct Hartree regex; direct log parsing is preferred for
-# energies to avoid precision loss from cclib's slightly different eV factor).
-# rq-bb0a5d96
-_EV_TO_HARTREE = qcel.constants.conversion_factor("eV", "hartree")
+
+# rq-bb0a5d96 — eV → Hartree fallback converter.
+# Uses cclib's own conversion factor (via cclib.parser.utils.convertor) rather
+# than qcelemental's: cclib stores ccdata.scfenergies / mpenergies / ccenergies
+# / dispersionenergies in eV using its internal Hartree↔eV factor (27.21138505).
+# Reversing with cclib's factor is an exact round-trip; reversing with qcel's
+# factor (27.21138602) introduces a ~3.6e-6 Ha bias that exceeds the
+# cross-program tolerances. This also keeps the fallback forward-compatible
+# with any future CODATA refresh in cclib.
+def _cclib_ev_to_hartree(value_ev: float) -> float:
+    from cclib.parser.utils import convertor
+    return convertor(value_ev, "eV", "hartree")
 
 # Regex patterns for parsing energies directly from Gaussian log in Hartree.
 # These bypass cclib's eV round-trip which causes ~1e-6 precision loss due to
@@ -226,17 +233,18 @@ def harvest(
         )  # identity AlignmentMill
 
     # --- Energies ---
-    # Parse energies directly from the Gaussian log in Hartree to avoid
-    # precision loss from cclib's eV round-trip (cclib and qcelemental use
-    # slightly different Hartree↔eV conversion factors, causing ~1e-6 error).
-    # Fall back to cclib values if regex fails.
+    # Parse energies directly from the Gaussian log in Hartree as the primary
+    # path; this preserves Gaussian's full printed precision. Fall back to
+    # cclib's stored value (in eV) only if the regex fails, converting via
+    # cclib.parser.utils.convertor so the eV→Ha reversal uses cclib's own
+    # factor and is exact relative to how cclib stored the quantity.
 
     # rq-37f40e92 — HF/SCF energy
     scf_match = _SCF_DONE_RE.search(log_content)
     if scf_match:
         scf_hartree = float(scf_match.group(1))
     else:
-        scf_hartree = float(ccdata.scfenergies[-1]) * _EV_TO_HARTREE
+        scf_hartree = _cclib_ev_to_hartree(float(ccdata.scfenergies[-1]))
     qcvars["HF TOTAL ENERGY"] = str(scf_hartree)
     qcvars["SCF TOTAL ENERGY"] = str(scf_hartree)
     qcvars["CURRENT REFERENCE ENERGY"] = str(scf_hartree)
@@ -251,7 +259,7 @@ def harvest(
         if mp2_match:
             mp2_hartree = _fortran_float(mp2_match.group(1))
         else:
-            mp2_hartree = float(ccdata.mpenergies[-1][-1]) * _EV_TO_HARTREE
+            mp2_hartree = _cclib_ev_to_hartree(float(ccdata.mpenergies[-1][-1]))
         qcvars["MP2 TOTAL ENERGY"] = str(mp2_hartree)
         qcvars["MP2 CORRELATION ENERGY"] = str(mp2_hartree - scf_hartree)
         qcvars["CURRENT ENERGY"] = str(mp2_hartree)
@@ -263,7 +271,7 @@ def harvest(
         if ccsd_matches:
             ccsd_hartree = float(ccsd_matches[-1].group(1))
         else:
-            ccsd_hartree = float(ccdata.ccenergies[-1]) * _EV_TO_HARTREE
+            ccsd_hartree = _cclib_ev_to_hartree(float(ccdata.ccenergies[-1]))
         qcvars["CCSD TOTAL ENERGY"] = str(ccsd_hartree)
         qcvars["CCSD CORRELATION ENERGY"] = str(ccsd_hartree - scf_hartree)
         qcvars["CURRENT ENERGY"] = str(ccsd_hartree)
@@ -274,7 +282,7 @@ def harvest(
         if ccsdt_match:
             ccsdt_hartree = _fortran_float(ccsdt_match.group(1))
         else:
-            ccsdt_hartree = float(ccdata.ccenergies[-1]) * _EV_TO_HARTREE
+            ccsdt_hartree = _cclib_ev_to_hartree(float(ccdata.ccenergies[-1]))
         qcvars["CCSD(T) TOTAL ENERGY"] = str(ccsdt_hartree)
         qcvars["CCSD(T) CORRELATION ENERGY"] = str(ccsdt_hartree - scf_hartree)
         qcvars["CURRENT ENERGY"] = str(ccsdt_hartree)
@@ -296,7 +304,7 @@ def harvest(
         and ccdata.dispersionenergies is not None
         and len(ccdata.dispersionenergies) > 0
     ):
-        disp_hartree = float(ccdata.dispersionenergies[-1]) * _EV_TO_HARTREE
+        disp_hartree = _cclib_ev_to_hartree(float(ccdata.dispersionenergies[-1]))
 
     if disp_hartree is not None:
         qcvars["DISPERSION CORRECTION ENERGY"] = str(disp_hartree)

--- a/qcengine/programs/gaussian/harvester.py
+++ b/qcengine/programs/gaussian/harvester.py
@@ -330,9 +330,12 @@ def harvest(
         # cclib hessian would be in standard orientation → transform with mill
         hess = mill.align_hessian(np.array(ccdata.hessian))
     else:
-        # cclib does not parse force constants from Gaussian Freq output;
-        # fall back to direct log parsing. Gaussian's "Force constants in
-        # Cartesian coordinates" are in the INPUT orientation.
+        # cclib's Gaussian parser does not populate ccdata.hessian (the full
+        # 3N×3N Cartesian Hessian matrix). It does populate ccdata.vibfconsts
+        # (per-normal-mode reduced force constants, shape (nmodes,)) from the
+        # "Frc consts --" lines, but that's not the matrix we need. Fall back
+        # to direct log parsing of "Force constants in Cartesian coordinates"
+        # (printed in the INPUT orientation).
         parsed_hess = _parse_force_constants(log_content, 3 * natoms)
         if parsed_hess is not None:
             if in_mol.fix_com and in_mol.fix_orientation:

--- a/qcengine/programs/gaussian/harvester.py
+++ b/qcengine/programs/gaussian/harvester.py
@@ -162,9 +162,9 @@ def harvest(
     in_real = list(in_mol.real)
     has_ghosts = not all(in_real)
     if has_ghosts:
-        if len(ccdata.atomnos) != len(in_mol.symbols):
+        if ccdata.natom != len(in_mol.symbols):
             raise ValueError(
-                f"Gaussian log atom count ({len(ccdata.atomnos)}) does not match the "
+                f"Gaussian log atom count ({ccdata.natom}) does not match the "
                 f"input molecule's atom count ({len(in_mol.symbols)})."
             )
         symbols = list(in_mol.symbols)
@@ -184,7 +184,7 @@ def harvest(
         calc_mol_kwargs["real"] = real_flags
     calc_mol = Molecule(**calc_mol_kwargs)
 
-    natoms = len(ccdata.atomnos)
+    natoms = ccdata.natom
     qcvars["N ATOMS"] = str(natoms)
 
     if hasattr(ccdata, "nbasis") and ccdata.nbasis is not None:

--- a/qcengine/programs/gaussian/harvester.py
+++ b/qcengine/programs/gaussian/harvester.py
@@ -59,6 +59,14 @@ def harvest(
     qcvars = PreservingDict()
     method_lower = method.lower()
 
+    # Normalise method variants: strip Gaussian-specific sub-options like ",full"
+    # so that energy-extraction logic sees the canonical method name.
+    # e.g. "ccsd(t,full)" → "ccsd(t)"
+    _METHOD_NORMALISE = {
+        "ccsd(t,full)": "ccsd(t)",
+    }
+    method_lower = _METHOD_NORMALISE.get(method_lower, method_lower)
+
     # --- Geometry and output molecule ---
     # rq-8d6fc024 rq-a76c3d7b rq-b7c7b8cb
     if not hasattr(ccdata, "atomcoords") or len(ccdata.atomcoords) == 0:
@@ -90,9 +98,18 @@ def harvest(
             f"is inconsistent with the input molecule (NRE: {in_mol.nuclear_repulsion_energy():.6f})."
         )
 
-    # Align output molecule to input molecule (same pattern as GAMESS harvester)
+    # Frame considerations (same pattern as GAMESS harvester)
     # rq-8d6fc024
-    return_mol, _ = in_mol.align(calc_mol, atoms_map=False, mols_align=True, run_mirror=True, verbose=0)
+    if in_mol.fix_com and in_mol.fix_orientation:
+        # Impose input frame if important as signalled by fix_*=True
+        return_mol = in_mol
+        _, data = calc_mol.align(in_mol, atoms_map=False, mols_align=True, run_mirror=True, verbose=0)
+        mill = data["mill"]
+    else:
+        return_mol, _ = in_mol.align(calc_mol, atoms_map=False, mols_align=True, run_mirror=True, verbose=0)
+        mill = qcel.molutil.compute_scramble(
+            len(in_mol.symbols), do_resort=False, do_shift=False, do_rotate=False, do_mirror=False
+        )  # identity AlignmentMill
 
     # --- Energies ---
     # rq-37f40e92 — HF/SCF energy is always extracted from scfenergies
@@ -136,14 +153,15 @@ def harvest(
     grad: Optional[np.ndarray] = None
     if hasattr(ccdata, "grads") and ccdata.grads is not None and len(ccdata.grads) > 0:
         # ccdata.grads shape: (nsteps, natoms, 3) in Hartree/Bohr (forces = -dE/dR)
-        # Gradient = -forces
-        grad = (-ccdata.grads[-1]).flatten()
+        # Gradient = -forces; align_gradient expects (natom, 3)
+        calc_grad = -ccdata.grads[-1]  # shape (natoms, 3)
+        grad = mill.align_gradient(calc_grad).flatten()
 
     # --- Hessian ---
     # rq-f2e32162 rq-344f3432
     hess: Optional[np.ndarray] = None
     if hasattr(ccdata, "hessian") and ccdata.hessian is not None:
-        hess = np.array(ccdata.hessian)
+        hess = mill.align_hessian(np.array(ccdata.hessian))
 
     # --- Properties: dipole and Mulliken charges ---
     # rq-c7fd08b5 rq-943856cc rq-53f8ed12 rq-4c4a1542 rq-ffae3fa6

--- a/qcengine/programs/gaussian/keywords.py
+++ b/qcengine/programs/gaussian/keywords.py
@@ -1,0 +1,110 @@
+"""Assemble a Gaussian .com input file from its components."""
+
+from typing import Any, Dict
+
+# Reserved user-keyword names that are handled via Link 0, not the route section.
+# rq-e7897f09
+_RESERVED_KEYWORDS = {"memory", "nprocs"}
+
+
+# rq-3c343d2a
+def build_route_line(
+    method_string: str,
+    basis: str,
+    job_type: str,
+    extra_keywords: Dict[str, str],
+    user_keywords: Dict[str, Any],
+) -> str:
+    """Format the Gaussian route (#P) section line.
+
+    Parameters
+    ----------
+    method_string:
+        Gaussian method token, e.g. "HF", "UB3LYP", "CCSD(T)".
+    basis:
+        Basis set name, e.g. "STO-3G", "6-31G*".
+    job_type:
+        Job-type keyword appended after method/basis, e.g. "Force=NoStep".
+        Empty string produces no extra token.
+    extra_keywords:
+        Additional Key=Value pairs always appended (e.g. {"Pop": "Full"}).
+        A value of "" produces a bare key.
+    user_keywords:
+        Pass-through keywords from AtomicInput.keywords.  Any key NOT in
+        _RESERVED_KEYWORDS is appended verbatim.  A falsy value produces a
+        bare key.
+
+    Returns
+    -------
+    str
+        The full route line, e.g. "#P HF/STO-3G Force=NoStep Pop=Full".
+    """
+    # rq-3c343d2a rq-af032242
+    parts = [f"#P {method_string}/{basis}"]
+
+    if job_type:
+        parts.append(job_type)
+
+    # rq-cd0d6637
+    for key, val in extra_keywords.items():
+        parts.append(f"{key}={val}" if val else key)
+
+    # rq-7152455e rq-e7897f09
+    for key, val in user_keywords.items():
+        if key.lower() in _RESERVED_KEYWORDS:
+            continue
+        parts.append(f"{key}={val}" if val else key)
+
+    return " ".join(parts)
+
+
+# rq-0052a2c7
+def build_com_file(
+    link0: Dict[str, Any],
+    route_line: str,
+    title: str,
+    charge: int,
+    multiplicity: int,
+    atom_block: str,
+) -> str:
+    """Assemble a complete Gaussian .com input file.
+
+    Parameters
+    ----------
+    link0:
+        Key/value pairs written as ``%Key=Value`` lines.
+        Expected keys: ``"NProcShared"``, ``"Mem"``.
+    route_line:
+        Full route section string, already formatted (starts with ``#P``).
+    title:
+        Title card (single line, must be non-blank).
+    charge:
+        Molecular charge.
+    multiplicity:
+        Spin multiplicity.
+    atom_block:
+        Newline-separated ``"<symbol> <x> <y> <z>"`` lines (Ångström).
+
+    Returns
+    -------
+    str
+        Complete .com file content ending with a trailing blank line.
+    """
+    # rq-0052a2c7 rq-d7e8161d
+    link0_lines = "\n".join(f"%{k}={v}" for k, v in link0.items())
+
+    # rq-342a2ca3
+    chg_mult = f"{charge} {multiplicity}"
+
+    # rq-23d8b2c6
+    sections = [
+        link0_lines,
+        route_line,
+        "",
+        title,
+        "",
+        chg_mult,
+        atom_block,
+        "",
+    ]
+    return "\n".join(sections) + "\n"

--- a/qcengine/programs/gaussian/runner.py
+++ b/qcengine/programs/gaussian/runner.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, Optional, Tuple
 
 import numpy as np
 import qcelemental as qcel
-from qcelemental.models import AtomicInput, AtomicResult, BasisSet, Provenance
+from qcelemental.models.v2 import AtomicInput, AtomicResult, BasisSet, Provenance
 from qcelemental.util import safe_version, which, which_import
 
 from ...exceptions import InputError, ResourceError, UnknownError
@@ -51,9 +51,6 @@ class GaussianHarness(ProgramHarness):
         "managed_memory": True,
     }
     version_cache: Dict[str, str] = {}
-
-    class Config(ProgramHarness.Config):
-        pass
 
     # rq-4cf7c460 rq-d3b8d8c3 rq-8e21b7d7 rq-b5e72c6d rq-bd98d417 rq-242ef1d8
     @staticmethod
@@ -125,7 +122,7 @@ class GaussianHarness(ProgramHarness):
         self.found(raise_error=True)
 
         # rq-c77a2c13
-        if isinstance(input_model.model.basis, BasisSet):
+        if isinstance(input_model.specification.model.basis, BasisSet):
             raise InputError(
                 "QCSchema BasisSet for model.basis is not supported by the Gaussian harness. "
                 "Use a string basis name (e.g. 'STO-3G')."
@@ -172,11 +169,11 @@ class GaussianHarness(ProgramHarness):
     ) -> Dict[str, Any]:
         """Construct the Gaussian .com input file and execution record."""
         # rq-0aa99076
-        if isinstance(input_model.model.basis, BasisSet):
+        if isinstance(input_model.specification.model.basis, BasisSet):
             raise InputError(
                 "QCSchema BasisSet for model.basis is not supported by the Gaussian harness."
             )
-        if input_model.model.basis is None:
+        if input_model.specification.model.basis is None:
             raise InputError("model.basis must be a string basis name for the Gaussian harness.")
 
         # rq-5053204b
@@ -184,9 +181,9 @@ class GaussianHarness(ProgramHarness):
             raise InputError("The Gaussian harness does not support ghost atoms (real=False).")
 
         mol = input_model.molecule
-        method = input_model.model.method
-        basis = input_model.model.basis
-        driver = input_model.driver.value  # DriverEnum → plain lowercase string
+        method = input_model.specification.model.method
+        basis = input_model.specification.model.basis
+        driver = input_model.specification.driver.value  # DriverEnum → plain lowercase string
 
         # rq-ef62979b
         modelchem = muster_modelchem(method, driver, mol.molecular_multiplicity)
@@ -212,7 +209,7 @@ class GaussianHarness(ProgramHarness):
             basis,
             modelchem["job_type"],
             modelchem["extra_keywords"],
-            input_model.keywords,
+            input_model.specification.keywords,
         )
 
         com_text = build_com_file(
@@ -266,7 +263,7 @@ class GaussianHarness(ProgramHarness):
         input_text = outfiles.pop("input", "") or ""
         log_text = outfiles.get("gaussian.log", "") or ""
 
-        method = input_model.model.method.lower()
+        method = input_model.specification.model.method.lower()
         # Strip any "gaussian-" prefix in case caller added one
         if method.startswith("gaussian-"):
             method = method[len("gaussian-"):]
@@ -286,7 +283,7 @@ class GaussianHarness(ProgramHarness):
             qcvars[f"{method_upper} TOTAL HESSIAN"] = hess
             qcvars["CURRENT HESSIAN"] = hess
 
-        driver = input_model.driver.value  # DriverEnum → plain lowercase string
+        driver = input_model.specification.driver.value  # DriverEnum → plain lowercase string
         try:
             if driver.upper() == "PROPERTIES":
                 retres = float(qcvars["CURRENT ENERGY"])
@@ -308,12 +305,13 @@ class GaussianHarness(ProgramHarness):
             creator="Gaussian",
             version=self.get_version(),
             routine="gaussian",
-        ).dict()
+        ).model_dump()
 
         output_data = {
-            "schema_version": 1,
+            "schema_version": 2,
+            "input_data": input_model,
             "molecule": out_mol,
-            "extras": {**input_model.extras, "qcvars": qcvars_serialised},
+            "extras": {**input_model.specification.extras, "qcvars": qcvars_serialised},
             "native_files": {
                 "gaussian.com": input_text,
                 "gaussian.log": log_text,
@@ -326,4 +324,4 @@ class GaussianHarness(ProgramHarness):
             "success": True,
         }
 
-        return AtomicResult(**{**input_model.dict(), **output_data})
+        return AtomicResult(**output_data)

--- a/qcengine/programs/gaussian/runner.py
+++ b/qcengine/programs/gaussian/runner.py
@@ -287,6 +287,8 @@ class GaussianHarness(ProgramHarness):
         try:
             if driver.upper() == "PROPERTIES":
                 retres = float(qcvars["CURRENT ENERGY"])
+            elif driver.upper() == "ENERGY":
+                retres = float(qcvars["CURRENT ENERGY"])
             else:
                 retres = qcvars[f"CURRENT {driver.upper()}"]
         except KeyError:

--- a/qcengine/programs/gaussian/runner.py
+++ b/qcengine/programs/gaussian/runner.py
@@ -1,0 +1,329 @@
+"""Compute quantum chemistry using Gaussian 16 or Gaussian 09."""
+
+import re
+from decimal import Decimal
+from typing import Any, Dict, Optional, Tuple
+
+import numpy as np
+import qcelemental as qcel
+from qcelemental.models import AtomicInput, AtomicResult, BasisSet, Provenance
+from qcelemental.util import safe_version, which, which_import
+
+from ...exceptions import InputError, ResourceError, UnknownError
+from ...util import execute
+from ..model import ProgramHarness
+from ..qcvar_identities_resources import build_atomicproperties, build_out
+from ..util import error_stamp
+from .germinate import muster_modelchem
+from .harvester import harvest, is_normal_termination
+from .keywords import build_com_file, build_route_line
+
+# rq-cb0f61f2
+_GAUSSIAN_EXECUTABLES = ("g16", "g09")
+
+# Regex to extract version from Gaussian startup output.
+# rq-cb0f61f2
+_VERSION_RE = re.compile(r"Gaussian\s+(\d+),\s+Revision\s+([\w.]+),")
+
+
+def _find_gaussian() -> Optional[str]:
+    """Return the path of the first Gaussian executable found on PATH, or None.
+
+    rq-cb0f61f2 rq-d3b8d8c3
+    """
+    for exe in _GAUSSIAN_EXECUTABLES:
+        path = which(exe, return_bool=False)
+        if path:
+            return path
+    return None
+
+
+# rq-998da273 rq-436a54d5
+class GaussianHarness(ProgramHarness):
+
+    # rq-998da273
+    _defaults = {
+        "name": "Gaussian",
+        "scratch": True,
+        "thread_safe": False,
+        "thread_parallel": True,
+        "node_parallel": False,
+        "managed_memory": True,
+    }
+    version_cache: Dict[str, str] = {}
+
+    class Config(ProgramHarness.Config):
+        pass
+
+    # rq-4cf7c460 rq-d3b8d8c3 rq-8e21b7d7 rq-b5e72c6d rq-bd98d417 rq-242ef1d8
+    @staticmethod
+    def found(raise_error: bool = False) -> bool:
+        """Return True iff both a Gaussian executable and cclib are available.
+
+        Checks for g16 first, then g09.  Also requires cclib to be importable.
+        """
+        qc = _find_gaussian() is not None
+        if not qc:
+            if raise_error:
+                raise ModuleNotFoundError(
+                    "Gaussian executable (g16 or g09) not found on PATH. "
+                    "Install Gaussian and ensure the executable is on your PATH."
+                )
+            return False
+
+        dep = which_import(
+            "cclib",
+            return_bool=True,
+            raise_error=raise_error,
+            raise_msg="For the Gaussian harness, please install cclib: `pip install cclib`.",
+        )
+        return dep
+
+    # rq-186c5060 rq-850ede4f rq-3e134642 rq-20d9a784
+    def get_version(self) -> str:
+        """Return a normalised Gaussian version string (e.g. "16.C.02").
+
+        Runs the Gaussian executable with a blank .com input file and parses the
+        version from the startup banner.  Result is cached per executable path.
+        """
+        self.found(raise_error=True)
+
+        exe_path = _find_gaussian()
+        if exe_path in self.version_cache:
+            return self.version_cache[exe_path]
+
+        # Run Gaussian with an empty .com file to provoke the version banner.
+        # Gaussian writes the version line to the log file even when the input
+        # is blank (causing a segfault), so collect version_probe.log and
+        # accept any exit code by passing a large exit_code threshold.
+        success, output = execute(
+            [exe_path, "version_probe.com"],
+            {"version_probe.com": "\n"},
+            ["version_probe.log"],
+            exit_code=255,
+        )
+        log_text = (output.get("outfiles") or {}).get("version_probe.log", "") or ""
+        stdout = output.get("stdout", "") or ""
+        stderr = output.get("stderr", "") or ""
+        combined = log_text + stdout + stderr
+
+        m = _VERSION_RE.search(combined)
+        if not m:
+            raise UnknownError(
+                f"Could not parse Gaussian version from output.\n"
+                f"stdout: {stdout}\nstderr: {stderr}"
+            )
+
+        version_str = f"{m.group(1)}.{m.group(2)}"
+        self.version_cache[exe_path] = version_str
+        return version_str
+
+    # rq-99807237 rq-e62578e2 rq-4d683dac rq-1a051bc2
+    # rq-c77a2c13 rq-165224fc rq-edb73b83 rq-a4c449da rq-71aceb93
+    def compute(self, input_model: AtomicInput, config: "TaskConfig") -> AtomicResult:
+        """Top-level compute entry point for the Gaussian harness."""
+        self.found(raise_error=True)
+
+        # rq-c77a2c13
+        if isinstance(input_model.model.basis, BasisSet):
+            raise InputError(
+                "QCSchema BasisSet for model.basis is not supported by the Gaussian harness. "
+                "Use a string basis name (e.g. 'STO-3G')."
+            )
+
+        job_inputs = self.build_input(input_model, config)
+        success, dexe = self.execute(job_inputs)
+
+        log_text = dexe["outfiles"].get("gaussian.log") or ""
+        stdin = job_inputs["infiles"].get("gaussian.com", "")
+        stdout = dexe.get("stdout", "") or ""
+        stderr = dexe.get("stderr", "") or ""
+
+        # rq-a4c449da
+        if "galloc: could not allocate memory" in log_text:
+            raise ResourceError(error_stamp(stdin, log_text, stderr))
+
+        # rq-165224fc
+        if (
+            "Ernie: is not defined as a Gaussian input file" in log_text
+            or "Ernie: unrecognized" in log_text
+        ):
+            raise InputError(error_stamp(stdin, log_text, stderr))
+
+        # rq-edb73b83
+        if "Error in internal coordinate system" in log_text:
+            raise InputError(error_stamp(stdin, log_text, stderr))
+
+        # rq-71aceb93 — absence of normal termination with no known pattern
+        if not is_normal_termination(log_text):
+            raise UnknownError(error_stamp(stdin, log_text, stderr))
+
+        dexe["outfiles"]["stdout"] = stdout
+        dexe["outfiles"]["stderr"] = stderr
+        dexe["outfiles"]["input"] = stdin
+        return self.parse_output(dexe["outfiles"], input_model)
+
+    # rq-9cdf3f7d rq-74e0110c rq-0052a2c7
+    def build_input(
+        self,
+        input_model: AtomicInput,
+        config: "TaskConfig",
+        template: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Construct the Gaussian .com input file and execution record."""
+        # rq-0aa99076
+        if isinstance(input_model.model.basis, BasisSet):
+            raise InputError(
+                "QCSchema BasisSet for model.basis is not supported by the Gaussian harness."
+            )
+        if input_model.model.basis is None:
+            raise InputError("model.basis must be a string basis name for the Gaussian harness.")
+
+        # rq-5053204b
+        if not all(input_model.molecule.real):
+            raise InputError("The Gaussian harness does not support ghost atoms (real=False).")
+
+        mol = input_model.molecule
+        method = input_model.model.method
+        basis = input_model.model.basis
+        driver = input_model.driver.value  # DriverEnum → plain lowercase string
+
+        # rq-ef62979b
+        modelchem = muster_modelchem(method, driver, mol.molecular_multiplicity)
+
+        # rq-74e0110c — build atom block in Ångström with 10+ decimal places
+        bohr_to_ang = qcel.constants.conversion_factor("bohr", "angstrom")
+        geom_ang = mol.geometry.reshape(-1, 3) * bohr_to_ang
+        atom_lines = [
+            f"{sym:2s}  {x:20.10f}  {y:20.10f}  {z:20.10f}"
+            for sym, (x, y, z) in zip(mol.symbols, geom_ang)
+        ]
+        atom_block = "\n".join(atom_lines)
+
+        # rq-db92093a rq-4ad16d95
+        mem_gb = max(1, int(config.memory))
+        link0 = {
+            "NProcShared": config.ncores,
+            "Mem": f"{mem_gb}GB",
+        }
+
+        route_line = build_route_line(
+            modelchem["method_string"],
+            basis,
+            modelchem["job_type"],
+            modelchem["extra_keywords"],
+            input_model.keywords,
+        )
+
+        com_text = build_com_file(
+            link0=link0,
+            route_line=route_line,
+            title="QCEngine Gaussian calculation",
+            charge=int(mol.molecular_charge),
+            multiplicity=int(mol.molecular_multiplicity),
+            atom_block=atom_block,
+        )
+
+        exe_path = _find_gaussian()
+
+        return {
+            "infiles": {"gaussian.com": com_text},
+            "command": [exe_path, "gaussian.com"],
+            "scratch_directory": config.scratch_directory,
+            "scratch_messy": config.scratch_messy,
+        }
+
+    def execute(
+        self,
+        inputs: Dict[str, Any],
+        extra_outfiles: Optional[list] = None,
+        extra_commands: Optional[list] = None,
+        scratch_name: Optional[str] = None,
+        timeout: Optional[int] = None,
+    ) -> Tuple[bool, Dict]:
+        """Run the Gaussian executable; collect gaussian.log."""
+        # rq-cb0f61f2
+        # Gaussian's exit code is unreliable; we always inspect the log.
+        # Pass exit_code=1 so execute() returns success=True for both 0 and 1.
+        success, dexe = execute(
+            inputs["command"],
+            inputs["infiles"],
+            ["gaussian.log"],
+            scratch_messy=inputs["scratch_messy"],
+            scratch_directory=inputs["scratch_directory"],
+            exit_code=1,
+        )
+        return success, dexe
+
+    def parse_output(
+        self,
+        outfiles: Dict[str, str],
+        input_model: AtomicInput,
+    ) -> AtomicResult:
+        """Parse Gaussian output files and return an AtomicResult."""
+        stdout = outfiles.pop("stdout", "") or ""
+        stderr = outfiles.pop("stderr", "") or ""
+        input_text = outfiles.pop("input", "") or ""
+        log_text = outfiles.get("gaussian.log", "") or ""
+
+        method = input_model.model.method.lower()
+        # Strip any "gaussian-" prefix in case caller added one
+        if method.startswith("gaussian-"):
+            method = method[len("gaussian-"):]
+
+        try:
+            qcvars, grad, hess, out_mol = harvest(input_model.molecule, method, log_text)
+        except Exception as e:
+            raise UnknownError(error_stamp(input_text, log_text, stderr)) from e
+
+        method_upper = method.upper()
+
+        if grad is not None:
+            qcvars[f"{method_upper} TOTAL GRADIENT"] = grad
+            qcvars["CURRENT GRADIENT"] = grad
+
+        if hess is not None:
+            qcvars[f"{method_upper} TOTAL HESSIAN"] = hess
+            qcvars["CURRENT HESSIAN"] = hess
+
+        driver = input_model.driver.value  # DriverEnum → plain lowercase string
+        try:
+            if driver.upper() == "PROPERTIES":
+                retres = float(qcvars["CURRENT ENERGY"])
+            else:
+                retres = qcvars[f"CURRENT {driver.upper()}"]
+        except KeyError:
+            raise UnknownError(error_stamp(input_text, log_text, stderr))
+
+        # Serialise Decimal → float/str so JSON encoding works downstream
+        qcvars_serialised = {
+            k.upper(): (str(v) if isinstance(v, Decimal) else v)
+            for k, v in qcvars.items()
+        }
+
+        build_out(qcvars)
+        atprop = build_atomicproperties(qcvars)
+
+        provenance = Provenance(
+            creator="Gaussian",
+            version=self.get_version(),
+            routine="gaussian",
+        ).dict()
+
+        output_data = {
+            "schema_version": 1,
+            "molecule": out_mol,
+            "extras": {**input_model.extras, "qcvars": qcvars_serialised},
+            "native_files": {
+                "gaussian.com": input_text,
+                "gaussian.log": log_text,
+            },
+            "properties": atprop,
+            "provenance": provenance,
+            "return_result": retres,
+            "stderr": stderr,
+            "stdout": stdout,
+            "success": True,
+        }
+
+        return AtomicResult(**{**input_model.dict(), **output_data})

--- a/qcengine/programs/gaussian/runner.py
+++ b/qcengine/programs/gaussian/runner.py
@@ -280,8 +280,11 @@ class GaussianHarness(ProgramHarness):
         method_upper = method.upper()
 
         if grad is not None:
-            qcvars[f"{method_upper} TOTAL GRADIENT"] = grad
-            qcvars["CURRENT GRADIENT"] = grad
+            # Reshape to (natom, 3) to match other harnesses' convention
+            natom = len(input_model.molecule.symbols)
+            grad_reshaped = grad.reshape(natom, 3)
+            qcvars[f"{method_upper} TOTAL GRADIENT"] = grad_reshaped
+            qcvars["CURRENT GRADIENT"] = grad_reshaped
 
         if hess is not None:
             qcvars[f"{method_upper} TOTAL HESSIAN"] = hess

--- a/qcengine/programs/gaussian/runner.py
+++ b/qcengine/programs/gaussian/runner.py
@@ -133,7 +133,10 @@ class GaussianHarness(ProgramHarness):
 
         log_text = dexe["outfiles"].get("gaussian.log") or ""
         stdin = job_inputs["infiles"].get("gaussian.com", "")
-        stdout = dexe.get("stdout", "") or ""
+        # Gaussian writes all output to the .log file (not to process stdout) when
+        # given a .com file argument. Expose the log as stdout for consistency with
+        # other harnesses whose programs write to process stdout.
+        stdout = log_text or dexe.get("stdout", "") or ""
         stderr = dexe.get("stderr", "") or ""
 
         # rq-a4c449da
@@ -192,7 +195,7 @@ class GaussianHarness(ProgramHarness):
         bohr_to_ang = qcel.constants.conversion_factor("bohr", "angstrom")
         geom_ang = mol.geometry.reshape(-1, 3) * bohr_to_ang
         atom_lines = [
-            f"{sym:2s}  {x:20.10f}  {y:20.10f}  {z:20.10f}"
+            f"{sym:2s}  {x:24.14f}  {y:24.14f}  {z:24.14f}"
             for sym, (x, y, z) in zip(mol.symbols, geom_ang)
         ]
         atom_block = "\n".join(atom_lines)
@@ -252,6 +255,7 @@ class GaussianHarness(ProgramHarness):
         )
         return success, dexe
 
+    # rq-bb7d680f
     def parse_output(
         self,
         outfiles: Dict[str, str],
@@ -260,7 +264,7 @@ class GaussianHarness(ProgramHarness):
         """Parse Gaussian output files and return an AtomicResult."""
         stdout = outfiles.pop("stdout", "") or ""
         stderr = outfiles.pop("stderr", "") or ""
-        input_text = outfiles.pop("input", "") or ""
+        input_text = outfiles.get("input", "") or ""
         log_text = outfiles.get("gaussian.log", "") or ""
 
         method = input_model.specification.model.method.lower()
@@ -309,15 +313,15 @@ class GaussianHarness(ProgramHarness):
             routine="gaussian",
         ).model_dump()
 
+        # rq-bb7d680f — use outfiles passthrough pattern (matching NWChem/GAMESS/CFOUR)
+        native_files = {k: v for k, v in outfiles.items() if v is not None}
+
         output_data = {
             "schema_version": 2,
             "input_data": input_model,
             "molecule": out_mol,
             "extras": {**input_model.specification.extras, "qcvars": qcvars_serialised},
-            "native_files": {
-                "gaussian.com": input_text,
-                "gaussian.log": log_text,
-            },
+            "native_files": native_files,
             "properties": atprop,
             "provenance": provenance,
             "return_result": retres,

--- a/qcengine/programs/gaussian/runner.py
+++ b/qcengine/programs/gaussian/runner.py
@@ -187,6 +187,20 @@ class GaussianHarness(ProgramHarness):
         # rq-ef62979b
         modelchem = muster_modelchem(method, driver, mol.molecular_multiplicity)
 
+        # rq-59b816b7 — Conflict between method-suffix dispersion and a
+        # user-provided EmpiricalDispersion keyword is ambiguous; raise rather
+        # than silently picking one.
+        if modelchem.get("dispersion_level") is not None:
+            user_kw = input_model.specification.keywords or {}
+            for k in user_kw:
+                if k.lower() == "empiricaldispersion":
+                    raise InputError(
+                        f"Empirical dispersion is overspecified: method "
+                        f"'{method}' implies EmpiricalDispersion="
+                        f"{modelchem['extra_keywords']['EmpiricalDispersion']}, "
+                        f"but keywords also contains '{k}'. Specify only one."
+                    )
+
         # rq-74e0110c rq-bd6cd9a4 — build atom block in Ångström with 10+ decimal places
         # Ghost atoms (real=False) get a "-Bq" suffix so Gaussian places basis functions
         # without a nucleus or electrons.

--- a/qcengine/programs/gaussian/runner.py
+++ b/qcengine/programs/gaussian/runner.py
@@ -179,10 +179,6 @@ class GaussianHarness(ProgramHarness):
         if input_model.specification.model.basis is None:
             raise InputError("model.basis must be a string basis name for the Gaussian harness.")
 
-        # rq-5053204b
-        if not all(input_model.molecule.real):
-            raise InputError("The Gaussian harness does not support ghost atoms (real=False).")
-
         mol = input_model.molecule
         method = input_model.specification.model.method
         basis = input_model.specification.model.basis
@@ -191,13 +187,15 @@ class GaussianHarness(ProgramHarness):
         # rq-ef62979b
         modelchem = muster_modelchem(method, driver, mol.molecular_multiplicity)
 
-        # rq-74e0110c — build atom block in Ångström with 10+ decimal places
+        # rq-74e0110c rq-bd6cd9a4 — build atom block in Ångström with 10+ decimal places
+        # Ghost atoms (real=False) get a "-Bq" suffix so Gaussian places basis functions
+        # without a nucleus or electrons.
         bohr_to_ang = qcel.constants.conversion_factor("bohr", "angstrom")
         geom_ang = mol.geometry.reshape(-1, 3) * bohr_to_ang
-        atom_lines = [
-            f"{sym:2s}  {x:24.14f}  {y:24.14f}  {z:24.14f}"
-            for sym, (x, y, z) in zip(mol.symbols, geom_ang)
-        ]
+        atom_lines = []
+        for sym, is_real, (x, y, z) in zip(mol.symbols, mol.real, geom_ang):
+            label = sym if is_real else f"{sym}-Bq"
+            atom_lines.append(f"{label:5s}  {x:24.14f}  {y:24.14f}  {z:24.14f}")
         atom_block = "\n".join(atom_lines)
 
         # rq-db92093a rq-4ad16d95

--- a/qcengine/programs/tests/test_alignment.py
+++ b/qcengine/programs/tests/test_alignment.py
@@ -83,11 +83,15 @@ def clsd_open_pmols(schema_versions):
         # yapf: disable
         pytest.param({"call": "cfour",  "reference": "rhf",  "fcae": "ae", "keywords": {"scf_conv": 12},                                                                     }, id="hf  rhf ae: cfour",      marks=using("cfour")),
         pytest.param({"call": "gamess", "reference": "rhf",  "fcae": "ae", "keywords": {},                                                                                   }, id="hf  rhf ae: gamess",     marks=using("gamess")),
+        # rq-81bc1d68
+        pytest.param({"call": "gaussian", "reference": "rhf", "fcae": "ae", "keywords": {},                                                                                   }, id="hf  rhf ae: gaussian",   marks=using("gaussian")),
         pytest.param({"call": "nwchem", "reference": "rhf",  "fcae": "ae", "keywords": {"scf__thresh": 1.e-6},                                                               }, id="hf  rhf ae: nwchem",     marks=using("nwchem")),
         pytest.param({"call": "psi4",   "reference": "rhf",  "fcae": "ae", "keywords": {"scf_type": "pk"},                                                                   }, id="hf  rhf ae: psi4",       marks=using("psi4")),
 
         pytest.param({"call": "cfour",  "reference": "uhf",  "fcae": "ae", "keywords": {"reference": "uhf", "scf_conv": 12},                                                 }, id="hf  uhf ae: cfour",      marks=using("cfour")),
         pytest.param({"call": "gamess", "reference": "uhf",  "fcae": "ae", "keywords": {"contrl__scftyp": "uhf"},                                                            }, id="hf  uhf ae: gamess",     marks=using("gamess")),
+        # rq-81bc1d68
+        pytest.param({"call": "gaussian", "reference": "uhf", "fcae": "ae", "keywords": {},                                                                                   }, id="hf  uhf ae: gaussian",   marks=using("gaussian")),
         pytest.param({"call": "nwchem", "reference": "uhf",  "fcae": "ae", "keywords": {"scf__uhf": True, "scf__thresh": 1.e-6},                                             }, id="hf  uhf ae: nwchem",     marks=using("nwchem")),
         pytest.param({"call": "psi4",   "reference": "uhf",  "fcae": "ae", "keywords": {"reference": "uhf", "scf_type": "pk"},                                               }, id="hf  uhf ae: psi4",       marks=using("psi4")),
         # yapf: enable

--- a/qcengine/programs/tests/test_canonical_config.py
+++ b/qcengine/programs/tests/test_canonical_config.py
@@ -17,6 +17,8 @@ _canonical_methods = [
     pytest.param("cfour", {"method": "hf", "basis": "6-31G"}, {}, marks=using("cfour")),
     pytest.param("dftd3", {"method": "b3lyp-d3"}, {}, marks=using("classic-dftd3")),
     pytest.param("gamess", {"method": "hf", "basis": "n31"}, {"basis__NGAUSS": 6}, marks=using("gamess")),
+    # rq-e71357c5
+    pytest.param("gaussian", {"method": "hf", "basis": "STO-3G"}, {}, marks=using("gaussian")),
     pytest.param("gcp", {"method": "hf3c"}, {}, marks=using("classic-gcp")),
     pytest.param("mctc-gcp", {"method": "dft/sv"}, {}, marks=using("mctc-gcp")),
     # needs attn ("molpro", {"method": "hf", "basis": "6-31G"}, {}),
@@ -58,6 +60,7 @@ def _get_molecule(program, method, molcls):
                 "cfour": {"memory_size": "5000"},
                 "gamess": {"system__mwords": "5000"},
                 "nwchem": {"memory": "5 gb"},
+                "gaussian": {},  # memory is Link 0, not a route keyword (rq-0edebcd3)
                 "psi4": {},  # no contradictory memory keyword in psi
             },
             id="dsl",
@@ -122,6 +125,8 @@ def test_local_options_memory_gib(program, model, keywords, memory_trickery, sch
     stdout_ref = {  # 1.555 GiB = 208708567 quad-words
         "cfour": "Allocated    1592 MB of main memory",
         "gamess": "208000000 WORDS OF MEMORY AVAILABLE",
+        # rq-0edebcd3 — Gaussian echoes Link 0 %Mem in the log; int(1.555)=1
+        "gaussian": r"%Mem=1GB",
         "nwchem": r"total\s+=\s+2087085\d\d doubles =\s+1592.3 Mbytes",  # doubles is quad-words. Mbytes is MiB
         "psi4": "1592 MiB Core",
     }
@@ -195,6 +200,7 @@ def test_local_options_scratch(program, model, keywords, schema_versions, reques
         "cfour": "University of Florida",  # freebie
         "dftd3": "Grimme",  # freebie
         "gamess": "IOWA STATE UNIVERSITY",  # freebie
+        "gaussian": "Gaussian, Inc.",  # freebie (rq-815d5fee)
         "gcp": "Grimme",  # freebie
         "mctc-gcp": "Grimme",  # freebie
         "mp2d": "Beran",  # freebie
@@ -210,6 +216,7 @@ def test_local_options_scratch(program, model, keywords, schema_versions, reques
         "cfour": "*/NEWFOCK",
         "dftd3": "*/dftd3_geometry.xyz",  # no outfiles
         "gamess": "*/gamess.dat",
+        "gaussian": "*/gaussian.log",  # rq-815d5fee
         "gcp": "*/gcp_geometry.xyz",  # no outfiles
         "mctc-gcp": "*/gcp_geometry.xyz",  # no outfiles
         "mp2d": "*/mp2d_geometry",  # no outfiles
@@ -283,6 +290,8 @@ def test_local_options_ncores(program, model, keywords, ncores, schema_versions,
         "cfour": rf"Running with {ncores} threads/proc",
         "gamess": rf"MEMDDI DISTRIBUTED OVER\s+{ncores} PROCESSORS",
         # "gamess": rf"PARALLEL VERSION RUNNING ON\s+{ncores} PROCESSORS IN\s+1 NODES",  # no line for serial
+        # rq-3a18d6af — Gaussian echoes %NProcShared=N and "Will use up to N processors"
+        "gaussian": rf"Will use up to\s+{ncores} processors",
         # nwchem is node_parallel only
         "psi4": rf"Threads:\s+{ncores}",
     }

--- a/qcengine/programs/tests/test_canonical_fields.py
+++ b/qcengine/programs/tests/test_canonical_fields.py
@@ -70,6 +70,8 @@ def test_protocol_native(program, model, keywords, native, schema_versions, requ
         "cfour": rf"\*CFOUR\(BASIS=6-31G",
         "dftd3": rf"1.000000     1.261000     1.703000",
         "gamess": rf"\$basis gbasis=n31 ngauss=6 \$end",
+        # rq-c01c892e
+        "gaussian": rf"#.*HF/STO-3G",
         "gcp": rf"level HF3C",
         "mctc-gcp": rf"level DFT/SV",
         "mp2d": rf"--TT_a1=0.944 --TT_a2=0.48",
@@ -81,6 +83,8 @@ def test_protocol_native(program, model, keywords, native, schema_versions, requ
         "cfour": ("GRD", rf"1.0+\s+0.0+\s+0.0+\s+0.03"),
         "dftd3": ("dftd3_geometry.xyz", rf"H\s+0.0+\s+0.0+\s+0.34"),
         "gamess": ("gamess.dat", rf"CLOSED SHELL ORBITALS --- GENERATED AT"),
+        # rq-c01c892e
+        "gaussian": ("gaussian.log", rf"Normal termination of Gaussian"),
         "gcp": ("gcp_geometry.xyz", rf"H\s+0.0+\s+0.0+\s+0.34"),
         "mctc-gcp": ("gcp_geometry.xyz", rf"H\s+0.0+\s+0.0+\s+0.34"),
         "mp2d": ("mp2d_geometry", rf"H\s+0.0+\s+0.0+\s+0.34"),

--- a/qcengine/programs/tests/test_gaussian.py
+++ b/qcengine/programs/tests/test_gaussian.py
@@ -1,5 +1,6 @@
 """Tests for the Gaussian harness: germinate, keywords, harvester, and runner."""
 
+import importlib.util
 import re
 from decimal import Decimal
 from typing import Any, Dict
@@ -17,6 +18,9 @@ from qcengine.programs.gaussian.keywords import build_com_file, build_route_line
 from qcengine.programs.gaussian import runner as gaussian_runner
 from qcengine.programs.gaussian.runner import GaussianHarness
 from qcengine.testing import uusing as using
+
+_cclib_available = importlib.util.find_spec("cclib") is not None
+requires_cclib = pytest.mark.skipif(not _cclib_available, reason="cclib not installed")
 
 # ---------------------------------------------------------------------------
 # Shared test fixtures
@@ -615,6 +619,7 @@ def _full_compute_patches(harness, water_energy_input, log_text, ccdata, return_
 
 
 # rq-99807237
+@requires_cclib
 def test_compute_returns_atomic_result_energy(harness, water_energy_input_all_files, water):
     log_text = _NORMAL_LOG
     ccdata = _make_ccdata_with_attrs(scfenergies=np.array([-2041.3]))
@@ -630,6 +635,7 @@ def test_compute_returns_atomic_result_energy(harness, water_energy_input_all_fi
 
 
 # rq-e62578e2
+@requires_cclib
 def test_compute_returns_atomic_result_gradient(harness, water):
     forces = np.array([[0.01, 0.0, -0.02], [0.0, 0.005, 0.01], [0.0, -0.005, 0.01]])
     ccdata = _make_ccdata_with_attrs(
@@ -661,6 +667,7 @@ def test_compute_returns_atomic_result_gradient(harness, water):
 
 
 # rq-4d683dac
+@requires_cclib
 def test_compute_returns_atomic_result_hessian(harness, water):
     hess_matrix = np.eye(9) * 0.5
     ccdata = _make_ccdata_with_attrs(
@@ -692,6 +699,7 @@ def test_compute_returns_atomic_result_hessian(harness, water):
 
 
 # rq-1a051bc2
+@requires_cclib
 def test_compute_returns_atomic_result_properties(harness, water):
     ccdata = _make_ccdata_with_attrs(
         scfenergies=np.array([-2041.3]),
@@ -740,6 +748,7 @@ def _make_water_mol():
 
 
 # rq-71b27e68
+@requires_cclib
 def test_harvest_hf_energy():
     in_mol = _make_water_mol()
     ccdata = _make_ccdata_with_attrs(scfenergies=np.array([-2041.3]))
@@ -751,6 +760,7 @@ def test_harvest_hf_energy():
 
 
 # rq-6bff3228
+@requires_cclib
 def test_harvest_dft_energy():
     in_mol = _make_water_mol()
     ccdata = _make_ccdata_with_attrs(scfenergies=np.array([-2082.1]))
@@ -762,6 +772,7 @@ def test_harvest_dft_energy():
 
 
 # rq-578bb785
+@requires_cclib
 def test_harvest_mp2_energies():
     in_mol = _make_water_mol()
     ccdata = _make_ccdata_with_attrs(
@@ -779,6 +790,7 @@ def test_harvest_mp2_energies():
 
 
 # rq-1b7ae62e
+@requires_cclib
 def test_harvest_ccsd_energies():
     in_mol = _make_water_mol()
     ccdata = _make_ccdata_with_attrs(
@@ -795,6 +807,7 @@ def test_harvest_ccsd_energies():
 
 
 # rq-eddef743
+@requires_cclib
 def test_harvest_ccsd_t_energies():
     in_mol = _make_water_mol()
     ccdata = _make_ccdata_with_attrs(
@@ -814,6 +827,7 @@ def test_harvest_ccsd_t_energies():
 
 
 # rq-36736115
+@requires_cclib
 def test_harvest_gradient_negated():
     in_mol = _make_water_mol()
     forces = np.array([[0.01, 0.0, -0.02], [0.0, 0.005, 0.01], [0.0, -0.005, 0.01]])
@@ -829,6 +843,7 @@ def test_harvest_gradient_negated():
 
 
 # rq-3b0adf96
+@requires_cclib
 def test_harvest_no_gradient_when_absent():
     in_mol = _make_water_mol()
     ccdata = _make_ccdata_with_attrs(scfenergies=np.array([-2041.3]))
@@ -844,6 +859,7 @@ def test_harvest_no_gradient_when_absent():
 
 
 # rq-f2e32162
+@requires_cclib
 def test_harvest_hessian():
     in_mol = _make_water_mol()
     hess_matrix = np.eye(9) * 0.5
@@ -859,6 +875,7 @@ def test_harvest_hessian():
 
 
 # rq-344f3432
+@requires_cclib
 def test_harvest_no_hessian_when_absent():
     in_mol = _make_water_mol()
     ccdata = _make_ccdata_with_attrs(scfenergies=np.array([-2041.3]))
@@ -873,6 +890,7 @@ def test_harvest_no_hessian_when_absent():
 
 
 # rq-4c4a1542
+@requires_cclib
 def test_harvest_dipole_moment():
     in_mol = _make_water_mol()
     dipole_vec = np.array([0.0, 1.85, 0.0])
@@ -886,6 +904,7 @@ def test_harvest_dipole_moment():
 
 
 # rq-ffae3fa6
+@requires_cclib
 def test_harvest_mulliken_charges():
     in_mol = _make_water_mol()
     charges = [-0.5, 0.25, 0.25]
@@ -900,6 +919,7 @@ def test_harvest_mulliken_charges():
 
 
 # rq-53f8ed12
+@requires_cclib
 def test_harvest_missing_mulliken_no_error():
     in_mol = _make_water_mol()
     ccdata = _make_ccdata_with_attrs(
@@ -917,6 +937,7 @@ def test_harvest_missing_mulliken_no_error():
 
 
 # rq-a76c3d7b
+@requires_cclib
 def test_harvest_output_molecule_symbols():
     in_mol = _make_water_mol()
     ccdata = _make_ccdata_with_attrs(scfenergies=np.array([-2041.3]))
@@ -926,6 +947,7 @@ def test_harvest_output_molecule_symbols():
 
 
 # rq-a9194afb
+@requires_cclib
 def test_harvest_nre_cross_check_passes():
     in_mol = _make_water_mol()
     ccdata = _make_ccdata_with_attrs(scfenergies=np.array([-2041.3]))
@@ -935,6 +957,7 @@ def test_harvest_nre_cross_check_passes():
 
 
 # rq-0b4cf843
+@requires_cclib
 def test_harvest_nre_mismatch_raises():
     in_mol = _make_water_mol()
     # Use very different geometry to force NRE mismatch
@@ -954,6 +977,7 @@ def test_harvest_nre_mismatch_raises():
 
 
 # rq-b7c7b8cb
+@requires_cclib
 def test_harvest_no_coords_raises():
     in_mol = _make_water_mol()
     ccdata = _make_ccdata_with_attrs(
@@ -966,6 +990,7 @@ def test_harvest_no_coords_raises():
 
 
 # rq-bb775969
+@requires_cclib
 def test_harvest_cclib_parse_failure_propagates():
     in_mol = _make_water_mol()
     with patch(

--- a/qcengine/programs/tests/test_gaussian.py
+++ b/qcengine/programs/tests/test_gaussian.py
@@ -1,0 +1,1032 @@
+"""Tests for the Gaussian harness: germinate, keywords, harvester, and runner."""
+
+import re
+from decimal import Decimal
+from typing import Any, Dict
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+import qcelemental as qcel
+from qcelemental.models import AtomicInput, BasisSet, Molecule
+
+from qcengine.exceptions import InputError, ResourceError, UnknownError
+from qcengine.programs.gaussian.germinate import muster_modelchem
+from qcengine.programs.gaussian.harvester import harvest, is_normal_termination
+from qcengine.programs.gaussian.keywords import build_com_file, build_route_line
+from qcengine.programs.gaussian import runner as gaussian_runner
+from qcengine.programs.gaussian.runner import GaussianHarness
+from qcengine.testing import using
+
+# ---------------------------------------------------------------------------
+# Shared test fixtures
+# ---------------------------------------------------------------------------
+
+_EV_TO_HARTREE = qcel.constants.conversion_factor("eV", "hartree")
+
+
+@pytest.fixture
+def water():
+    """Simple water molecule for use in tests."""
+    return Molecule.from_data(
+        """
+        0 1
+        O  0.000000000  0.000000000  0.117176320
+        H  0.000000000  0.757335953 -0.468705281
+        H  0.000000000 -0.757335953 -0.468705281
+        units angstrom
+        """
+    )
+
+
+@pytest.fixture
+def water_energy_input(water):
+    """Minimal AtomicInput for a closed-shell HF/STO-3G energy on water."""
+    return AtomicInput(molecule=water, driver="energy", model={"method": "HF", "basis": "STO-3G"})
+
+
+@pytest.fixture
+def water_energy_input_all_files(water):
+    """AtomicInput with native_files protocol set to 'all' for testing file output."""
+    return AtomicInput(
+        molecule=water,
+        driver="energy",
+        model={"method": "HF", "basis": "STO-3G"},
+        protocols={"native_files": "all"},
+    )
+
+
+@pytest.fixture
+def harness():
+    return GaussianHarness()
+
+
+# ---------------------------------------------------------------------------
+# Mock ccdata helper
+# ---------------------------------------------------------------------------
+
+
+def _make_ccdata(
+    scfenergies=None,
+    mpenergies=None,
+    ccenergies=None,
+    atomcoords=None,
+    atomnos=None,
+    grads=None,
+    hessian=None,
+    moments=None,
+    atomcharges=None,
+):
+    """Build a minimal mock ccdata object."""
+    # Water geometry in Angstrom
+    if atomcoords is None:
+        atomcoords = np.array(
+            [[[0.0, 0.0, 0.117176], [0.0, 0.757336, -0.468705], [0.0, -0.757336, -0.468705]]]
+        )
+    if atomnos is None:
+        atomnos = np.array([8, 1, 1])
+    if scfenergies is None:
+        scfenergies = np.array([-2041.3])
+
+    obj = MagicMock()
+    obj.scfenergies = scfenergies
+    obj.mpenergies = mpenergies
+    obj.ccenergies = ccenergies
+    obj.atomcoords = atomcoords
+    obj.atomnos = atomnos
+    obj.grads = grads
+    obj.hessian = hessian
+    obj.moments = moments
+    obj.atomcharges = atomcharges if atomcharges is not None else {}
+    # Make hasattr work correctly
+    if grads is None:
+        del obj.grads
+    if hessian is None:
+        del obj.hessian
+    if moments is None:
+        del obj.moments
+    return obj
+
+
+def _make_ccdata_with_attrs(**kwargs):
+    """Like _make_ccdata but use spec=None so we can control hasattr."""
+    ccdata = type("CCData", (), {})()
+    defaults = dict(
+        scfenergies=np.array([-2041.3]),
+        atomcoords=np.array(
+            [[[0.0, 0.0, 0.117176], [0.0, 0.757336, -0.468705], [0.0, -0.757336, -0.468705]]]
+        ),
+        atomnos=np.array([8, 1, 1]),
+        mpenergies=None,
+        ccenergies=None,
+        grads=None,
+        hessian=None,
+        moments=None,
+        atomcharges={},
+    )
+    defaults.update(kwargs)
+    for k, v in defaults.items():
+        setattr(ccdata, k, v)
+    return ccdata
+
+
+def _patch_cclib(ccdata):
+    """Return a context manager that patches cclib to return ccdata."""
+    mock_ccopen = MagicMock()
+    mock_ccopen.return_value.parse.return_value = ccdata
+    return patch("cclib.io.ccopen", mock_ccopen)
+
+
+# ---------------------------------------------------------------------------
+# Tests: germinate.muster_modelchem — method mapping
+# ---------------------------------------------------------------------------
+
+
+# rq-0199bb02
+def test_muster_modelchem_hf():
+    result = muster_modelchem("hf", "energy", 1)
+    assert result["method_string"] == "HF"
+    assert result["job_type"] == ""
+    assert result["extra_keywords"] == {}
+
+
+# rq-7049aaa5
+def test_muster_modelchem_scf_alias():
+    result = muster_modelchem("scf", "energy", 1)
+    assert result["method_string"] == "HF"
+
+
+# rq-546faafb
+def test_muster_modelchem_mp2():
+    result = muster_modelchem("mp2", "energy", 1)
+    assert result["method_string"] == "MP2"
+
+
+# rq-2052a2fa
+def test_muster_modelchem_ccsd():
+    result = muster_modelchem("ccsd", "energy", 1)
+    assert result["method_string"] == "CCSD"
+
+
+# rq-92492893
+def test_muster_modelchem_ccsd_t():
+    result = muster_modelchem("ccsd(t)", "energy", 1)
+    assert result["method_string"] == "CCSD(T)"
+
+
+# rq-851d782c
+def test_muster_modelchem_passthrough():
+    result = muster_modelchem("B3LYP", "energy", 1)
+    assert result["method_string"] == "B3LYP"
+
+
+# rq-079b1e22
+def test_muster_modelchem_case_insensitive():
+    result = muster_modelchem("CCSD(T)", "energy", 1)
+    assert result["method_string"] == "CCSD(T)"
+
+
+# ---------------------------------------------------------------------------
+# Tests: germinate.muster_modelchem — driver mapping
+# ---------------------------------------------------------------------------
+
+
+# rq-c266b9bb
+def test_muster_modelchem_energy_job_type():
+    result = muster_modelchem("hf", "energy", 1)
+    assert result["job_type"] == ""
+
+
+# rq-f1c116db
+def test_muster_modelchem_gradient_job_type():
+    result = muster_modelchem("hf", "gradient", 1)
+    assert result["job_type"] == "Force=NoStep"
+
+
+# rq-82942b90
+def test_muster_modelchem_hessian_job_type():
+    result = muster_modelchem("hf", "hessian", 1)
+    assert result["job_type"] == "Freq"
+
+
+# rq-f512b60b
+def test_muster_modelchem_properties_driver():
+    result = muster_modelchem("hf", "properties", 1)
+    assert result["job_type"] == ""
+    assert result["extra_keywords"].get("Pop") == "Full"
+
+
+# rq-e008c6fe
+def test_muster_modelchem_unsupported_driver():
+    with pytest.raises(InputError):
+        muster_modelchem("hf", "optimization", 1)
+
+
+# ---------------------------------------------------------------------------
+# Tests: germinate.muster_modelchem — open-shell handling
+# ---------------------------------------------------------------------------
+
+
+# rq-972b6470
+def test_muster_modelchem_singlet_no_u_prefix():
+    result = muster_modelchem("hf", "energy", 1)
+    assert result["method_string"] == "HF"
+
+
+# rq-6d73bb9e
+def test_muster_modelchem_doublet_auto_u_prefix():
+    result = muster_modelchem("hf", "energy", 2)
+    assert result["method_string"] == "UHF"
+
+
+# rq-c946c285
+def test_muster_modelchem_triplet_dft_auto_u_prefix():
+    result = muster_modelchem("B3LYP", "energy", 3)
+    assert result["method_string"] == "UB3LYP"
+
+
+# rq-25c4ad49
+def test_muster_modelchem_no_double_u_prefix():
+    result = muster_modelchem("UHF", "energy", 2)
+    assert result["method_string"] == "UHF"
+
+
+# rq-fe13245b
+def test_muster_modelchem_rohf_no_u_prefix():
+    result = muster_modelchem("ROHF", "energy", 2)
+    assert result["method_string"] == "ROHF"
+
+
+# ---------------------------------------------------------------------------
+# Tests: keywords.build_route_line
+# ---------------------------------------------------------------------------
+
+
+# rq-af032242
+def test_build_route_line_hf_energy():
+    line = build_route_line("HF", "STO-3G", "", {}, {})
+    assert line == "#P HF/STO-3G"
+
+
+# rq-9acd1ce5
+def test_build_route_line_gradient():
+    line = build_route_line("HF", "STO-3G", "Force=NoStep", {}, {})
+    assert line.startswith("#P HF/STO-3G")
+    assert "Force=NoStep" in line
+
+
+# rq-cd0d6637
+def test_build_route_line_properties_pop_full():
+    line = build_route_line("HF", "STO-3G", "", {"Pop": "Full"}, {})
+    assert "Pop=Full" in line
+
+
+# rq-7152455e
+def test_build_route_line_user_keyword_appended():
+    line = build_route_line("HF", "STO-3G", "", {}, {"SCF": "Tight"})
+    assert "SCF=Tight" in line
+
+
+# rq-e7897f09
+def test_build_route_line_reserved_keywords_excluded():
+    line = build_route_line("HF", "STO-3G", "", {}, {"memory": "8GB", "nprocs": "4"})
+    assert "memory" not in line
+    assert "nprocs" not in line
+
+
+# ---------------------------------------------------------------------------
+# Tests: keywords.build_com_file
+# ---------------------------------------------------------------------------
+
+
+# rq-d7e8161d
+def test_build_com_file_link0_section():
+    com = build_com_file(
+        {"NProcShared": 4, "Mem": "8GB"},
+        "#P HF/STO-3G",
+        "title",
+        0,
+        1,
+        "H  0.0  0.0  0.0\nH  0.0  0.0  0.74",
+    )
+    assert com.startswith("%NProcShared=4\n%Mem=8GB")
+
+
+# rq-342a2ca3
+def test_build_com_file_charge_multiplicity_line():
+    com = build_com_file({"NProcShared": 1, "Mem": "1GB"}, "#P HF/STO-3G", "t", 1, 2, "H 0 0 0")
+    assert "1 2" in com
+
+
+# rq-b819d8e0
+def test_build_com_file_coordinate_precision():
+    atom_block = "O   0.0000000000   0.1171763200   0.0000000000"
+    com = build_com_file({"NProcShared": 1, "Mem": "1GB"}, "#P HF/STO-3G", "t", 0, 1, atom_block)
+    # Check there are at least 10 decimal digits in the atom line
+    assert re.search(r"\d+\.\d{10}", com)
+
+
+# rq-23d8b2c6
+def test_build_com_file_trailing_blank_line():
+    com = build_com_file({"NProcShared": 1, "Mem": "1GB"}, "#P HF/STO-3G", "t", 0, 1, "H 0 0 0")
+    assert com.endswith("\n\n")
+
+
+# rq-db92093a
+def test_build_input_memory_rounds_down_minimum_1(water_energy_input, harness):
+    from qcengine.config import TaskConfig
+
+    cfg = TaskConfig(scratch_directory=None, scratch_messy=False, ncores=1, memory=0.5, retries=0)
+    with patch("qcengine.programs.gaussian.runner._find_gaussian", return_value="/usr/local/g16/g16"):
+        job = harness.build_input(water_energy_input, cfg)
+    assert "%Mem=1GB" in job["infiles"]["gaussian.com"]
+
+
+# rq-4ad16d95
+def test_build_input_memory_whole_gb(water_energy_input, harness):
+    from qcengine.config import TaskConfig
+
+    cfg = TaskConfig(scratch_directory=None, scratch_messy=False, ncores=4, memory=8.0, retries=0)
+    with patch("qcengine.programs.gaussian.runner._find_gaussian", return_value="/usr/local/g16/g16"):
+        job = harness.build_input(water_energy_input, cfg)
+    assert "%Mem=8GB" in job["infiles"]["gaussian.com"]
+
+
+# rq-5053204b
+def test_build_input_ghost_atoms_raise(harness):
+    from qcengine.config import TaskConfig
+
+    ghost_mol = Molecule.from_data(
+        {"symbols": ["O", "H", "H"], "geometry": [0, 0, 0.2, 0, 1.4, -0.9, 0, -1.4, -0.9],
+         "real": [True, False, True]}
+    )
+    inp = AtomicInput(molecule=ghost_mol, driver="energy", model={"method": "HF", "basis": "STO-3G"})
+    cfg = TaskConfig(scratch_directory=None, scratch_messy=False, ncores=1, memory=1.0, retries=0)
+    with patch("qcengine.programs.gaussian.runner._find_gaussian", return_value="/usr/local/g16/g16"):
+        with pytest.raises(InputError):
+            harness.build_input(inp, cfg)
+
+
+# rq-0aa99076
+def test_build_input_basisset_object_raises(water, harness):
+    from qcengine.config import TaskConfig
+
+    bs = BasisSet(name="sto-3g", center_data={}, atom_map=[])
+    inp = AtomicInput(molecule=water, driver="energy", model={"method": "HF", "basis": bs})
+    cfg = TaskConfig(scratch_directory=None, scratch_messy=False, ncores=1, memory=1.0, retries=0)
+    with pytest.raises(InputError):
+        harness.build_input(inp, cfg)
+
+
+# ---------------------------------------------------------------------------
+# Tests: runner.GaussianHarness.found()
+# ---------------------------------------------------------------------------
+
+
+# rq-4cf7c460
+def test_found_true_when_g16_and_cclib_available(harness):
+    with patch("qcengine.programs.gaussian.runner._find_gaussian", return_value="/usr/local/g16/g16"):
+        with patch("qcengine.programs.gaussian.runner.which_import", return_value=True):
+            assert harness.found() is True
+
+
+# rq-d3b8d8c3
+def test_found_falls_back_to_g09(harness):
+    def fake_find():
+        # Simulates g16 absent, g09 present
+        from unittest.mock import call
+        return "/usr/local/g09/g09"
+
+    with patch("qcengine.programs.gaussian.runner._find_gaussian", side_effect=fake_find):
+        with patch("qcengine.programs.gaussian.runner.which_import", return_value=True):
+            assert harness.found() is True
+
+
+# rq-8e21b7d7
+def test_found_false_when_no_gaussian(harness):
+    with patch("qcengine.programs.gaussian.runner._find_gaussian", return_value=None):
+        assert harness.found() is False
+
+
+# rq-b5e72c6d
+def test_found_false_when_cclib_missing(harness):
+    with patch("qcengine.programs.gaussian.runner._find_gaussian", return_value="/usr/local/g16/g16"):
+        with patch("qcengine.programs.gaussian.runner.which_import", return_value=False):
+            assert harness.found() is False
+
+
+# rq-bd98d417
+def test_found_raises_when_gaussian_missing_raise_error(harness):
+    with patch("qcengine.programs.gaussian.runner._find_gaussian", return_value=None):
+        with pytest.raises(ModuleNotFoundError):
+            harness.found(raise_error=True)
+
+
+# rq-242ef1d8
+def test_found_raises_when_cclib_missing_raise_error(harness):
+    with patch("qcengine.programs.gaussian.runner._find_gaussian", return_value="/usr/local/g16/g16"):
+        with patch(
+            "qcengine.programs.gaussian.runner.which_import",
+            side_effect=ModuleNotFoundError("cclib not found"),
+        ):
+            with pytest.raises(ModuleNotFoundError):
+                harness.found(raise_error=True)
+
+
+# ---------------------------------------------------------------------------
+# Tests: runner.GaussianHarness.get_version()
+# ---------------------------------------------------------------------------
+
+_VERSION_BANNER_16 = (
+    " Gaussian 16, Revision C.02,\n"
+    " M. J. Frisch, et al.\n"
+    " Copyright (c) 1988-2017, Gaussian, Inc.\n"
+)
+
+_VERSION_BANNER_09 = (
+    " Gaussian 09, Revision D.01,\n"
+    " M. J. Frisch, et al.\n"
+)
+
+
+# rq-186c5060
+def test_get_version_g16(harness):
+    with patch("qcengine.programs.gaussian.runner._find_gaussian", return_value="/g16"):
+        with patch("qcengine.programs.gaussian.runner.which_import", return_value=True):
+            with patch(
+                "qcengine.programs.gaussian.runner.execute",
+                return_value=(True, {"stdout": _VERSION_BANNER_16, "stderr": "", "outfiles": {}}),
+            ):
+                harness.version_cache.clear()
+                version = harness.get_version()
+    assert version == "16.C.02"
+
+
+# rq-850ede4f
+def test_get_version_g09(harness):
+    with patch("qcengine.programs.gaussian.runner._find_gaussian", return_value="/g09"):
+        with patch("qcengine.programs.gaussian.runner.which_import", return_value=True):
+            with patch(
+                "qcengine.programs.gaussian.runner.execute",
+                return_value=(True, {"stdout": _VERSION_BANNER_09, "stderr": "", "outfiles": {}}),
+            ):
+                harness.version_cache.clear()
+                version = harness.get_version()
+    assert version == "09.D.01"
+
+
+# rq-3e134642
+def test_get_version_cached(harness):
+    harness.version_cache["/g16"] = "16.C.02"
+    with patch("qcengine.programs.gaussian.runner._find_gaussian", return_value="/g16"):
+        with patch("qcengine.programs.gaussian.runner.which_import", return_value=True):
+            with patch("qcengine.programs.gaussian.runner.execute") as mock_exe:
+                version = harness.get_version()
+                mock_exe.assert_not_called()
+    assert version == "16.C.02"
+    harness.version_cache.clear()
+
+
+# rq-20d9a784
+def test_get_version_unparseable_raises(harness):
+    with patch("qcengine.programs.gaussian.runner._find_gaussian", return_value="/g16"):
+        with patch("qcengine.programs.gaussian.runner.which_import", return_value=True):
+            with patch(
+                "qcengine.programs.gaussian.runner.execute",
+                return_value=(False, {"stdout": "no version here", "stderr": "", "outfiles": {}}),
+            ):
+                harness.version_cache.clear()
+                with pytest.raises(UnknownError):
+                    harness.get_version()
+
+
+# ---------------------------------------------------------------------------
+# Tests: runner.GaussianHarness.compute() — error dispatch
+# ---------------------------------------------------------------------------
+
+_NORMAL_LOG = "Normal termination of Gaussian 16\n"
+
+
+def _mock_compute(harness, water_energy_input, log_text):
+    """Helper: patch found, build_input, execute, and get_version for compute tests."""
+    job_record = {
+        "infiles": {"gaussian.com": "%NProcShared=1\n#P HF/STO-3G\n"},
+        "command": ["/g16", "gaussian.com"],
+        "scratch_directory": None,
+        "scratch_messy": False,
+    }
+    dexe = {
+        "outfiles": {"gaussian.log": log_text},
+        "stdout": "",
+        "stderr": "",
+    }
+    return job_record, dexe
+
+
+# rq-c77a2c13
+def test_compute_raises_for_basisset_object(harness, water):
+    bs = BasisSet(name="sto-3g", center_data={}, atom_map=[])
+    inp = AtomicInput(molecule=water, driver="energy", model={"method": "HF", "basis": bs})
+    with patch("qcengine.programs.gaussian.runner._find_gaussian", return_value="/g16"):
+        with patch("qcengine.programs.gaussian.runner.which_import", return_value=True):
+            with pytest.raises(InputError):
+                harness.compute(inp, MagicMock())
+
+
+# rq-a4c449da
+def test_compute_raises_resource_error_on_memory_failure(harness, water_energy_input):
+    log = "galloc: could not allocate memory\nError termination\n"
+    job_record, dexe = _mock_compute(harness, water_energy_input, log)
+    with patch("qcengine.programs.gaussian.runner._find_gaussian", return_value="/g16"):
+        with patch("qcengine.programs.gaussian.runner.which_import", return_value=True):
+            with patch.object(GaussianHarness, "build_input", return_value=job_record):
+                with patch.object(GaussianHarness, "execute", return_value=(False, dexe)):
+                    with pytest.raises(ResourceError):
+                        harness.compute(water_energy_input, MagicMock())
+
+
+# rq-165224fc
+def test_compute_raises_input_error_on_ernie(harness, water_energy_input):
+    log = "Ernie: is not defined as a Gaussian input file\nError termination\n"
+    job_record, dexe = _mock_compute(harness, water_energy_input, log)
+    with patch("qcengine.programs.gaussian.runner._find_gaussian", return_value="/g16"):
+        with patch("qcengine.programs.gaussian.runner.which_import", return_value=True):
+            with patch.object(GaussianHarness, "build_input", return_value=job_record):
+                with patch.object(GaussianHarness, "execute", return_value=(False, dexe)):
+                    with pytest.raises(InputError):
+                        harness.compute(water_energy_input, MagicMock())
+
+
+# rq-edb73b83
+def test_compute_raises_input_error_on_internal_coord(harness, water_energy_input):
+    log = "Error in internal coordinate system\nError termination\n"
+    job_record, dexe = _mock_compute(harness, water_energy_input, log)
+    with patch("qcengine.programs.gaussian.runner._find_gaussian", return_value="/g16"):
+        with patch("qcengine.programs.gaussian.runner.which_import", return_value=True):
+            with patch.object(GaussianHarness, "build_input", return_value=job_record):
+                with patch.object(GaussianHarness, "execute", return_value=(False, dexe)):
+                    with pytest.raises(InputError):
+                        harness.compute(water_energy_input, MagicMock())
+
+
+# rq-71aceb93
+def test_compute_raises_unknown_error_on_abnormal_termination(harness, water_energy_input):
+    log = "Something went wrong.\nError termination via Lnk1e\n"
+    job_record, dexe = _mock_compute(harness, water_energy_input, log)
+    with patch("qcengine.programs.gaussian.runner._find_gaussian", return_value="/g16"):
+        with patch("qcengine.programs.gaussian.runner.which_import", return_value=True):
+            with patch.object(GaussianHarness, "build_input", return_value=job_record):
+                with patch.object(GaussianHarness, "execute", return_value=(False, dexe)):
+                    with pytest.raises(UnknownError):
+                        harness.compute(water_energy_input, MagicMock())
+
+
+# ---------------------------------------------------------------------------
+# Tests: runner.GaussianHarness.compute() — success paths
+# ---------------------------------------------------------------------------
+
+def _full_compute_patches(harness, water_energy_input, log_text, ccdata, return_result):
+    """Return context-manager stack for a successful compute() call."""
+    from contextlib import ExitStack
+
+    job_record = {
+        "infiles": {"gaussian.com": "%NProcShared=1\n#P HF/STO-3G\n"},
+        "command": ["/g16", "gaussian.com"],
+        "scratch_directory": None,
+        "scratch_messy": False,
+    }
+    dexe = {
+        "outfiles": {"gaussian.log": log_text},
+        "stdout": "",
+        "stderr": "",
+    }
+
+    stack = ExitStack()
+    stack.enter_context(patch("qcengine.programs.gaussian.runner._find_gaussian", return_value="/g16"))
+    stack.enter_context(patch("qcengine.programs.gaussian.runner.which_import", return_value=True))
+    stack.enter_context(patch.object(GaussianHarness, "build_input", return_value=job_record))
+    stack.enter_context(patch.object(GaussianHarness, "execute", return_value=(True, dexe)))
+    stack.enter_context(patch.object(GaussianHarness, "get_version", return_value="16.C.02"))
+    stack.enter_context(_patch_cclib(ccdata))
+    return stack
+
+
+# rq-99807237
+def test_compute_returns_atomic_result_energy(harness, water_energy_input_all_files, water):
+    log_text = _NORMAL_LOG
+    ccdata = _make_ccdata_with_attrs(scfenergies=np.array([-2041.3]))
+
+    with _full_compute_patches(harness, water_energy_input_all_files, log_text, ccdata, None):
+        result = harness.compute(water_energy_input_all_files, MagicMock())
+
+    assert result.success is True
+    assert isinstance(result.return_result, float)
+    assert "gaussian.com" in result.native_files
+    assert "gaussian.log" in result.native_files
+    assert result.provenance.creator == "Gaussian"
+
+
+# rq-e62578e2
+def test_compute_returns_atomic_result_gradient(harness, water):
+    forces = np.array([[0.01, 0.0, -0.02], [0.0, 0.005, 0.01], [0.0, -0.005, 0.01]])
+    ccdata = _make_ccdata_with_attrs(
+        scfenergies=np.array([-2041.3]),
+        grads=forces[np.newaxis, :, :],  # shape (1, 3, 3)
+    )
+    inp = AtomicInput(molecule=water, driver="gradient", model={"method": "HF", "basis": "STO-3G"})
+    log_text = _NORMAL_LOG
+
+    job_record = {
+        "infiles": {"gaussian.com": ""},
+        "command": ["/g16", "gaussian.com"],
+        "scratch_directory": None,
+        "scratch_messy": False,
+    }
+    dexe = {"outfiles": {"gaussian.log": log_text}, "stdout": "", "stderr": ""}
+
+    with patch("qcengine.programs.gaussian.runner._find_gaussian", return_value="/g16"):
+        with patch("qcengine.programs.gaussian.runner.which_import", return_value=True):
+            with patch.object(GaussianHarness, "build_input", return_value=job_record):
+                with patch.object(GaussianHarness, "execute", return_value=(True, dexe)):
+                    with patch.object(GaussianHarness, "get_version", return_value="16.C.02"):
+                        with _patch_cclib(ccdata):
+                            result = harness.compute(inp, MagicMock())
+
+    assert result.success is True
+    # AtomicResult shapes gradient as (natoms, 3); 3 atoms → shape (3, 3)
+    assert np.array(result.return_result).shape == (3, 3)
+
+
+# rq-4d683dac
+def test_compute_returns_atomic_result_hessian(harness, water):
+    hess_matrix = np.eye(9) * 0.5
+    ccdata = _make_ccdata_with_attrs(
+        scfenergies=np.array([-2041.3]),
+        hessian=hess_matrix,
+    )
+    inp = AtomicInput(molecule=water, driver="hessian", model={"method": "HF", "basis": "STO-3G"})
+    log_text = _NORMAL_LOG
+
+    job_record = {
+        "infiles": {"gaussian.com": ""},
+        "command": ["/g16", "gaussian.com"],
+        "scratch_directory": None,
+        "scratch_messy": False,
+    }
+    dexe = {"outfiles": {"gaussian.log": log_text}, "stdout": "", "stderr": ""}
+
+    with patch("qcengine.programs.gaussian.runner._find_gaussian", return_value="/g16"):
+        with patch("qcengine.programs.gaussian.runner.which_import", return_value=True):
+            with patch.object(GaussianHarness, "build_input", return_value=job_record):
+                with patch.object(GaussianHarness, "execute", return_value=(True, dexe)):
+                    with patch.object(GaussianHarness, "get_version", return_value="16.C.02"):
+                        with _patch_cclib(ccdata):
+                            result = harness.compute(inp, MagicMock())
+
+    assert result.success is True
+    # AtomicResult shapes hessian as (3*natoms, 3*natoms); 3 atoms → (9, 9)
+    assert np.array(result.return_result).shape == (9, 9)
+
+
+# rq-1a051bc2
+def test_compute_returns_atomic_result_properties(harness, water):
+    ccdata = _make_ccdata_with_attrs(
+        scfenergies=np.array([-2041.3]),
+        moments=[None, np.array([0.0, 1.85, 0.0])],
+        atomcharges={"mulliken": [-0.5, 0.25, 0.25]},
+    )
+    inp = AtomicInput(molecule=water, driver="properties", model={"method": "HF", "basis": "STO-3G"})
+    log_text = _NORMAL_LOG
+
+    job_record = {
+        "infiles": {"gaussian.com": ""},
+        "command": ["/g16", "gaussian.com"],
+        "scratch_directory": None,
+        "scratch_messy": False,
+    }
+    dexe = {"outfiles": {"gaussian.log": log_text}, "stdout": "", "stderr": ""}
+
+    with patch("qcengine.programs.gaussian.runner._find_gaussian", return_value="/g16"):
+        with patch("qcengine.programs.gaussian.runner.which_import", return_value=True):
+            with patch.object(GaussianHarness, "build_input", return_value=job_record):
+                with patch.object(GaussianHarness, "execute", return_value=(True, dexe)):
+                    with patch.object(GaussianHarness, "get_version", return_value="16.C.02"):
+                        with _patch_cclib(ccdata):
+                            result = harness.compute(inp, MagicMock())
+
+    assert result.success is True
+    assert isinstance(result.return_result, float)
+    assert "CURRENT ENERGY" in result.extras["qcvars"]
+
+
+# ---------------------------------------------------------------------------
+# Tests: harvester.harvest() — energy parsing
+# ---------------------------------------------------------------------------
+
+
+def _make_water_mol():
+    return Molecule.from_data(
+        """
+        0 1
+        O  0.000000000  0.000000000  0.117176320
+        H  0.000000000  0.757335953 -0.468705281
+        H  0.000000000 -0.757335953 -0.468705281
+        units angstrom
+        """
+    )
+
+
+# rq-71b27e68
+def test_harvest_hf_energy():
+    in_mol = _make_water_mol()
+    ccdata = _make_ccdata_with_attrs(scfenergies=np.array([-2041.3]))
+    with _patch_cclib(ccdata):
+        qcvars, grad, hess, out_mol = harvest(in_mol, "hf", "dummy log")
+    expected = -2041.3 * _EV_TO_HARTREE
+    assert abs(float(qcvars["HF TOTAL ENERGY"]) - expected) < 1e-8
+    assert abs(float(qcvars["CURRENT ENERGY"]) - float(qcvars["HF TOTAL ENERGY"])) < 1e-12
+
+
+# rq-6bff3228
+def test_harvest_dft_energy():
+    in_mol = _make_water_mol()
+    ccdata = _make_ccdata_with_attrs(scfenergies=np.array([-2082.1]))
+    with _patch_cclib(ccdata):
+        qcvars, grad, hess, out_mol = harvest(in_mol, "b3lyp", "dummy log")
+    expected = -2082.1 * _EV_TO_HARTREE
+    assert abs(float(qcvars["HF TOTAL ENERGY"]) - expected) < 1e-8
+    assert abs(float(qcvars["CURRENT ENERGY"]) - float(qcvars["HF TOTAL ENERGY"])) < 1e-12
+
+
+# rq-578bb785
+def test_harvest_mp2_energies():
+    in_mol = _make_water_mol()
+    ccdata = _make_ccdata_with_attrs(
+        scfenergies=np.array([-2041.3]),
+        mpenergies=np.array([[-2044.8]]),
+    )
+    with _patch_cclib(ccdata):
+        qcvars, grad, hess, out_mol = harvest(in_mol, "mp2", "dummy log")
+    hf_h = -2041.3 * _EV_TO_HARTREE
+    mp2_h = -2044.8 * _EV_TO_HARTREE
+    assert abs(float(qcvars["HF TOTAL ENERGY"]) - hf_h) < 1e-8
+    assert abs(float(qcvars["MP2 TOTAL ENERGY"]) - mp2_h) < 1e-8
+    assert abs(float(qcvars["MP2 CORRELATION ENERGY"]) - (mp2_h - hf_h)) < 1e-8
+    assert abs(float(qcvars["CURRENT ENERGY"]) - mp2_h) < 1e-8
+
+
+# rq-1b7ae62e
+def test_harvest_ccsd_energies():
+    in_mol = _make_water_mol()
+    ccdata = _make_ccdata_with_attrs(
+        scfenergies=np.array([-2041.3]),
+        ccenergies=np.array([-2045.2]),
+    )
+    with _patch_cclib(ccdata):
+        qcvars, grad, hess, out_mol = harvest(in_mol, "ccsd", "dummy log")
+    hf_h = -2041.3 * _EV_TO_HARTREE
+    ccsd_h = -2045.2 * _EV_TO_HARTREE
+    assert abs(float(qcvars["CCSD TOTAL ENERGY"]) - ccsd_h) < 1e-8
+    assert abs(float(qcvars["CCSD CORRELATION ENERGY"]) - (ccsd_h - hf_h)) < 1e-8
+    assert abs(float(qcvars["CURRENT ENERGY"]) - ccsd_h) < 1e-8
+
+
+# rq-eddef743
+def test_harvest_ccsd_t_energies():
+    in_mol = _make_water_mol()
+    ccdata = _make_ccdata_with_attrs(
+        scfenergies=np.array([-2041.3]),
+        ccenergies=np.array([-2045.5]),
+    )
+    with _patch_cclib(ccdata):
+        qcvars, grad, hess, out_mol = harvest(in_mol, "ccsd(t)", "dummy log")
+    ccsdt_h = -2045.5 * _EV_TO_HARTREE
+    assert abs(float(qcvars["CCSD(T) TOTAL ENERGY"]) - ccsdt_h) < 1e-8
+    assert abs(float(qcvars["CURRENT ENERGY"]) - ccsdt_h) < 1e-8
+
+
+# ---------------------------------------------------------------------------
+# Tests: harvester.harvest() — gradient parsing
+# ---------------------------------------------------------------------------
+
+
+# rq-36736115
+def test_harvest_gradient_negated():
+    in_mol = _make_water_mol()
+    forces = np.array([[0.01, 0.0, -0.02], [0.0, 0.005, 0.01], [0.0, -0.005, 0.01]])
+    ccdata = _make_ccdata_with_attrs(
+        scfenergies=np.array([-2041.3]),
+        grads=forces[np.newaxis, :, :],
+    )
+    with _patch_cclib(ccdata):
+        qcvars, grad, hess, out_mol = harvest(in_mol, "hf", "dummy log")
+    expected = -forces.flatten()
+    assert grad is not None
+    np.testing.assert_allclose(grad, expected, atol=1e-12)
+
+
+# rq-3b0adf96
+def test_harvest_no_gradient_when_absent():
+    in_mol = _make_water_mol()
+    ccdata = _make_ccdata_with_attrs(scfenergies=np.array([-2041.3]))
+    # grads is None (no attribute)
+    with _patch_cclib(ccdata):
+        qcvars, grad, hess, out_mol = harvest(in_mol, "hf", "dummy log")
+    assert grad is None
+
+
+# ---------------------------------------------------------------------------
+# Tests: harvester.harvest() — Hessian parsing
+# ---------------------------------------------------------------------------
+
+
+# rq-f2e32162
+def test_harvest_hessian():
+    in_mol = _make_water_mol()
+    hess_matrix = np.eye(9) * 0.5
+    ccdata = _make_ccdata_with_attrs(
+        scfenergies=np.array([-2041.3]),
+        hessian=hess_matrix,
+    )
+    with _patch_cclib(ccdata):
+        qcvars, grad, hess, out_mol = harvest(in_mol, "hf", "dummy log")
+    assert hess is not None
+    assert hess.shape == (9, 9)
+    np.testing.assert_allclose(hess, hess_matrix)
+
+
+# rq-344f3432
+def test_harvest_no_hessian_when_absent():
+    in_mol = _make_water_mol()
+    ccdata = _make_ccdata_with_attrs(scfenergies=np.array([-2041.3]))
+    with _patch_cclib(ccdata):
+        qcvars, grad, hess, out_mol = harvest(in_mol, "hf", "dummy log")
+    assert hess is None
+
+
+# ---------------------------------------------------------------------------
+# Tests: harvester.harvest() — properties parsing
+# ---------------------------------------------------------------------------
+
+
+# rq-4c4a1542
+def test_harvest_dipole_moment():
+    in_mol = _make_water_mol()
+    dipole_vec = np.array([0.0, 1.85, 0.0])
+    ccdata = _make_ccdata_with_attrs(
+        scfenergies=np.array([-2041.3]),
+        moments=[None, dipole_vec],
+    )
+    with _patch_cclib(ccdata):
+        qcvars, grad, hess, out_mol = harvest(in_mol, "hf", "dummy log")
+    assert abs(float(qcvars["DIPOLE MOMENT"]) - 1.85) < 1e-6
+
+
+# rq-ffae3fa6
+def test_harvest_mulliken_charges():
+    in_mol = _make_water_mol()
+    charges = [-0.5, 0.25, 0.25]
+    ccdata = _make_ccdata_with_attrs(
+        scfenergies=np.array([-2041.3]),
+        atomcharges={"mulliken": charges},
+    )
+    with _patch_cclib(ccdata):
+        qcvars, grad, hess, out_mol = harvest(in_mol, "hf", "dummy log")
+    assert "MULLIKEN CHARGES" in qcvars
+    assert len(qcvars["MULLIKEN CHARGES"]) == 3
+
+
+# rq-53f8ed12
+def test_harvest_missing_mulliken_no_error():
+    in_mol = _make_water_mol()
+    ccdata = _make_ccdata_with_attrs(
+        scfenergies=np.array([-2041.3]),
+        atomcharges={},
+    )
+    with _patch_cclib(ccdata):
+        qcvars, grad, hess, out_mol = harvest(in_mol, "hf", "dummy log")
+    assert "MULLIKEN CHARGES" not in qcvars
+
+
+# ---------------------------------------------------------------------------
+# Tests: harvester.harvest() — geometry and molecule output
+# ---------------------------------------------------------------------------
+
+
+# rq-a76c3d7b
+def test_harvest_output_molecule_symbols():
+    in_mol = _make_water_mol()
+    ccdata = _make_ccdata_with_attrs(scfenergies=np.array([-2041.3]))
+    with _patch_cclib(ccdata):
+        qcvars, grad, hess, out_mol = harvest(in_mol, "hf", "dummy log")
+    assert list(out_mol.symbols) == ["O", "H", "H"]
+
+
+# rq-a9194afb
+def test_harvest_nre_cross_check_passes():
+    in_mol = _make_water_mol()
+    ccdata = _make_ccdata_with_attrs(scfenergies=np.array([-2041.3]))
+    # Should not raise
+    with _patch_cclib(ccdata):
+        harvest(in_mol, "hf", "dummy log")
+
+
+# rq-0b4cf843
+def test_harvest_nre_mismatch_raises():
+    in_mol = _make_water_mol()
+    # Use very different geometry to force NRE mismatch
+    far_coords = np.array([[[0.0, 0.0, 100.0], [0.0, 0.0, 200.0], [0.0, 0.0, 300.0]]])
+    ccdata = _make_ccdata_with_attrs(
+        scfenergies=np.array([-2041.3]),
+        atomcoords=far_coords,
+    )
+    with _patch_cclib(ccdata):
+        with pytest.raises(ValueError, match="inconsistent"):
+            harvest(in_mol, "hf", "dummy log")
+
+
+# ---------------------------------------------------------------------------
+# Tests: harvester.harvest() — error conditions
+# ---------------------------------------------------------------------------
+
+
+# rq-b7c7b8cb
+def test_harvest_no_coords_raises():
+    in_mol = _make_water_mol()
+    ccdata = _make_ccdata_with_attrs(
+        scfenergies=np.array([-2041.3]),
+        atomcoords=np.array([]),  # empty
+    )
+    with _patch_cclib(ccdata):
+        with pytest.raises(ValueError):
+            harvest(in_mol, "hf", "dummy log")
+
+
+# rq-bb775969
+def test_harvest_cclib_parse_failure_propagates():
+    in_mol = _make_water_mol()
+    with patch(
+        "cclib.io.ccopen",
+        side_effect=Exception("cclib parse error"),
+    ):
+        with pytest.raises(Exception, match="cclib parse error"):
+            harvest(in_mol, "hf", "unparseable log")
+
+
+# ---------------------------------------------------------------------------
+# Tests: harvester.is_normal_termination()
+# ---------------------------------------------------------------------------
+
+
+# rq-90141f40
+def test_is_normal_termination_true():
+    log = "Some output\nNormal termination of Gaussian 16\n"
+    assert is_normal_termination(log) is True
+
+
+# rq-12c41d5e
+def test_is_normal_termination_false():
+    log = "Some output\nError termination via Lnk1e\n"
+    assert is_normal_termination(log) is False
+
+
+# ---------------------------------------------------------------------------
+# Integration tests (require Gaussian + cclib installed)
+# ---------------------------------------------------------------------------
+
+
+@using("gaussian")
+def test_gaussian_energy_water(water):
+    """End-to-end HF/STO-3G energy on water via the actual Gaussian executable."""
+    import qcengine as qcng
+
+    result = qcng.compute(
+        {
+            "molecule": water.dict(),
+            "driver": "energy",
+            "model": {"method": "HF", "basis": "STO-3G"},
+        },
+        "gaussian",
+        raise_error=True,
+    )
+    assert result.success is True
+    assert result.return_result < 0.0
+    assert "HF TOTAL ENERGY" in result.extras["qcvars"]
+
+
+@using("gaussian")
+def test_gaussian_gradient_water(water):
+    """End-to-end HF/STO-3G gradient on water via the actual Gaussian executable."""
+    import qcengine as qcng
+
+    result = qcng.compute(
+        {
+            "molecule": water.dict(),
+            "driver": "gradient",
+            "model": {"method": "HF", "basis": "STO-3G"},
+        },
+        "gaussian",
+        raise_error=True,
+    )
+    assert result.success is True
+    assert np.array(result.return_result).shape == (3, 3)

--- a/qcengine/programs/tests/test_gaussian.py
+++ b/qcengine/programs/tests/test_gaussian.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pytest
 import qcelemental as qcel
-from qcelemental.models import AtomicInput, BasisSet, Molecule
+from qcelemental.models.v2 import AtomicInput, AtomicSpecification, BasisSet, Molecule
 
 from qcengine.exceptions import InputError, ResourceError, UnknownError
 from qcengine.programs.gaussian.germinate import muster_modelchem
@@ -16,7 +16,7 @@ from qcengine.programs.gaussian.harvester import harvest, is_normal_termination
 from qcengine.programs.gaussian.keywords import build_com_file, build_route_line
 from qcengine.programs.gaussian import runner as gaussian_runner
 from qcengine.programs.gaussian.runner import GaussianHarness
-from qcengine.testing import using
+from qcengine.testing import uusing as using
 
 # ---------------------------------------------------------------------------
 # Shared test fixtures
@@ -42,7 +42,7 @@ def water():
 @pytest.fixture
 def water_energy_input(water):
     """Minimal AtomicInput for a closed-shell HF/STO-3G energy on water."""
-    return AtomicInput(molecule=water, driver="energy", model={"method": "HF", "basis": "STO-3G"})
+    return AtomicInput(molecule=water, specification=AtomicSpecification(program="gaussian", driver="energy", model={"method": "HF", "basis": "STO-3G"}))
 
 
 @pytest.fixture
@@ -50,9 +50,12 @@ def water_energy_input_all_files(water):
     """AtomicInput with native_files protocol set to 'all' for testing file output."""
     return AtomicInput(
         molecule=water,
-        driver="energy",
-        model={"method": "HF", "basis": "STO-3G"},
-        protocols={"native_files": "all"},
+        specification=AtomicSpecification(
+            program="gaussian",
+            driver="energy",
+            model={"method": "HF", "basis": "STO-3G"},
+            protocols={"native_files": "all"},
+        ),
     )
 
 
@@ -336,7 +339,7 @@ def test_build_com_file_trailing_blank_line():
 def test_build_input_memory_rounds_down_minimum_1(water_energy_input, harness):
     from qcengine.config import TaskConfig
 
-    cfg = TaskConfig(scratch_directory=None, scratch_messy=False, ncores=1, memory=0.5, retries=0)
+    cfg = TaskConfig(scratch_directory=None, scratch_messy=False, ncores=1, nnodes=1, memory=0.5, retries=0, mpiexec_command=None)
     with patch("qcengine.programs.gaussian.runner._find_gaussian", return_value="/usr/local/g16/g16"):
         job = harness.build_input(water_energy_input, cfg)
     assert "%Mem=1GB" in job["infiles"]["gaussian.com"]
@@ -346,7 +349,7 @@ def test_build_input_memory_rounds_down_minimum_1(water_energy_input, harness):
 def test_build_input_memory_whole_gb(water_energy_input, harness):
     from qcengine.config import TaskConfig
 
-    cfg = TaskConfig(scratch_directory=None, scratch_messy=False, ncores=4, memory=8.0, retries=0)
+    cfg = TaskConfig(scratch_directory=None, scratch_messy=False, ncores=4, nnodes=1, memory=8.0, retries=0, mpiexec_command=None)
     with patch("qcengine.programs.gaussian.runner._find_gaussian", return_value="/usr/local/g16/g16"):
         job = harness.build_input(water_energy_input, cfg)
     assert "%Mem=8GB" in job["infiles"]["gaussian.com"]
@@ -360,8 +363,8 @@ def test_build_input_ghost_atoms_raise(harness):
         {"symbols": ["O", "H", "H"], "geometry": [0, 0, 0.2, 0, 1.4, -0.9, 0, -1.4, -0.9],
          "real": [True, False, True]}
     )
-    inp = AtomicInput(molecule=ghost_mol, driver="energy", model={"method": "HF", "basis": "STO-3G"})
-    cfg = TaskConfig(scratch_directory=None, scratch_messy=False, ncores=1, memory=1.0, retries=0)
+    inp = AtomicInput(molecule=ghost_mol, specification=AtomicSpecification(program="gaussian", driver="energy", model={"method": "HF", "basis": "STO-3G"}))
+    cfg = TaskConfig(scratch_directory=None, scratch_messy=False, ncores=1, nnodes=1, memory=1.0, retries=0, mpiexec_command=None)
     with patch("qcengine.programs.gaussian.runner._find_gaussian", return_value="/usr/local/g16/g16"):
         with pytest.raises(InputError):
             harness.build_input(inp, cfg)
@@ -372,8 +375,8 @@ def test_build_input_basisset_object_raises(water, harness):
     from qcengine.config import TaskConfig
 
     bs = BasisSet(name="sto-3g", center_data={}, atom_map=[])
-    inp = AtomicInput(molecule=water, driver="energy", model={"method": "HF", "basis": bs})
-    cfg = TaskConfig(scratch_directory=None, scratch_messy=False, ncores=1, memory=1.0, retries=0)
+    inp = AtomicInput(molecule=water, specification=AtomicSpecification(program="gaussian", driver="energy", model={"method": "HF", "basis": bs}))
+    cfg = TaskConfig(scratch_directory=None, scratch_messy=False, ncores=1, nnodes=1, memory=1.0, retries=0, mpiexec_command=None)
     with pytest.raises(InputError):
         harness.build_input(inp, cfg)
 
@@ -526,7 +529,7 @@ def _mock_compute(harness, water_energy_input, log_text):
 # rq-c77a2c13
 def test_compute_raises_for_basisset_object(harness, water):
     bs = BasisSet(name="sto-3g", center_data={}, atom_map=[])
-    inp = AtomicInput(molecule=water, driver="energy", model={"method": "HF", "basis": bs})
+    inp = AtomicInput(molecule=water, specification=AtomicSpecification(program="gaussian", driver="energy", model={"method": "HF", "basis": bs}))
     with patch("qcengine.programs.gaussian.runner._find_gaussian", return_value="/g16"):
         with patch("qcengine.programs.gaussian.runner.which_import", return_value=True):
             with pytest.raises(InputError):
@@ -633,7 +636,7 @@ def test_compute_returns_atomic_result_gradient(harness, water):
         scfenergies=np.array([-2041.3]),
         grads=forces[np.newaxis, :, :],  # shape (1, 3, 3)
     )
-    inp = AtomicInput(molecule=water, driver="gradient", model={"method": "HF", "basis": "STO-3G"})
+    inp = AtomicInput(molecule=water, specification=AtomicSpecification(program="gaussian", driver="gradient", model={"method": "HF", "basis": "STO-3G"}))
     log_text = _NORMAL_LOG
 
     job_record = {
@@ -664,7 +667,7 @@ def test_compute_returns_atomic_result_hessian(harness, water):
         scfenergies=np.array([-2041.3]),
         hessian=hess_matrix,
     )
-    inp = AtomicInput(molecule=water, driver="hessian", model={"method": "HF", "basis": "STO-3G"})
+    inp = AtomicInput(molecule=water, specification=AtomicSpecification(program="gaussian", driver="hessian", model={"method": "HF", "basis": "STO-3G"}))
     log_text = _NORMAL_LOG
 
     job_record = {
@@ -695,7 +698,7 @@ def test_compute_returns_atomic_result_properties(harness, water):
         moments=[None, np.array([0.0, 1.85, 0.0])],
         atomcharges={"mulliken": [-0.5, 0.25, 0.25]},
     )
-    inp = AtomicInput(molecule=water, driver="properties", model={"method": "HF", "basis": "STO-3G"})
+    inp = AtomicInput(molecule=water, specification=AtomicSpecification(program="gaussian", driver="properties", model={"method": "HF", "basis": "STO-3G"}))
     log_text = _NORMAL_LOG
 
     job_record = {
@@ -1001,11 +1004,7 @@ def test_gaussian_energy_water(water):
     import qcengine as qcng
 
     result = qcng.compute(
-        {
-            "molecule": water.dict(),
-            "driver": "energy",
-            "model": {"method": "HF", "basis": "STO-3G"},
-        },
+        AtomicInput(molecule=water, specification=AtomicSpecification(program="gaussian", driver="energy", model={"method": "HF", "basis": "STO-3G"})),
         "gaussian",
         raise_error=True,
     )
@@ -1020,11 +1019,7 @@ def test_gaussian_gradient_water(water):
     import qcengine as qcng
 
     result = qcng.compute(
-        {
-            "molecule": water.dict(),
-            "driver": "gradient",
-            "model": {"method": "HF", "basis": "STO-3G"},
-        },
+        AtomicInput(molecule=water, specification=AtomicSpecification(program="gaussian", driver="gradient", model={"method": "HF", "basis": "STO-3G"})),
         "gaussian",
         raise_error=True,
     )

--- a/qcengine/programs/tests/test_gaussian.py
+++ b/qcengine/programs/tests/test_gaussian.py
@@ -26,12 +26,17 @@ requires_cclib = pytest.mark.skipif(not _cclib_available, reason="cclib not inst
 # Shared test fixtures
 # ---------------------------------------------------------------------------
 
-# The harvester now reverses cclib's eV-stored energies via cclib's own
-# convertor (avoiding the ~3.6e-6 Ha bias from qcel's slightly different CODATA
-# factor). Tests of the cclib-fallback path compute expected values via the
-# same factor so the round-trip is exact.
+# The harvester reads all energies via cclib's parsed attributes and reverses
+# the eV → Hartree conversion with cclib's own convertor (structurally exact).
+# Tests compute expected values via the same factor so the round-trip is exact.
 from cclib.parser.utils import convertor as _cclib_convertor  # noqa: E402
 _EV_TO_HARTREE = _cclib_convertor(1.0, "eV", "hartree")
+_HARTREE_TO_EV = _cclib_convertor(1.0, "hartree", "eV")
+
+
+def _ha_to_ev(value_ha):
+    """Convert Hartree → eV via cclib's converter for use in test mocks."""
+    return _cclib_convertor(value_ha, "hartree", "eV")
 
 
 @pytest.fixture
@@ -1753,73 +1758,71 @@ def test_dispersion_method_suffix_only(harness, water):
 # ---------------------------------------------------------------------------
 
 
-_DISP_LOG_SNIPPET = (
-    " SCF Done:  E(RB3LYP) =  -76.4014123456     A.U. after   12 cycles\n"
-    " Dispersion energy=       -0.0046617305 Hartrees.\n"
-)
+_DISP_SCF_HA = -76.4014123456
+_DISP_DISP_HA = -0.0046617305
+
+
+def _disp_ccdata(scf_ha=_DISP_SCF_HA, disp_ha=_DISP_DISP_HA, disp_present=True):
+    """Build a mock ccdata for B3LYP-D3-like calculations.
+
+    Both energies are stored in eV via cclib's converter, so harvest()'s
+    inverse cclib.parser.utils.convertor("eV", "hartree") recovers the
+    original Hartree values exactly.
+    """
+    ccdata = _make_ccdata_with_attrs(scfenergies=np.array([_ha_to_ev(scf_ha)]))
+    if disp_present:
+        ccdata.dispersionenergies = np.array([_ha_to_ev(disp_ha)])
+    return ccdata
 
 
 # rq-1d5da737
 @requires_cclib
-def test_dispersion_harvest_regex_path():
+def test_dispersion_harvest_from_cclib():
+    """Dispersion energy is read from ccdata.dispersionenergies."""
     in_mol = _make_water_mol()
-    ccdata = _make_ccdata_with_attrs(scfenergies=np.array([-2079.3]))
-    with _patch_cclib(ccdata):
-        qcvars, _, _, _ = harvest(in_mol, "b3lyp-d3", _DISP_LOG_SNIPPET)
-    assert abs(float(qcvars["DISPERSION CORRECTION ENERGY"]) - (-0.0046617305)) < 1e-12
+    with _patch_cclib(_disp_ccdata()):
+        qcvars, _, _, _ = harvest(in_mol, "b3lyp-d3", "")
+    assert abs(float(qcvars["DISPERSION CORRECTION ENERGY"]) - _DISP_DISP_HA) < 1e-12
 
 
 # rq-1d5da737
 @requires_cclib
-def test_dispersion_harvest_cclib_fallback():
-    """When the log has no 'Dispersion energy=' line, fall back to ccdata.dispersionenergies."""
+def test_dispersion_harvest_no_dispersionenergies_no_qcvars():
+    """When ccdata has no dispersionenergies attribute, no dispersion qcvars are set."""
     in_mol = _make_water_mol()
-    # eV values that round-trip to a known Hartree quantity
-    disp_ev = -0.1269192
-    ccdata = _make_ccdata_with_attrs(scfenergies=np.array([-2079.3]))
-    ccdata.dispersionenergies = np.array([disp_ev])
-    with _patch_cclib(ccdata):
-        qcvars, _, _, _ = harvest(in_mol, "b3lyp-d3", "SCF Done: E(RB3LYP) = -76.4 A.U. after 10 cycles\n")
-    expected = disp_ev * _EV_TO_HARTREE
-    assert abs(float(qcvars["DISPERSION CORRECTION ENERGY"]) - expected) < 1e-8
+    with _patch_cclib(_disp_ccdata(disp_present=False)):
+        qcvars, _, _, _ = harvest(in_mol, "b3lyp-d3", "")
+    assert "DISPERSION CORRECTION ENERGY" not in qcvars
+    assert "B3LYP-D3 DISPERSION CORRECTION ENERGY" not in qcvars
 
 
 # rq-1d5da737
 @requires_cclib
 def test_dispersion_harvest_functional_specific_qcvars():
     in_mol = _make_water_mol()
-    ccdata = _make_ccdata_with_attrs(scfenergies=np.array([-2079.3]))
-    with _patch_cclib(ccdata):
-        qcvars, _, _, _ = harvest(in_mol, "b3lyp-d3", _DISP_LOG_SNIPPET)
+    with _patch_cclib(_disp_ccdata()):
+        qcvars, _, _, _ = harvest(in_mol, "b3lyp-d3", "")
     assert "B3LYP-D3 DISPERSION CORRECTION ENERGY" in qcvars
-    assert abs(float(qcvars["B3LYP-D3 DISPERSION CORRECTION ENERGY"]) - (-0.0046617305)) < 1e-12
+    assert abs(float(qcvars["B3LYP-D3 DISPERSION CORRECTION ENERGY"]) - _DISP_DISP_HA) < 1e-12
 
 
 # rq-1d5da737
 @requires_cclib
 def test_dispersion_harvest_functional_total_excludes_dispersion():
     in_mol = _make_water_mol()
-    ccdata = _make_ccdata_with_attrs(scfenergies=np.array([-2079.3]))
-    with _patch_cclib(ccdata):
-        qcvars, _, _, _ = harvest(in_mol, "b3lyp-d3", _DISP_LOG_SNIPPET)
-    scf = -76.4014123456
-    disp = -0.0046617305
-    assert abs(float(qcvars["B3LYP FUNCTIONAL TOTAL ENERGY"]) - scf) < 1e-10
-    assert abs(float(qcvars["B3LYP-D3 TOTAL ENERGY"]) - (scf + disp)) < 1e-10
-    assert abs(float(qcvars["CURRENT ENERGY"]) - (scf + disp)) < 1e-10
+    with _patch_cclib(_disp_ccdata()):
+        qcvars, _, _, _ = harvest(in_mol, "b3lyp-d3", "")
+    assert abs(float(qcvars["B3LYP FUNCTIONAL TOTAL ENERGY"]) - _DISP_SCF_HA) < 1e-10
+    assert abs(float(qcvars["B3LYP-D3 TOTAL ENERGY"]) - (_DISP_SCF_HA + _DISP_DISP_HA)) < 1e-10
+    assert abs(float(qcvars["CURRENT ENERGY"]) - (_DISP_SCF_HA + _DISP_DISP_HA)) < 1e-10
 
 
 # rq-1d5da737
 @requires_cclib
 def test_dispersion_harvest_d3bj_uses_parenthesised_label():
     in_mol = _make_water_mol()
-    log = (
-        " SCF Done:  E(RB3LYP) =  -76.4014123456     A.U. after   12 cycles\n"
-        " Dispersion energy=       -0.0070000000 Hartrees.\n"
-    )
-    ccdata = _make_ccdata_with_attrs(scfenergies=np.array([-2079.3]))
-    with _patch_cclib(ccdata):
-        qcvars, _, _, _ = harvest(in_mol, "b3lyp-d3bj", log)
+    with _patch_cclib(_disp_ccdata(disp_ha=-0.007)):
+        qcvars, _, _, _ = harvest(in_mol, "b3lyp-d3bj", "")
     assert "B3LYP-D3(BJ) DISPERSION CORRECTION ENERGY" in qcvars
     assert "B3LYP-D3(BJ) TOTAL ENERGY" in qcvars
 
@@ -1828,13 +1831,11 @@ def test_dispersion_harvest_d3bj_uses_parenthesised_label():
 @requires_cclib
 def test_dispersion_harvest_scf_hf_unchanged():
     in_mol = _make_water_mol()
-    ccdata = _make_ccdata_with_attrs(scfenergies=np.array([-2079.3]))
-    with _patch_cclib(ccdata):
-        qcvars, _, _, _ = harvest(in_mol, "b3lyp-d3", _DISP_LOG_SNIPPET)
-    scf = -76.4014123456
+    with _patch_cclib(_disp_ccdata()):
+        qcvars, _, _, _ = harvest(in_mol, "b3lyp-d3", "")
     # SCF TOTAL ENERGY / HF TOTAL ENERGY excludes the dispersion contribution
-    assert abs(float(qcvars["HF TOTAL ENERGY"]) - scf) < 1e-10
-    assert abs(float(qcvars["SCF TOTAL ENERGY"]) - scf) < 1e-10
+    assert abs(float(qcvars["HF TOTAL ENERGY"]) - _DISP_SCF_HA) < 1e-10
+    assert abs(float(qcvars["SCF TOTAL ENERGY"]) - _DISP_SCF_HA) < 1e-10
 
 
 # rq-1d5da737
@@ -1842,17 +1843,14 @@ def test_dispersion_harvest_scf_hf_unchanged():
 def test_dispersion_harvest_method_without_suffix_no_functional_qcvars():
     """If user passes EmpiricalDispersion via keyword (no method suffix), generic qcvars only."""
     in_mol = _make_water_mol()
-    ccdata = _make_ccdata_with_attrs(scfenergies=np.array([-2079.3]))
-    with _patch_cclib(ccdata):
-        qcvars, _, _, _ = harvest(in_mol, "b3lyp", _DISP_LOG_SNIPPET)
+    with _patch_cclib(_disp_ccdata()):
+        qcvars, _, _, _ = harvest(in_mol, "b3lyp", "")
     assert "DISPERSION CORRECTION ENERGY" in qcvars
     # No formal dash label known → no functional-specific qcvars
     assert "B3LYP-D3 DISPERSION CORRECTION ENERGY" not in qcvars
     assert "B3LYP-D3 TOTAL ENERGY" not in qcvars
     # CURRENT ENERGY still reflects scf + disp for DFT
-    scf = -76.4014123456
-    disp = -0.0046617305
-    assert abs(float(qcvars["CURRENT ENERGY"]) - (scf + disp)) < 1e-10
+    assert abs(float(qcvars["CURRENT ENERGY"]) - (_DISP_SCF_HA + _DISP_DISP_HA)) < 1e-10
 
 
 # rq-1d5da737
@@ -1883,17 +1881,139 @@ def test_dispersion_harvest_nlc_method_no_dispersion_qcvars():
 # rq-1d5da737
 @requires_cclib
 def test_dispersion_harvest_gradient_unchanged():
-    """Dispersion in log doesn't disturb the gradient pipeline; cclib's grads is the total."""
+    """Dispersion in ccdata doesn't disturb the gradient pipeline; cclib's grads is the total."""
     in_mol = _make_water_mol()
     forces = np.array([[0.01, 0.0, -0.02], [0.0, 0.005, 0.01], [0.0, -0.005, 0.01]])
-    ccdata = _make_ccdata_with_attrs(
-        scfenergies=np.array([-2079.3]),
-        grads=forces[np.newaxis, :, :],
-    )
+    ccdata = _disp_ccdata()
+    ccdata.grads = forces[np.newaxis, :, :]
     with _patch_cclib(ccdata):
-        qcvars, grad, _, _ = harvest(in_mol, "b3lyp-d3", _DISP_LOG_SNIPPET)
+        qcvars, grad, _, _ = harvest(in_mol, "b3lyp-d3", "")
     assert grad is not None
     np.testing.assert_allclose(grad, -forces.flatten(), atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# Tests: cclib-only energy extraction (error and consistency)
+# ---------------------------------------------------------------------------
+
+
+def _make_ccdata_without(*attrs):
+    """Build a ccdata mock and delete the named attributes (to simulate missing cclib data)."""
+    ccdata = _make_ccdata_with_attrs(scfenergies=np.array([-2079.3]))
+    for a in attrs:
+        if hasattr(ccdata, a):
+            delattr(ccdata, a)
+    return ccdata
+
+
+# rq-c20746b1
+@requires_cclib
+def test_cclib_only_missing_scfenergies_raises():
+    in_mol = _make_water_mol()
+    ccdata = _make_ccdata_without("scfenergies")
+    with _patch_cclib(ccdata):
+        with pytest.raises(ValueError, match=r"scfenergies"):
+            harvest(in_mol, "hf", "")
+
+
+# rq-c20746b1
+@requires_cclib
+def test_cclib_only_empty_scfenergies_raises():
+    in_mol = _make_water_mol()
+    ccdata = _make_ccdata_with_attrs(scfenergies=np.array([]))
+    with _patch_cclib(ccdata):
+        with pytest.raises(ValueError, match=r"scfenergies"):
+            harvest(in_mol, "hf", "")
+
+
+# rq-c20746b1
+@requires_cclib
+def test_cclib_only_missing_mpenergies_raises_for_mp2():
+    in_mol = _make_water_mol()
+    ccdata = _make_ccdata_without("mpenergies")  # scfenergies kept
+    with _patch_cclib(ccdata):
+        with pytest.raises(ValueError, match=r"mpenergies"):
+            harvest(in_mol, "mp2", "")
+
+
+# rq-c20746b1
+@requires_cclib
+def test_cclib_only_missing_ccenergies_raises_for_ccsd():
+    in_mol = _make_water_mol()
+    ccdata = _make_ccdata_without("ccenergies")
+    with _patch_cclib(ccdata):
+        with pytest.raises(ValueError, match=r"ccenergies"):
+            harvest(in_mol, "ccsd", "")
+
+
+# rq-c20746b1
+@requires_cclib
+def test_cclib_only_missing_ccenergies_raises_for_ccsd_t():
+    in_mol = _make_water_mol()
+    ccdata = _make_ccdata_without("ccenergies")
+    with _patch_cclib(ccdata):
+        with pytest.raises(ValueError, match=r"ccenergies"):
+            harvest(in_mol, "ccsd(t)", "")
+
+
+# rq-c20746b1
+@requires_cclib
+def test_cclib_only_scf_round_trips_within_1_ulp():
+    """The Ha → eV → Ha round-trip through cclib's convertor must be ≤ 1 ULP."""
+    in_mol = _make_water_mol()
+    scf_ha = -76.0571491640
+    ccdata = _make_ccdata_with_attrs(scfenergies=np.array([_ha_to_ev(scf_ha)]))
+    with _patch_cclib(ccdata):
+        qcvars, _, _, _ = harvest(in_mol, "hf", "")
+    # The round-trip should be exact to within a single ULP of the magnitude.
+    import math
+    delta = abs(float(qcvars["HF TOTAL ENERGY"]) - scf_ha)
+    assert delta <= math.ulp(scf_ha) * 4  # generous: 4 ULPs
+
+
+# rq-c20746b1
+@requires_cclib
+def test_cclib_only_mp2_total_from_mpenergies_last():
+    in_mol = _make_water_mol()
+    scf_ha = -76.05
+    mp2_ha = -76.30
+    ccdata = _make_ccdata_with_attrs(
+        scfenergies=np.array([_ha_to_ev(scf_ha)]),
+        mpenergies=np.array([[_ha_to_ev(mp2_ha)]]),
+    )
+    with _patch_cclib(ccdata):
+        qcvars, _, _, _ = harvest(in_mol, "mp2", "")
+    assert abs(float(qcvars["MP2 TOTAL ENERGY"]) - mp2_ha) < 1e-12
+    assert abs(float(qcvars["MP2 CORRELATION ENERGY"]) - (mp2_ha - scf_ha)) < 1e-12
+
+
+# rq-c20746b1 rq-eddef743
+@requires_cclib
+def test_cclib_only_ccsd_t_does_not_emit_ccsd_qcvar():
+    """For a CCSD(T) job, cclib only stores the CCSD(T) total; no CCSD qcvar surfaces."""
+    in_mol = _make_water_mol()
+    scf_ha = -76.05
+    ccsdt_ha = -76.32
+    ccdata = _make_ccdata_with_attrs(
+        scfenergies=np.array([_ha_to_ev(scf_ha)]),
+        ccenergies=np.array([_ha_to_ev(ccsdt_ha)]),
+    )
+    with _patch_cclib(ccdata):
+        qcvars, _, _, _ = harvest(in_mol, "ccsd(t)", "")
+    assert "CCSD(T) TOTAL ENERGY" in qcvars
+    assert "CCSD TOTAL ENERGY" not in qcvars
+    assert abs(float(qcvars["CCSD(T) TOTAL ENERGY"]) - ccsdt_ha) < 1e-12
+
+
+# rq-0743e952
+def test_cclib_only_no_energy_regex_constants_in_harvester():
+    """The harvester module must not define energy-extraction regex constants."""
+    from qcengine.programs.gaussian import harvester as h
+    for name in ("_SCF_DONE_RE", "_MP2_ENERGY_RE", "_CCSD_ENERGY_RE",
+                 "_CCSD_T_ENERGY_RE", "_DISPERSION_ENERGY_RE"):
+        assert not hasattr(h, name), f"harvester still defines removed constant {name!r}"
+    # _fortran_float is retained for Hessian parsing
+    assert hasattr(h, "_fortran_float")
 
 
 # ---------------------------------------------------------------------------

--- a/qcengine/programs/tests/test_gaussian.py
+++ b/qcengine/programs/tests/test_gaussian.py
@@ -1564,6 +1564,330 @@ def test_atom_labels_out_mol_preserves_labels_when_fixed():
 
 
 # ---------------------------------------------------------------------------
+# Tests: empirical dispersion (germinate)
+# ---------------------------------------------------------------------------
+
+
+# rq-0c1b5066
+def test_dispersion_germinate_d3():
+    """muster_modelchem strips '-d3' and emits EmpiricalDispersion=GD3."""
+    result = muster_modelchem("b3lyp-d3", "energy", 1)
+    assert result["method_string"] == "B3LYP"
+    assert result["extra_keywords"]["EmpiricalDispersion"] == "GD3"
+    assert result["dispersion_level"] == "D3"
+    assert result["functional_name"] == "B3LYP"
+
+
+# rq-0c1b5066
+def test_dispersion_germinate_d3bj():
+    result = muster_modelchem("b3lyp-d3bj", "energy", 1)
+    assert result["method_string"] == "B3LYP"
+    assert result["extra_keywords"]["EmpiricalDispersion"] == "GD3BJ"
+    assert result["dispersion_level"] == "D3(BJ)"
+
+
+# rq-0c1b5066
+def test_dispersion_germinate_d2():
+    result = muster_modelchem("b3lyp-d2", "energy", 1)
+    assert result["method_string"] == "B3LYP"
+    assert result["extra_keywords"]["EmpiricalDispersion"] == "GD2"
+    assert result["dispersion_level"] == "D2"
+
+
+# rq-0c1b5066
+def test_dispersion_germinate_d3zero2b_alias():
+    result = muster_modelchem("b3lyp-d3zero2b", "energy", 1)
+    assert result["dispersion_level"] == "D3"
+    assert result["functional_name"] == "B3LYP"
+
+
+# rq-0c1b5066
+def test_dispersion_germinate_bare_d_alias():
+    """The bare '-d' alias maps to D2 (per QCEngine's get_dispersion_aliases)."""
+    result = muster_modelchem("b3lyp-d", "energy", 1)
+    assert result["dispersion_level"] == "D2"
+
+
+# rq-0c1b5066
+def test_dispersion_germinate_no_suffix_unchanged():
+    result = muster_modelchem("b3lyp", "energy", 1)
+    assert result["method_string"] == "B3LYP"
+    assert "EmpiricalDispersion" not in result["extra_keywords"]
+    assert "dispersion_level" not in result
+
+
+# rq-0c1b5066
+def test_dispersion_germinate_hyphenated_non_dispersion_preserved():
+    """cam-B3LYP must not get falsely stripped (cam isn't an alias)."""
+    result = muster_modelchem("cam-b3lyp", "energy", 1)
+    assert result["method_string"] == "CAM-B3LYP"
+    assert "EmpiricalDispersion" not in result["extra_keywords"]
+    assert "dispersion_level" not in result
+
+
+# rq-0c1b5066
+def test_dispersion_germinate_hf_d3():
+    result = muster_modelchem("hf-d3", "energy", 1)
+    assert result["method_string"] == "HF"
+    assert result["extra_keywords"]["EmpiricalDispersion"] == "GD3"
+    assert result["functional_name"] == "HF"
+
+
+# rq-0c1b5066
+def test_dispersion_germinate_open_shell():
+    result = muster_modelchem("b3lyp-d3", "energy", 2)
+    assert result["method_string"] == "UB3LYP"
+    assert result["extra_keywords"]["EmpiricalDispersion"] == "GD3"
+    assert result["dispersion_level"] == "D3"
+    assert result["functional_name"] == "B3LYP"
+
+
+# rq-0c1b5066
+def test_dispersion_germinate_rohf_no_double_prefix():
+    result = muster_modelchem("rohf-d3", "energy", 2)
+    assert result["method_string"] == "ROHF"
+    assert result["extra_keywords"]["EmpiricalDispersion"] == "GD3"
+
+
+# rq-0c1b5066
+@pytest.mark.parametrize("method", ["b3lyp-d3m", "b3lyp-d3mbj", "b3lyp-d4", "b3lyp-d3op", "b3lyp-nl"])
+def test_dispersion_germinate_unsupported_levels_raise(method):
+    with pytest.raises(InputError, match=r"not natively supported"):
+        muster_modelchem(method, "energy", 1)
+
+
+# rq-0c1b5066 — explicit "longer suffix wins" test
+def test_dispersion_germinate_longer_suffix_wins():
+    """d3bj must be matched before d3 + stray 'bj'."""
+    result = muster_modelchem("b3lyp-d3bj", "energy", 1)
+    assert result["dispersion_level"] == "D3(BJ)"
+    assert result["functional_name"] == "B3LYP"
+
+
+# ---------------------------------------------------------------------------
+# Tests: empirical dispersion (runner conflict detection)
+# ---------------------------------------------------------------------------
+
+
+# rq-59b816b7
+def test_dispersion_conflict_raises(harness, water):
+    inp = AtomicInput(
+        molecule=water,
+        specification=AtomicSpecification(
+            program="gaussian",
+            driver="energy",
+            model={"method": "b3lyp-d3", "basis": "STO-3G"},
+            keywords={"EmpiricalDispersion": "GD3BJ"},
+        ),
+    )
+    with patch("qcengine.programs.gaussian.runner._find_gaussian", return_value="/g16"):
+        with pytest.raises(InputError, match="overspecified"):
+            harness.build_input(inp, _default_taskconfig())
+
+
+# rq-59b816b7
+def test_dispersion_conflict_case_insensitive(harness, water):
+    inp = AtomicInput(
+        molecule=water,
+        specification=AtomicSpecification(
+            program="gaussian",
+            driver="energy",
+            model={"method": "b3lyp-d3", "basis": "STO-3G"},
+            keywords={"empiricaldispersion": "GD3"},
+        ),
+    )
+    with patch("qcengine.programs.gaussian.runner._find_gaussian", return_value="/g16"):
+        with pytest.raises(InputError, match="overspecified"):
+            harness.build_input(inp, _default_taskconfig())
+
+
+# rq-59b816b7
+def test_dispersion_user_keyword_only_passes_through(harness, water):
+    """If the method has no dispersion suffix, a user EmpiricalDispersion kw passes through."""
+    inp = AtomicInput(
+        molecule=water,
+        specification=AtomicSpecification(
+            program="gaussian",
+            driver="energy",
+            model={"method": "B3LYP", "basis": "STO-3G"},
+            keywords={"EmpiricalDispersion": "GD3"},
+        ),
+    )
+    with patch("qcengine.programs.gaussian.runner._find_gaussian", return_value="/g16"):
+        job = harness.build_input(inp, _default_taskconfig())
+    assert "EmpiricalDispersion=GD3" in job["infiles"]["gaussian.com"]
+
+
+# rq-59b816b7
+def test_dispersion_method_suffix_only(harness, water):
+    """method='b3lyp-d3' produces exactly one EmpiricalDispersion token and bare B3LYP/basis."""
+    inp = AtomicInput(
+        molecule=water,
+        specification=AtomicSpecification(
+            program="gaussian",
+            driver="energy",
+            model={"method": "b3lyp-d3", "basis": "STO-3G"},
+        ),
+    )
+    with patch("qcengine.programs.gaussian.runner._find_gaussian", return_value="/g16"):
+        job = harness.build_input(inp, _default_taskconfig())
+    com = job["infiles"]["gaussian.com"]
+    assert com.count("EmpiricalDispersion=GD3") == 1
+    # Route line has B3LYP/STO-3G, NOT B3LYP-D3/STO-3G
+    route = next(ln for ln in com.splitlines() if ln.startswith("#P"))
+    assert "B3LYP/STO-3G" in route
+    assert "B3LYP-D3/" not in route
+
+
+# ---------------------------------------------------------------------------
+# Tests: empirical dispersion (harvester)
+# ---------------------------------------------------------------------------
+
+
+_DISP_LOG_SNIPPET = (
+    " SCF Done:  E(RB3LYP) =  -76.4014123456     A.U. after   12 cycles\n"
+    " Dispersion energy=       -0.0046617305 Hartrees.\n"
+)
+
+
+# rq-1d5da737
+@requires_cclib
+def test_dispersion_harvest_regex_path():
+    in_mol = _make_water_mol()
+    ccdata = _make_ccdata_with_attrs(scfenergies=np.array([-2079.3]))
+    with _patch_cclib(ccdata):
+        qcvars, _, _, _ = harvest(in_mol, "b3lyp-d3", _DISP_LOG_SNIPPET)
+    assert abs(float(qcvars["DISPERSION CORRECTION ENERGY"]) - (-0.0046617305)) < 1e-12
+
+
+# rq-1d5da737
+@requires_cclib
+def test_dispersion_harvest_cclib_fallback():
+    """When the log has no 'Dispersion energy=' line, fall back to ccdata.dispersionenergies."""
+    in_mol = _make_water_mol()
+    # eV values that round-trip to a known Hartree quantity
+    disp_ev = -0.1269192
+    ccdata = _make_ccdata_with_attrs(scfenergies=np.array([-2079.3]))
+    ccdata.dispersionenergies = np.array([disp_ev])
+    with _patch_cclib(ccdata):
+        qcvars, _, _, _ = harvest(in_mol, "b3lyp-d3", "SCF Done: E(RB3LYP) = -76.4 A.U. after 10 cycles\n")
+    expected = disp_ev * _EV_TO_HARTREE
+    assert abs(float(qcvars["DISPERSION CORRECTION ENERGY"]) - expected) < 1e-8
+
+
+# rq-1d5da737
+@requires_cclib
+def test_dispersion_harvest_functional_specific_qcvars():
+    in_mol = _make_water_mol()
+    ccdata = _make_ccdata_with_attrs(scfenergies=np.array([-2079.3]))
+    with _patch_cclib(ccdata):
+        qcvars, _, _, _ = harvest(in_mol, "b3lyp-d3", _DISP_LOG_SNIPPET)
+    assert "B3LYP-D3 DISPERSION CORRECTION ENERGY" in qcvars
+    assert abs(float(qcvars["B3LYP-D3 DISPERSION CORRECTION ENERGY"]) - (-0.0046617305)) < 1e-12
+
+
+# rq-1d5da737
+@requires_cclib
+def test_dispersion_harvest_functional_total_excludes_dispersion():
+    in_mol = _make_water_mol()
+    ccdata = _make_ccdata_with_attrs(scfenergies=np.array([-2079.3]))
+    with _patch_cclib(ccdata):
+        qcvars, _, _, _ = harvest(in_mol, "b3lyp-d3", _DISP_LOG_SNIPPET)
+    scf = -76.4014123456
+    disp = -0.0046617305
+    assert abs(float(qcvars["B3LYP FUNCTIONAL TOTAL ENERGY"]) - scf) < 1e-10
+    assert abs(float(qcvars["B3LYP-D3 TOTAL ENERGY"]) - (scf + disp)) < 1e-10
+    assert abs(float(qcvars["CURRENT ENERGY"]) - (scf + disp)) < 1e-10
+
+
+# rq-1d5da737
+@requires_cclib
+def test_dispersion_harvest_d3bj_uses_parenthesised_label():
+    in_mol = _make_water_mol()
+    log = (
+        " SCF Done:  E(RB3LYP) =  -76.4014123456     A.U. after   12 cycles\n"
+        " Dispersion energy=       -0.0070000000 Hartrees.\n"
+    )
+    ccdata = _make_ccdata_with_attrs(scfenergies=np.array([-2079.3]))
+    with _patch_cclib(ccdata):
+        qcvars, _, _, _ = harvest(in_mol, "b3lyp-d3bj", log)
+    assert "B3LYP-D3(BJ) DISPERSION CORRECTION ENERGY" in qcvars
+    assert "B3LYP-D3(BJ) TOTAL ENERGY" in qcvars
+
+
+# rq-1d5da737
+@requires_cclib
+def test_dispersion_harvest_scf_hf_unchanged():
+    in_mol = _make_water_mol()
+    ccdata = _make_ccdata_with_attrs(scfenergies=np.array([-2079.3]))
+    with _patch_cclib(ccdata):
+        qcvars, _, _, _ = harvest(in_mol, "b3lyp-d3", _DISP_LOG_SNIPPET)
+    scf = -76.4014123456
+    # SCF TOTAL ENERGY / HF TOTAL ENERGY excludes the dispersion contribution
+    assert abs(float(qcvars["HF TOTAL ENERGY"]) - scf) < 1e-10
+    assert abs(float(qcvars["SCF TOTAL ENERGY"]) - scf) < 1e-10
+
+
+# rq-1d5da737
+@requires_cclib
+def test_dispersion_harvest_method_without_suffix_no_functional_qcvars():
+    """If user passes EmpiricalDispersion via keyword (no method suffix), generic qcvars only."""
+    in_mol = _make_water_mol()
+    ccdata = _make_ccdata_with_attrs(scfenergies=np.array([-2079.3]))
+    with _patch_cclib(ccdata):
+        qcvars, _, _, _ = harvest(in_mol, "b3lyp", _DISP_LOG_SNIPPET)
+    assert "DISPERSION CORRECTION ENERGY" in qcvars
+    # No formal dash label known → no functional-specific qcvars
+    assert "B3LYP-D3 DISPERSION CORRECTION ENERGY" not in qcvars
+    assert "B3LYP-D3 TOTAL ENERGY" not in qcvars
+    # CURRENT ENERGY still reflects scf + disp for DFT
+    scf = -76.4014123456
+    disp = -0.0046617305
+    assert abs(float(qcvars["CURRENT ENERGY"]) - (scf + disp)) < 1e-10
+
+
+# rq-1d5da737
+@requires_cclib
+def test_dispersion_harvest_absent_no_qcvars():
+    in_mol = _make_water_mol()
+    ccdata = _make_ccdata_with_attrs(scfenergies=np.array([-2079.3]))
+    # No dispersion line in log, no dispersionenergies attribute
+    log = " SCF Done:  E(RB3LYP) =  -76.4014123456     A.U. after   12 cycles\n"
+    with _patch_cclib(ccdata):
+        qcvars, _, _, _ = harvest(in_mol, "b3lyp", log)
+    assert "DISPERSION CORRECTION ENERGY" not in qcvars
+    assert abs(float(qcvars["CURRENT ENERGY"]) - float(qcvars["SCF TOTAL ENERGY"])) < 1e-12
+
+
+# rq-1d5da737
+@requires_cclib
+def test_dispersion_harvest_nlc_method_no_dispersion_qcvars():
+    """wB97M-V is self-consistent NLC; no 'Dispersion energy=' line in log."""
+    in_mol = _make_water_mol()
+    ccdata = _make_ccdata_with_attrs(scfenergies=np.array([-2079.3]))
+    log = " SCF Done:  E(RwB97M-V) =  -76.5     A.U. after   12 cycles\n"
+    with _patch_cclib(ccdata):
+        qcvars, _, _, _ = harvest(in_mol, "wb97m-v", log)
+    assert "DISPERSION CORRECTION ENERGY" not in qcvars
+
+
+# rq-1d5da737
+@requires_cclib
+def test_dispersion_harvest_gradient_unchanged():
+    """Dispersion in log doesn't disturb the gradient pipeline; cclib's grads is the total."""
+    in_mol = _make_water_mol()
+    forces = np.array([[0.01, 0.0, -0.02], [0.0, 0.005, 0.01], [0.0, -0.005, 0.01]])
+    ccdata = _make_ccdata_with_attrs(
+        scfenergies=np.array([-2079.3]),
+        grads=forces[np.newaxis, :, :],
+    )
+    with _patch_cclib(ccdata):
+        qcvars, grad, _, _ = harvest(in_mol, "b3lyp-d3", _DISP_LOG_SNIPPET)
+    assert grad is not None
+    np.testing.assert_allclose(grad, -forces.flatten(), atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
 # Integration tests (require Gaussian + cclib installed)
 # ---------------------------------------------------------------------------
 
@@ -1595,3 +1919,48 @@ def test_gaussian_gradient_water(water):
     )
     assert result.success is True
     assert np.array(result.return_result).shape == (3, 3)
+
+
+# rq-17959824
+@using("gaussian")
+def test_gaussian_b3lyp_d3_water(water):
+    """B3LYP-D3/6-31G* energy on water; verify dispersion qcvars are populated and consistent."""
+    import qcengine as qcng
+
+    result = qcng.compute(
+        AtomicInput(
+            molecule=water,
+            specification=AtomicSpecification(
+                program="gaussian",
+                driver="energy",
+                model={"method": "b3lyp-d3", "basis": "6-31g*"},
+            ),
+        ),
+        "gaussian",
+        raise_error=True,
+    )
+    assert result.success is True
+
+    qcvars = result.extras["qcvars"]
+    # All three Psi4-convention qcvars must be present.
+    assert "B3LYP-D3 DISPERSION CORRECTION ENERGY" in qcvars
+    assert "B3LYP-D3 TOTAL ENERGY" in qcvars
+    assert "B3LYP FUNCTIONAL TOTAL ENERGY" in qcvars
+    # Empirical reference values (Gaussian 16, Revision C.02). Tolerance is loose
+    # enough to absorb minor patch-level variation in the D3 parameter set.
+    atol = 1.0e-6
+    ref_func = -76.4087263383
+    ref_disp = -0.0000078919
+    ref_total = ref_func + ref_disp
+    assert abs(float(qcvars["B3LYP FUNCTIONAL TOTAL ENERGY"]) - ref_func) < atol
+    assert abs(float(qcvars["B3LYP-D3 DISPERSION CORRECTION ENERGY"]) - ref_disp) < atol
+    assert abs(float(qcvars["B3LYP-D3 TOTAL ENERGY"]) - ref_total) < atol
+    # SCF + dispersion == total (numerical consistency).
+    scf = float(qcvars["B3LYP FUNCTIONAL TOTAL ENERGY"])
+    disp = float(qcvars["B3LYP-D3 DISPERSION CORRECTION ENERGY"])
+    tot = float(qcvars["B3LYP-D3 TOTAL ENERGY"])
+    assert abs((scf + disp) - tot) < 1.0e-10
+    # CURRENT ENERGY is the dispersion-corrected total.
+    assert abs(float(qcvars["CURRENT ENERGY"]) - tot) < 1.0e-10
+    # SCF TOTAL ENERGY / HF TOTAL ENERGY exclude dispersion.
+    assert abs(float(qcvars["SCF TOTAL ENERGY"]) - scf) < 1.0e-10

--- a/qcengine/programs/tests/test_gaussian.py
+++ b/qcengine/programs/tests/test_gaussian.py
@@ -134,6 +134,10 @@ def _make_ccdata_with_attrs(**kwargs):
     defaults.update(kwargs)
     for k, v in defaults.items():
         setattr(ccdata, k, v)
+    # cclib's Gaussian parser sets `natom` as an int. Mirror that here so the
+    # harvester's `ccdata.natom` reads work without each test having to set it.
+    if not hasattr(ccdata, "natom"):
+        setattr(ccdata, "natom", len(ccdata.atomnos))
     return ccdata
 
 

--- a/qcengine/programs/tests/test_gaussian.py
+++ b/qcengine/programs/tests/test_gaussian.py
@@ -29,9 +29,17 @@ requires_cclib = pytest.mark.skipif(not _cclib_available, reason="cclib not inst
 # The harvester reads all energies via cclib's parsed attributes and reverses
 # the eV → Hartree conversion with cclib's own convertor (structurally exact).
 # Tests compute expected values via the same factor so the round-trip is exact.
-from cclib.parser.utils import convertor as _cclib_convertor  # noqa: E402
-_EV_TO_HARTREE = _cclib_convertor(1.0, "eV", "hartree")
-_HARTREE_TO_EV = _cclib_convertor(1.0, "hartree", "eV")
+# Guard the import: when cclib is missing, every test that uses these helpers
+# is already gated behind @requires_cclib, so the module must still be
+# importable for collection on cclib-less CI runners.
+if _cclib_available:
+    from cclib.parser.utils import convertor as _cclib_convertor
+    _EV_TO_HARTREE = _cclib_convertor(1.0, "eV", "hartree")
+    _HARTREE_TO_EV = _cclib_convertor(1.0, "hartree", "eV")
+else:
+    _cclib_convertor = None
+    _EV_TO_HARTREE = None
+    _HARTREE_TO_EV = None
 
 
 def _ha_to_ev(value_ha):

--- a/qcengine/programs/tests/test_gaussian.py
+++ b/qcengine/programs/tests/test_gaussian.py
@@ -2016,3 +2016,215 @@ def test_gaussian_b3lyp_d3_water(water):
     assert abs(float(qcvars["CURRENT ENERGY"]) - tot) < 1.0e-10
     # SCF TOTAL ENERGY / HF TOTAL ENERGY exclude dispersion.
     assert abs(float(qcvars["SCF TOTAL ENERGY"]) - scf) < 1.0e-10
+
+
+# ---------------------------------------------------------------------------
+# E2E coverage tests (see rqm/gaussian/e2e-coverage.md)
+# ---------------------------------------------------------------------------
+
+
+# rq-54afb7b8
+@using("gaussian")
+def test_gaussian_hessian_hf_water(water):
+    """HF/STO-3G Hessian on water — exercises _parse_force_constants pipeline end-to-end."""
+    import qcengine as qcng
+
+    inp = AtomicInput(
+        molecule=water,
+        specification=AtomicSpecification(
+            program="gaussian", driver="hessian",
+            model={"method": "HF", "basis": "STO-3G"},
+        ),
+    )
+    result = qcng.compute(inp, "gaussian", raise_error=True)
+    assert result.success is True
+
+    hess = np.asarray(result.return_result)
+    atol = 1.0e-6
+    assert hess.shape == (9, 9)
+    assert abs(np.trace(hess) - 3.2315247000) < atol
+    assert abs(np.linalg.norm(hess) - 2.2444460940) < atol
+    assert abs(hess[0, 0] - (-0.0560541000)) < atol
+    assert abs(hess[3, 3] - (-0.0223351000)) < atol
+    assert abs(hess[0, 1]) < 1.0e-10
+    assert np.allclose(hess, hess.T, atol=1.0e-10)
+
+
+# rq-70b16c33
+@using("gaussian")
+def test_gaussian_properties_hf_water(water):
+    """HF/STO-3G properties driver: dipole + Mulliken end-to-end."""
+    import qcengine as qcng
+
+    inp = AtomicInput(
+        molecule=water,
+        specification=AtomicSpecification(
+            program="gaussian", driver="properties",
+            model={"method": "HF", "basis": "STO-3G"},
+        ),
+    )
+    result = qcng.compute(inp, "gaussian", raise_error=True)
+    assert result.success is True
+    assert isinstance(result.return_result, float)
+
+    qcvars = result.extras["qcvars"]
+    atol = 1.0e-6
+    assert abs(float(qcvars["HF TOTAL ENERGY"]) - (-74.962963201)) < atol
+    # Dipole magnitude (Debye) — looser tol absorbs Gaussian rounding in the log.
+    assert abs(float(qcvars["DIPOLE MOMENT"]) - 1.7252) < 1.0e-3
+    mulliken = list(qcvars["MULLIKEN CHARGES"])
+    assert len(mulliken) == 3
+    assert abs(sum(float(q) for q in mulliken)) < 1.0e-4
+    assert abs(float(mulliken[0]) - (-0.366114)) < 1.0e-3
+
+
+# rq-3727e53b
+@using("gaussian")
+def test_gaussian_dft_b3lyp_water(water):
+    """Plain B3LYP/cc-pVDZ (no dispersion suffix) — confirms the DFT pass-through branch."""
+    import qcengine as qcng
+
+    inp = AtomicInput(
+        molecule=water,
+        specification=AtomicSpecification(
+            program="gaussian", driver="energy",
+            model={"method": "B3LYP", "basis": "cc-pVDZ"},
+        ),
+    )
+    result = qcng.compute(inp, "gaussian", raise_error=True)
+    assert result.success is True
+
+    atol = 1.0e-6
+    ref = -76.4203540604
+    assert abs(float(result.return_result) - ref) < atol
+
+    qcvars = result.extras["qcvars"]
+    # The SCF energy IS the B3LYP energy when no dispersion is requested.
+    assert abs(float(qcvars["HF TOTAL ENERGY"]) - ref) < 1.0e-10
+    assert abs(float(qcvars["CURRENT ENERGY"]) - ref) < 1.0e-10
+    # No dispersion qcvars when the method has no dispersion suffix.
+    assert "DISPERSION CORRECTION ENERGY" not in qcvars
+    assert "B3LYP-D3 DISPERSION CORRECTION ENERGY" not in qcvars
+
+
+# rq-66ca9a20
+@using("gaussian")
+def test_gaussian_b3lyp_d3_gradient_water(water):
+    """B3LYP-D3/6-31G* gradient — confirms the dispersion + gradient combination."""
+    import qcengine as qcng
+
+    inp = AtomicInput(
+        molecule=water,
+        specification=AtomicSpecification(
+            program="gaussian", driver="gradient",
+            model={"method": "b3lyp-d3", "basis": "6-31g*"},
+        ),
+    )
+    result = qcng.compute(inp, "gaussian", raise_error=True)
+    assert result.success is True
+
+    grad = np.asarray(result.return_result)
+    assert grad.shape == (3, 3)
+    ref_grad = np.array([
+        [0.0,  0.0,        -0.01437422],
+        [0.0, -0.00800138,  0.00718711],
+        [0.0,  0.00800138,  0.00718711],
+    ])
+    np.testing.assert_allclose(grad, ref_grad, atol=1.0e-6)
+
+    qcvars = result.extras["qcvars"]
+    atol = 1.0e-6
+    assert abs(float(qcvars["B3LYP-D3 DISPERSION CORRECTION ENERGY"]) - (-0.0000078919)) < atol
+    assert abs(float(qcvars["B3LYP FUNCTIONAL TOTAL ENERGY"]) - (-76.4087263383)) < atol
+    assert abs(float(qcvars["B3LYP-D3 TOTAL ENERGY"]) - (-76.4087342302)) < atol
+
+
+# rq-d06d7266
+@using("gaussian")
+def test_gaussian_uhf_nh2():
+    """NH2 radical (charge=0, mult=2) — confirms U-prefix auto-emission for open-shell."""
+    import qcengine as qcng
+
+    nh2 = Molecule.from_data(
+        """
+        0 2
+        N  0.000000000  0.000000000  0.140030000
+        H  0.000000000  0.802300000 -0.490100000
+        H  0.000000000 -0.802300000 -0.490100000
+        units angstrom
+        """
+    )
+    inp = AtomicInput(
+        molecule=nh2,
+        specification=AtomicSpecification(
+            program="gaussian", driver="energy",
+            model={"method": "HF", "basis": "cc-pVDZ"},
+            protocols={"native_files": "all"},
+        ),
+    )
+    result = qcng.compute(inp, "gaussian", raise_error=True)
+    assert result.success is True
+
+    atol = 1.0e-6
+    assert abs(float(result.return_result) - (-55.5671259096)) < atol
+
+    qcvars = result.extras["qcvars"]
+    assert abs(float(qcvars["HF TOTAL ENERGY"]) - (-55.5671259096)) < atol
+
+    com = result.native_files["input"]
+    assert "UHF/cc-pVDZ" in com
+    # Charge/multiplicity line — look for an exact "0 2" line in the molecule block.
+    assert any(ln.strip() == "0 2" for ln in com.splitlines())
+
+
+# rq-cd65e68a
+@using("gaussian")
+def test_gaussian_single_atom_he():
+    """Single He atom HF/cc-pVDZ — edge case: zero NRE, no bonds."""
+    import qcengine as qcng
+
+    he = Molecule.from_data(
+        """
+        0 1
+        He 0.0 0.0 0.0
+        units angstrom
+        """
+    )
+    inp = AtomicInput(
+        molecule=he,
+        specification=AtomicSpecification(
+            program="gaussian", driver="energy",
+            model={"method": "HF", "basis": "cc-pVDZ"},
+        ),
+    )
+    result = qcng.compute(inp, "gaussian", raise_error=True)
+    assert result.success is True
+    assert abs(float(result.return_result) - (-2.85516047724)) < 1.0e-6
+    assert result.properties.nuclear_repulsion_energy == 0.0
+
+
+# rq-b8065553
+@using("gaussian")
+def test_gaussian_b3lyp_d3_hessian_water(water):
+    """B3LYP-D3/6-31G* Hessian — confirms DFT-D Hessian succeeds and emits dispersion qcvar."""
+    import qcengine as qcng
+
+    inp = AtomicInput(
+        molecule=water,
+        specification=AtomicSpecification(
+            program="gaussian", driver="hessian",
+            model={"method": "b3lyp-d3", "basis": "6-31g*"},
+        ),
+    )
+    result = qcng.compute(inp, "gaussian", raise_error=True)
+    assert result.success is True
+
+    hess = np.asarray(result.return_result)
+    atol = 1.0e-6
+    assert hess.shape == (9, 9)
+    assert abs(np.trace(hess) - 2.3626060600) < atol
+    assert abs(np.linalg.norm(hess) - 1.5979941261) < atol
+    assert np.allclose(hess, hess.T, atol=1.0e-10)
+
+    qcvars = result.extras["qcvars"]
+    assert abs(float(qcvars["B3LYP-D3 DISPERSION CORRECTION ENERGY"]) - (-0.0000078919)) < atol

--- a/qcengine/programs/tests/test_gaussian.py
+++ b/qcengine/programs/tests/test_gaussian.py
@@ -359,21 +359,6 @@ def test_build_input_memory_whole_gb(water_energy_input, harness):
     assert "%Mem=8GB" in job["infiles"]["gaussian.com"]
 
 
-# rq-5053204b
-def test_build_input_ghost_atoms_raise(harness):
-    from qcengine.config import TaskConfig
-
-    ghost_mol = Molecule.from_data(
-        {"symbols": ["O", "H", "H"], "geometry": [0, 0, 0.2, 0, 1.4, -0.9, 0, -1.4, -0.9],
-         "real": [True, False, True]}
-    )
-    inp = AtomicInput(molecule=ghost_mol, specification=AtomicSpecification(program="gaussian", driver="energy", model={"method": "HF", "basis": "STO-3G"}))
-    cfg = TaskConfig(scratch_directory=None, scratch_messy=False, ncores=1, nnodes=1, memory=1.0, retries=0, mpiexec_command=None)
-    with patch("qcengine.programs.gaussian.runner._find_gaussian", return_value="/usr/local/g16/g16"):
-        with pytest.raises(InputError):
-            harness.build_input(inp, cfg)
-
-
 # rq-0aa99076
 def test_build_input_basisset_object_raises(water, harness):
     from qcengine.config import TaskConfig
@@ -1016,6 +1001,342 @@ def test_is_normal_termination_true():
 def test_is_normal_termination_false():
     log = "Some output\nError termination via Lnk1e\n"
     assert is_normal_termination(log) is False
+
+
+# ---------------------------------------------------------------------------
+# Tests: ghost-atom support
+# ---------------------------------------------------------------------------
+
+
+def _make_hene_ghost_mol():
+    """He real at origin, Ne ghost at (2.5, 0, 0) Å, with fix_com/fix_orientation."""
+    return Molecule.from_data(
+        """
+        0 1
+        He 0.0 0.0 0.0
+        @Ne 2.5 0.0 0.0
+        nocom
+        noreorient
+        """
+    )
+
+
+def _default_taskconfig(**overrides):
+    from qcengine.config import TaskConfig
+
+    cfg = dict(
+        scratch_directory=None,
+        scratch_messy=False,
+        ncores=1,
+        nnodes=1,
+        memory=1.0,
+        retries=0,
+        mpiexec_command=None,
+    )
+    cfg.update(overrides)
+    return TaskConfig(**cfg)
+
+
+def _spec(driver="energy", method="HF", basis="STO-3G"):
+    return AtomicSpecification(
+        program="gaussian",
+        driver=driver,
+        model={"method": method, "basis": basis},
+    )
+
+
+# rq-2229f087
+def test_ghost_real_atom_emits_plain_symbol(harness):
+    mol = Molecule.from_data(
+        {
+            "symbols": ["H"],
+            "geometry": [0.0, 0.0, 0.0],
+            "real": [True],
+            "molecular_charge": 0,
+            "molecular_multiplicity": 2,
+        }
+    )
+    inp = AtomicInput(molecule=mol, specification=_spec())
+    with patch("qcengine.programs.gaussian.runner._find_gaussian", return_value="/g16"):
+        job = harness.build_input(inp, _default_taskconfig())
+    com = job["infiles"]["gaussian.com"]
+    atom_lines = [ln for ln in com.splitlines() if ln.lstrip().startswith(("H ", "H-Bq"))]
+    assert any(ln.lstrip().startswith("H ") for ln in atom_lines)
+    assert not any(ln.lstrip().startswith("H-Bq ") for ln in atom_lines)
+
+
+# rq-916e4919
+def test_ghost_atom_emits_bq_suffix(harness):
+    mol = Molecule.from_data(
+        {
+            "symbols": ["H"],
+            "geometry": [0.0, 0.0, 0.0],
+            "real": [False],
+            "molecular_charge": 0,
+            "molecular_multiplicity": 1,
+        }
+    )
+    inp = AtomicInput(molecule=mol, specification=_spec())
+    with patch("qcengine.programs.gaussian.runner._find_gaussian", return_value="/g16"):
+        job = harness.build_input(inp, _default_taskconfig())
+    com = job["infiles"]["gaussian.com"]
+    assert any(ln.lstrip().startswith("H-Bq ") for ln in com.splitlines())
+
+
+# rq-2a015edf
+def test_ghost_mixed_real_and_ghost(harness):
+    mol = _make_hene_ghost_mol()
+    inp = AtomicInput(molecule=mol, specification=_spec())
+    with patch("qcengine.programs.gaussian.runner._find_gaussian", return_value="/g16"):
+        job = harness.build_input(inp, _default_taskconfig())
+    lines = [ln for ln in job["infiles"]["gaussian.com"].splitlines() if ln.strip()]
+    he_idx = next(i for i, ln in enumerate(lines) if ln.lstrip().startswith("He "))
+    ne_idx = next(i for i, ln in enumerate(lines) if ln.lstrip().startswith("Ne-Bq "))
+    assert he_idx < ne_idx  # input order preserved
+
+
+# rq-a100502c
+def test_ghost_route_line_unchanged(harness):
+    mol = _make_hene_ghost_mol()
+    inp = AtomicInput(molecule=mol, specification=_spec(method="HF", basis="6-31G*"))
+    with patch("qcengine.programs.gaussian.runner._find_gaussian", return_value="/g16"):
+        job = harness.build_input(inp, _default_taskconfig())
+    lines = job["infiles"]["gaussian.com"].splitlines()
+    route_lines = [ln for ln in lines if ln.startswith("#P")]
+    assert route_lines == ["#P HF/6-31G*"]
+
+
+# rq-ce76f384
+def test_ghost_all_atoms_ghost(harness):
+    mol = Molecule.from_data(
+        {
+            "symbols": ["H", "H"],
+            "geometry": [0.0, 0.0, 0.0, 0.0, 0.0, 1.4],
+            "real": [False, False],
+            "molecular_charge": 0,
+            "molecular_multiplicity": 1,
+        }
+    )
+    inp = AtomicInput(molecule=mol, specification=_spec())
+    with patch("qcengine.programs.gaussian.runner._find_gaussian", return_value="/g16"):
+        job = harness.build_input(inp, _default_taskconfig())
+    com = job["infiles"]["gaussian.com"]
+    atom_lines = [
+        ln for ln in com.splitlines()
+        if ln.lstrip().startswith(("H ", "H-Bq"))
+    ]
+    assert len(atom_lines) == 2
+    assert all("-Bq" in ln for ln in atom_lines)
+
+
+# rq-ceef73bd
+def test_ghost_coordinate_precision_preserved(harness):
+    mol = Molecule.from_data(
+        {
+            "symbols": ["H"],
+            "geometry": [1.23456789012 / qcel.constants.conversion_factor("bohr", "angstrom"), 0.0, 0.0],
+            "real": [False],
+            "molecular_charge": 0,
+            "molecular_multiplicity": 1,
+        }
+    )
+    inp = AtomicInput(molecule=mol, specification=_spec())
+    with patch("qcengine.programs.gaussian.runner._find_gaussian", return_value="/g16"):
+        job = harness.build_input(inp, _default_taskconfig())
+    com = job["infiles"]["gaussian.com"]
+    ghost_line = next(ln for ln in com.splitlines() if "H-Bq" in ln)
+    assert re.search(r"\d+\.\d{10}", ghost_line)
+
+
+# rq-b27d4aff
+@requires_cclib
+def test_ghost_out_mol_real_preserved():
+    in_mol = _make_hene_ghost_mol()
+    ccdata = _make_ccdata_with_attrs(
+        scfenergies=np.array([-77.7]),
+        atomcoords=np.array([[[0.0, 0.0, 0.0], [2.5, 0.0, 0.0]]]),
+        atomnos=np.array([2, 10]),
+    )
+    with _patch_cclib(ccdata):
+        _, _, _, out_mol = harvest(in_mol, "hf", "dummy log")
+    assert list(out_mol.real) == [True, False]
+
+
+# rq-731f01ba
+@requires_cclib
+def test_ghost_out_mol_symbols_from_in_mol():
+    in_mol = _make_hene_ghost_mol()
+    ccdata = _make_ccdata_with_attrs(
+        scfenergies=np.array([-77.7]),
+        atomcoords=np.array([[[0.0, 0.0, 0.0], [2.5, 0.0, 0.0]]]),
+        atomnos=np.array([2, 10]),
+    )
+    with _patch_cclib(ccdata):
+        _, _, _, out_mol = harvest(in_mol, "hf", "dummy log")
+    assert list(out_mol.symbols) == ["He", "Ne"]
+
+
+# rq-7411efa0
+@requires_cclib
+def test_ghost_atom_count_sanity_check_passes():
+    in_mol = _make_hene_ghost_mol()
+    ccdata = _make_ccdata_with_attrs(
+        scfenergies=np.array([-77.7]),
+        atomcoords=np.array([[[0.0, 0.0, 0.0], [2.5, 0.0, 0.0]]]),
+        atomnos=np.array([2, 10]),
+    )
+    with _patch_cclib(ccdata):
+        # Should not raise: 2 atoms in cclib output == 2 atoms in in_mol
+        harvest(in_mol, "hf", "dummy log")
+
+
+# rq-66067019
+@requires_cclib
+def test_ghost_atom_count_mismatch_raises():
+    in_mol = _make_hene_ghost_mol()  # 2 atoms
+    # cclib reports 3 atoms but in_mol has 2 → mismatch
+    ccdata = _make_ccdata_with_attrs(
+        scfenergies=np.array([-77.7]),
+        atomcoords=np.array([[[0.0, 0.0, 0.0], [2.5, 0.0, 0.0], [5.0, 0.0, 0.0]]]),
+        atomnos=np.array([2, 10, 10]),
+    )
+    with _patch_cclib(ccdata):
+        with pytest.raises(ValueError, match="atom count"):
+            harvest(in_mol, "hf", "dummy log")
+
+
+# rq-a69d0898
+@requires_cclib
+def test_ghost_nre_check_excludes_ghosts():
+    in_mol = _make_hene_ghost_mol()
+    ccdata = _make_ccdata_with_attrs(
+        scfenergies=np.array([-77.7]),
+        atomcoords=np.array([[[0.0, 0.0, 0.0], [2.5, 0.0, 0.0]]]),
+        atomnos=np.array([2, 10]),
+    )
+    with _patch_cclib(ccdata):
+        # NRE = 0 for both (single real atom), no ValueError
+        harvest(in_mol, "hf", "dummy log")
+
+
+# rq-b57c882b
+@requires_cclib
+def test_ghost_nre_mismatch_still_raises():
+    # Use a 2 real + 1 ghost system so the real-atom-only NRE is nonzero
+    # and can mismatch when the parsed geometry differs.
+    in_mol = Molecule.from_data(
+        {
+            "symbols": ["H", "H", "He"],
+            "geometry": [0.0, 0.0, 0.0, 0.0, 0.0, 1.4, 5.0, 0.0, 0.0],
+            "real": [True, True, False],
+            "molecular_charge": 0,
+            "molecular_multiplicity": 1,
+            "fix_com": True,
+            "fix_orientation": True,
+        }
+    )
+    # Parsed geometry has the two real H atoms far apart, so the
+    # real-atom-only NRE differs from in_mol's by far more than 1e-3 Ha.
+    far_coords = np.array([[[0.0, 0.0, 0.0], [0.0, 0.0, 50.0], [5.0, 0.0, 0.0]]])
+    ccdata = _make_ccdata_with_attrs(
+        scfenergies=np.array([-1.0]),
+        atomcoords=far_coords,
+        atomnos=np.array([1, 1, 2]),
+    )
+    with _patch_cclib(ccdata):
+        with pytest.raises(ValueError, match="inconsistent"):
+            harvest(in_mol, "hf", "dummy log")
+
+
+# rq-e5a98119
+@requires_cclib
+def test_ghost_nre_check_unchanged_for_all_real():
+    in_mol = _make_water_mol()
+    ccdata = _make_ccdata_with_attrs(scfenergies=np.array([-2041.3]))
+    with _patch_cclib(ccdata):
+        # Existing behaviour: no ghosts, full-mol NRE comparison, no raise
+        harvest(in_mol, "hf", "dummy log")
+
+
+# rq-d97cc860
+@requires_cclib
+def test_ghost_gradient_spans_real_and_ghost():
+    in_mol = _make_hene_ghost_mol()
+    # Forces: nonzero on He, zero on Ne (ghost)
+    forces = np.array([[0.001, 0.0, 0.0], [0.0, 0.0, 0.0]])
+    ccdata = _make_ccdata_with_attrs(
+        scfenergies=np.array([-77.7]),
+        atomcoords=np.array([[[0.0, 0.0, 0.0], [2.5, 0.0, 0.0]]]),
+        atomnos=np.array([2, 10]),
+        grads=forces[np.newaxis, :, :],
+    )
+    with _patch_cclib(ccdata):
+        _, grad, _, _ = harvest(in_mol, "hf", "dummy log")
+    assert grad is not None
+    assert grad.shape == (6,)
+    # Ghost atom (index 1) gradient is zero
+    np.testing.assert_allclose(grad[3:6], np.zeros(3), atol=1e-12)
+
+
+# rq-f8ce079b
+@requires_cclib
+def test_ghost_align_uses_generic_ghosts():
+    # The harvester constructs calc_mol via qcelemental.models.Molecule (v1)
+    # and dispatches align() on it, so spy on the same class.
+    from qcelemental.models import Molecule as HarvesterMolecule
+
+    in_mol = _make_hene_ghost_mol()
+    ccdata = _make_ccdata_with_attrs(
+        scfenergies=np.array([-77.7]),
+        atomcoords=np.array([[[0.0, 0.0, 0.0], [2.5, 0.0, 0.0]]]),
+        atomnos=np.array([2, 10]),
+    )
+
+    captured = {"calls": []}
+    real_align = HarvesterMolecule.align
+
+    def spy_align(self, other, **kwargs):
+        captured["calls"].append(kwargs)
+        return real_align(self, other, **kwargs)
+
+    with _patch_cclib(ccdata):
+        with patch.object(HarvesterMolecule, "align", spy_align):
+            harvest(in_mol, "hf", "dummy log")
+
+    assert captured["calls"], "expected at least one Molecule.align call"
+    assert all(call.get("generic_ghosts") is True for call in captured["calls"])
+
+
+# rq-04028610
+@requires_cclib
+def test_ghost_compute_preserves_ghost_designation(harness):
+    in_mol = _make_hene_ghost_mol()
+    inp = AtomicInput(molecule=in_mol, specification=_spec(method="HF", basis="STO-3G"))
+
+    ccdata = _make_ccdata_with_attrs(
+        scfenergies=np.array([-77.7]),
+        atomcoords=np.array([[[0.0, 0.0, 0.0], [2.5, 0.0, 0.0]]]),
+        atomnos=np.array([2, 10]),
+    )
+    log_text = _NORMAL_LOG
+    job_record = {
+        "infiles": {"gaussian.com": "%NProcShared=1\n#P HF/STO-3G\n"},
+        "command": ["/g16", "gaussian.com"],
+        "scratch_directory": None,
+        "scratch_messy": False,
+    }
+    dexe = {"outfiles": {"gaussian.log": log_text}, "stdout": "", "stderr": ""}
+
+    with patch("qcengine.programs.gaussian.runner._find_gaussian", return_value="/g16"):
+        with patch("qcengine.programs.gaussian.runner.which_import", return_value=True):
+            with patch.object(GaussianHarness, "build_input", return_value=job_record):
+                with patch.object(GaussianHarness, "execute", return_value=(True, dexe)):
+                    with patch.object(GaussianHarness, "get_version", return_value="16.C.02"):
+                        with _patch_cclib(ccdata):
+                            result = harness.compute(inp, MagicMock())
+
+    assert list(result.molecule.real) == [True, False]
+    assert list(result.molecule.symbols) == ["He", "Ne"]
 
 
 # ---------------------------------------------------------------------------

--- a/qcengine/programs/tests/test_gaussian.py
+++ b/qcengine/programs/tests/test_gaussian.py
@@ -629,7 +629,7 @@ def test_compute_returns_atomic_result_energy(harness, water_energy_input_all_fi
 
     assert result.success is True
     assert isinstance(result.return_result, float)
-    assert "gaussian.com" in result.native_files
+    assert "input" in result.native_files  # rq-f13e0d24
     assert "gaussian.log" in result.native_files
     assert result.provenance.creator == "Gaussian"
 

--- a/qcengine/programs/tests/test_gaussian.py
+++ b/qcengine/programs/tests/test_gaussian.py
@@ -1407,24 +1407,6 @@ def test_tricky_ghost_mp2_full_harvested_as_mp2():
     assert abs(float(qcvars["CURRENT ENERGY"]) - float(qcvars["MP2 TOTAL ENERGY"])) < 1e-12
 
 
-# rq-dc9a34d9
-def test_pgline_regex_matches_c2v():
-    """The pgline regex extracts a non-* Gaussian point group."""
-    line = " Full point group                 C2V     NOp   4"
-    m = re.search(r"Full point group\s+(?P<pg>\S+)", line)
-    assert m is not None
-    assert m.group("pg") == "C2V"
-
-
-# rq-dc9a34d9
-def test_pgline_regex_matches_linear():
-    """The pgline regex extracts a linear point group containing '*'."""
-    line = " Full point group                 C*V     NOp   4"
-    m = re.search(r"Full point group\s+(?P<pg>\S+)", line)
-    assert m is not None
-    assert m.group("pg") == "C*V"
-
-
 # ---------------------------------------------------------------------------
 # Tests: atom-label tolerance
 # ---------------------------------------------------------------------------
@@ -1480,53 +1462,6 @@ def test_atom_labels_four_labeled_h_emit_bare_symbols(harness):
     assert len(h_lines) == 4
     for forbidden in ("H5", "H_other", "H_4sq"):
         assert forbidden not in com
-
-
-# rq-7a592160
-def test_atom_labels_empty_labels_same_output_as_unlabeled(harness):
-    geom = [0.0, 0.0, 0.0, 5.0, 0.0, 0.0, 0.0, 5.0, 0.0, 5.0, 5.0, 0.0]
-    mol_with_empty = Molecule.from_data(
-        {
-            "symbols": ["H", "H", "H", "H"],
-            "atom_labels": ["", "", "", ""],
-            "geometry": geom,
-            "molecular_charge": 0,
-            "molecular_multiplicity": 1,
-        }
-    )
-    mol_without = Molecule.from_data(
-        {
-            "symbols": ["H", "H", "H", "H"],
-            "geometry": geom,
-            "molecular_charge": 0,
-            "molecular_multiplicity": 1,
-        }
-    )
-    spec = _spec(method="MP2", basis="aug-cc-pvdz")
-    with patch("qcengine.programs.gaussian.runner._find_gaussian", return_value="/g16"):
-        com_with = harness.build_input(AtomicInput(molecule=mol_with_empty, specification=spec), _default_taskconfig())["infiles"]["gaussian.com"]
-        com_without = harness.build_input(AtomicInput(molecule=mol_without, specification=spec), _default_taskconfig())["infiles"]["gaussian.com"]
-    assert com_with == com_without
-
-
-# rq-090d144e
-def test_atom_labels_route_line_clean(harness):
-    mol = _build_labeled_h_mol()
-    inp = AtomicInput(molecule=mol, specification=_spec(method="MP2", basis="aug-cc-pvdz"))
-    with patch("qcengine.programs.gaussian.runner._find_gaussian", return_value="/g16"):
-        job = harness.build_input(inp, _default_taskconfig())
-    route = next(ln for ln in job["infiles"]["gaussian.com"].splitlines() if ln.startswith("#P"))
-    for forbidden in ("5", "_other", "_4sq"):
-        assert forbidden not in route or forbidden in "aug-cc-pvdz"
-
-
-# rq-c0a7e84e
-def test_atom_labels_build_input_does_not_raise(harness):
-    mol = _build_labeled_h_mol()
-    inp = AtomicInput(molecule=mol, specification=_spec(method="MP2", basis="aug-cc-pvdz"))
-    with patch("qcengine.programs.gaussian.runner._find_gaussian", return_value="/g16"):
-        # Should not raise
-        harness.build_input(inp, _default_taskconfig())
 
 
 # rq-0892bdc0 — ghost atom with non-empty label still emits "<sym>-Bq", label dropped
@@ -1777,16 +1712,6 @@ def _disp_ccdata(scf_ha=_DISP_SCF_HA, disp_ha=_DISP_DISP_HA, disp_present=True):
 
 # rq-1d5da737
 @requires_cclib
-def test_dispersion_harvest_from_cclib():
-    """Dispersion energy is read from ccdata.dispersionenergies."""
-    in_mol = _make_water_mol()
-    with _patch_cclib(_disp_ccdata()):
-        qcvars, _, _, _ = harvest(in_mol, "b3lyp-d3", "")
-    assert abs(float(qcvars["DISPERSION CORRECTION ENERGY"]) - _DISP_DISP_HA) < 1e-12
-
-
-# rq-1d5da737
-@requires_cclib
 def test_dispersion_harvest_no_dispersionenergies_no_qcvars():
     """When ccdata has no dispersionenergies attribute, no dispersion qcvars are set."""
     in_mol = _make_water_mol()
@@ -1798,10 +1723,13 @@ def test_dispersion_harvest_no_dispersionenergies_no_qcvars():
 
 # rq-1d5da737
 @requires_cclib
-def test_dispersion_harvest_functional_specific_qcvars():
+def test_dispersion_harvest_qcvars_from_cclib():
+    """Dispersion energy is read from ccdata.dispersionenergies and emitted under
+    both the generic and functional-specific qcvar keys."""
     in_mol = _make_water_mol()
     with _patch_cclib(_disp_ccdata()):
         qcvars, _, _, _ = harvest(in_mol, "b3lyp-d3", "")
+    assert abs(float(qcvars["DISPERSION CORRECTION ENERGY"]) - _DISP_DISP_HA) < 1e-12
     assert "B3LYP-D3 DISPERSION CORRECTION ENERGY" in qcvars
     assert abs(float(qcvars["B3LYP-D3 DISPERSION CORRECTION ENERGY"]) - _DISP_DISP_HA) < 1e-12
 
@@ -1857,11 +1785,10 @@ def test_dispersion_harvest_method_without_suffix_no_functional_qcvars():
 @requires_cclib
 def test_dispersion_harvest_absent_no_qcvars():
     in_mol = _make_water_mol()
+    # ccdata has scfenergies but no dispersionenergies attribute
     ccdata = _make_ccdata_with_attrs(scfenergies=np.array([-2079.3]))
-    # No dispersion line in log, no dispersionenergies attribute
-    log = " SCF Done:  E(RB3LYP) =  -76.4014123456     A.U. after   12 cycles\n"
     with _patch_cclib(ccdata):
-        qcvars, _, _, _ = harvest(in_mol, "b3lyp", log)
+        qcvars, _, _, _ = harvest(in_mol, "b3lyp", "")
     assert "DISPERSION CORRECTION ENERGY" not in qcvars
     assert abs(float(qcvars["CURRENT ENERGY"]) - float(qcvars["SCF TOTAL ENERGY"])) < 1e-12
 
@@ -1869,12 +1796,11 @@ def test_dispersion_harvest_absent_no_qcvars():
 # rq-1d5da737
 @requires_cclib
 def test_dispersion_harvest_nlc_method_no_dispersion_qcvars():
-    """wB97M-V is self-consistent NLC; no 'Dispersion energy=' line in log."""
+    """wB97M-V is self-consistent NLC; cclib's dispersionenergies attribute is absent."""
     in_mol = _make_water_mol()
     ccdata = _make_ccdata_with_attrs(scfenergies=np.array([-2079.3]))
-    log = " SCF Done:  E(RwB97M-V) =  -76.5     A.U. after   12 cycles\n"
     with _patch_cclib(ccdata):
-        qcvars, _, _, _ = harvest(in_mol, "wb97m-v", log)
+        qcvars, _, _, _ = harvest(in_mol, "wb97m-v", "")
     assert "DISPERSION CORRECTION ENERGY" not in qcvars
 
 
@@ -2003,17 +1929,6 @@ def test_cclib_only_ccsd_t_does_not_emit_ccsd_qcvar():
     assert "CCSD(T) TOTAL ENERGY" in qcvars
     assert "CCSD TOTAL ENERGY" not in qcvars
     assert abs(float(qcvars["CCSD(T) TOTAL ENERGY"]) - ccsdt_ha) < 1e-12
-
-
-# rq-0743e952
-def test_cclib_only_no_energy_regex_constants_in_harvester():
-    """The harvester module must not define energy-extraction regex constants."""
-    from qcengine.programs.gaussian import harvester as h
-    for name in ("_SCF_DONE_RE", "_MP2_ENERGY_RE", "_CCSD_ENERGY_RE",
-                 "_CCSD_T_ENERGY_RE", "_DISPERSION_ENERGY_RE"):
-        assert not hasattr(h, name), f"harvester still defines removed constant {name!r}"
-    # _fortran_float is retained for Hessian parsing
-    assert hasattr(h, "_fortran_float")
 
 
 # ---------------------------------------------------------------------------

--- a/qcengine/programs/tests/test_gaussian.py
+++ b/qcengine/programs/tests/test_gaussian.py
@@ -1340,6 +1340,230 @@ def test_ghost_compute_preserves_ghost_designation(harness):
 
 
 # ---------------------------------------------------------------------------
+# Tests: tricky-ghost (mp2(full) method + NoSymm)
+# ---------------------------------------------------------------------------
+
+
+# rq-2cb2c5c0
+def test_tricky_ghost_mp2_full_method_string():
+    """muster_modelchem("mp2(full)") emits Gaussian's "MP2(Full)" route token."""
+    result = muster_modelchem("mp2(full)", "energy", 1)
+    assert result["method_string"] == "MP2(Full)"
+
+
+# rq-2cb2c5c0
+def test_tricky_ghost_mp2_full_method_string_gradient():
+    """muster_modelchem("mp2(full)", "gradient") uses Force=NoStep job type."""
+    result = muster_modelchem("mp2(full)", "gradient", 1)
+    assert result["method_string"] == "MP2(Full)"
+    assert result["job_type"] == "Force=NoStep"
+
+
+# rq-2cb2c5c0
+def test_tricky_ghost_mp2_full_open_shell():
+    """Open-shell mp2(full) gets a U prefix like other MP2 variants."""
+    result = muster_modelchem("mp2(full)", "energy", 2)
+    assert result["method_string"] == "UMP2(Full)"
+
+
+# rq-2cb2c5c0
+def test_tricky_ghost_nosymm_emitted_bare():
+    """NoSymm in user_keywords with empty value emits as a bare token."""
+    line = build_route_line("MP2(Full)", "6-31g*", "Force=NoStep", {}, {"NoSymm": ""})
+    assert line.startswith("#P MP2(Full)/6-31g* Force=NoStep")
+    assert " NoSymm" in line
+    assert "NoSymm=" not in line  # bare, not "NoSymm="
+
+
+# rq-2cb2c5c0
+@requires_cclib
+def test_tricky_ghost_mp2_full_harvested_as_mp2():
+    """harvest() normalises method 'mp2(full)' to 'mp2' so MP2 qcvars are populated."""
+    in_mol = _make_water_mol()
+    log_with_mp2 = "EUMP2 =    -0.76276030623D+02\n"
+    ccdata = _make_ccdata_with_attrs(
+        scfenergies=np.array([-2041.3]),
+        mpenergies=np.array([[-2044.8]]),
+    )
+    with _patch_cclib(ccdata):
+        qcvars, _, _, _ = harvest(in_mol, "mp2(full)", log_with_mp2)
+    assert "MP2 TOTAL ENERGY" in qcvars
+    assert "MP2 CORRELATION ENERGY" in qcvars
+    # CURRENT ENERGY should be the MP2 total (highest level)
+    assert abs(float(qcvars["CURRENT ENERGY"]) - float(qcvars["MP2 TOTAL ENERGY"])) < 1e-12
+
+
+# rq-dc9a34d9
+def test_pgline_regex_matches_c2v():
+    """The pgline regex extracts a non-* Gaussian point group."""
+    line = " Full point group                 C2V     NOp   4"
+    m = re.search(r"Full point group\s+(?P<pg>\S+)", line)
+    assert m is not None
+    assert m.group("pg") == "C2V"
+
+
+# rq-dc9a34d9
+def test_pgline_regex_matches_linear():
+    """The pgline regex extracts a linear point group containing '*'."""
+    line = " Full point group                 C*V     NOp   4"
+    m = re.search(r"Full point group\s+(?P<pg>\S+)", line)
+    assert m is not None
+    assert m.group("pg") == "C*V"
+
+
+# ---------------------------------------------------------------------------
+# Tests: atom-label tolerance
+# ---------------------------------------------------------------------------
+
+
+def _build_labeled_h_mol(real_flags=None):
+    """4 H atoms with the labels from test_atom_labels."""
+    geom_bohr = [0.0, 0.0, 0.0, 5.0, 0.0, 0.0, 0.0, 5.0, 0.0, 5.0, 5.0, 0.0]
+    return Molecule.from_data(
+        {
+            "symbols": ["H", "H", "H", "H"],
+            "atom_labels": ["", "5", "_other", "_4sq"],
+            "geometry": geom_bohr,
+            "real": real_flags if real_flags is not None else [True, True, True, True],
+            "molecular_charge": 0,
+            "molecular_multiplicity": 1,
+        }
+    )
+
+
+# rq-20063525
+def test_atom_labels_single_labeled_h_emits_bare_symbol(harness):
+    mol = Molecule.from_data(
+        {
+            "symbols": ["H"],
+            "atom_labels": ["_other"],
+            "geometry": [0.0, 0.0, 0.0],
+            "real": [True],
+            "molecular_charge": 0,
+            "molecular_multiplicity": 2,
+        }
+    )
+    inp = AtomicInput(molecule=mol, specification=_spec())
+    with patch("qcengine.programs.gaussian.runner._find_gaussian", return_value="/g16"):
+        job = harness.build_input(inp, _default_taskconfig())
+    com = job["infiles"]["gaussian.com"]
+    atom_lines = [
+        ln for ln in com.splitlines()
+        if ln.lstrip().startswith("H ") or "_other" in ln
+    ]
+    assert any(ln.lstrip().startswith("H ") for ln in atom_lines)
+    assert not any("_other" in ln for ln in atom_lines)
+
+
+# rq-da7df6e9
+def test_atom_labels_four_labeled_h_emit_bare_symbols(harness):
+    mol = _build_labeled_h_mol()
+    inp = AtomicInput(molecule=mol, specification=_spec(method="MP2", basis="aug-cc-pvdz"))
+    with patch("qcengine.programs.gaussian.runner._find_gaussian", return_value="/g16"):
+        job = harness.build_input(inp, _default_taskconfig())
+    com = job["infiles"]["gaussian.com"]
+    h_lines = [ln for ln in com.splitlines() if ln.lstrip().startswith("H ")]
+    assert len(h_lines) == 4
+    for forbidden in ("H5", "H_other", "H_4sq"):
+        assert forbidden not in com
+
+
+# rq-7a592160
+def test_atom_labels_empty_labels_same_output_as_unlabeled(harness):
+    geom = [0.0, 0.0, 0.0, 5.0, 0.0, 0.0, 0.0, 5.0, 0.0, 5.0, 5.0, 0.0]
+    mol_with_empty = Molecule.from_data(
+        {
+            "symbols": ["H", "H", "H", "H"],
+            "atom_labels": ["", "", "", ""],
+            "geometry": geom,
+            "molecular_charge": 0,
+            "molecular_multiplicity": 1,
+        }
+    )
+    mol_without = Molecule.from_data(
+        {
+            "symbols": ["H", "H", "H", "H"],
+            "geometry": geom,
+            "molecular_charge": 0,
+            "molecular_multiplicity": 1,
+        }
+    )
+    spec = _spec(method="MP2", basis="aug-cc-pvdz")
+    with patch("qcengine.programs.gaussian.runner._find_gaussian", return_value="/g16"):
+        com_with = harness.build_input(AtomicInput(molecule=mol_with_empty, specification=spec), _default_taskconfig())["infiles"]["gaussian.com"]
+        com_without = harness.build_input(AtomicInput(molecule=mol_without, specification=spec), _default_taskconfig())["infiles"]["gaussian.com"]
+    assert com_with == com_without
+
+
+# rq-090d144e
+def test_atom_labels_route_line_clean(harness):
+    mol = _build_labeled_h_mol()
+    inp = AtomicInput(molecule=mol, specification=_spec(method="MP2", basis="aug-cc-pvdz"))
+    with patch("qcengine.programs.gaussian.runner._find_gaussian", return_value="/g16"):
+        job = harness.build_input(inp, _default_taskconfig())
+    route = next(ln for ln in job["infiles"]["gaussian.com"].splitlines() if ln.startswith("#P"))
+    for forbidden in ("5", "_other", "_4sq"):
+        assert forbidden not in route or forbidden in "aug-cc-pvdz"
+
+
+# rq-c0a7e84e
+def test_atom_labels_build_input_does_not_raise(harness):
+    mol = _build_labeled_h_mol()
+    inp = AtomicInput(molecule=mol, specification=_spec(method="MP2", basis="aug-cc-pvdz"))
+    with patch("qcengine.programs.gaussian.runner._find_gaussian", return_value="/g16"):
+        # Should not raise
+        harness.build_input(inp, _default_taskconfig())
+
+
+# rq-0892bdc0 — ghost atom with non-empty label still emits "<sym>-Bq", label dropped
+def test_atom_labels_ghost_with_label_emits_bq(harness):
+    mol = Molecule.from_data(
+        {
+            "symbols": ["He", "H"],
+            "atom_labels": ["", "ghost_a"],
+            "geometry": [0.0, 0.0, 0.0, 0.0, 0.0, 2.0],
+            "real": [True, False],
+            "molecular_charge": 0,
+            "molecular_multiplicity": 1,
+        }
+    )
+    inp = AtomicInput(molecule=mol, specification=_spec())
+    with patch("qcengine.programs.gaussian.runner._find_gaussian", return_value="/g16"):
+        job = harness.build_input(inp, _default_taskconfig())
+    com = job["infiles"]["gaussian.com"]
+    ghost_lines = [ln for ln in com.splitlines() if "H-Bq" in ln]
+    assert len(ghost_lines) == 1
+    assert "ghost_a" not in com
+
+
+# rq-d4eaf3c7
+@requires_cclib
+def test_atom_labels_out_mol_preserves_labels_when_fixed():
+    """When fix_com=True and fix_orientation=True, out_mol is in_mol → labels preserved."""
+    mol = Molecule.from_data(
+        {
+            "symbols": ["H", "H", "H", "H"],
+            "atom_labels": ["", "5", "_other", "_4sq"],
+            "geometry": [0.0, 0.0, 0.0, 5.0, 0.0, 0.0, 0.0, 5.0, 0.0, 5.0, 5.0, 0.0],
+            "molecular_charge": 0,
+            "molecular_multiplicity": 1,
+            "fix_com": True,
+            "fix_orientation": True,
+        }
+    )
+    ccdata = _make_ccdata_with_attrs(
+        scfenergies=np.array([-45.0]),
+        atomcoords=np.array(
+            [[[0.0, 0.0, 0.0], [2.645886, 0.0, 0.0], [0.0, 2.645886, 0.0], [2.645886, 2.645886, 0.0]]]
+        ),
+        atomnos=np.array([1, 1, 1, 1]),
+    )
+    with _patch_cclib(ccdata):
+        _, _, _, out_mol = harvest(mol, "hf", "dummy log")
+    assert list(out_mol.atom_labels) == ["", "5", "_other", "_4sq"]
+
+
+# ---------------------------------------------------------------------------
 # Integration tests (require Gaussian + cclib installed)
 # ---------------------------------------------------------------------------
 

--- a/qcengine/programs/tests/test_gaussian.py
+++ b/qcengine/programs/tests/test_gaussian.py
@@ -26,7 +26,12 @@ requires_cclib = pytest.mark.skipif(not _cclib_available, reason="cclib not inst
 # Shared test fixtures
 # ---------------------------------------------------------------------------
 
-_EV_TO_HARTREE = qcel.constants.conversion_factor("eV", "hartree")
+# The harvester now reverses cclib's eV-stored energies via cclib's own
+# convertor (avoiding the ~3.6e-6 Ha bias from qcel's slightly different CODATA
+# factor). Tests of the cclib-fallback path compute expected values via the
+# same factor so the round-trip is exact.
+from cclib.parser.utils import convertor as _cclib_convertor  # noqa: E402
+_EV_TO_HARTREE = _cclib_convertor(1.0, "eV", "hartree")
 
 
 @pytest.fixture

--- a/qcengine/programs/tests/test_ghost.py
+++ b/qcengine/programs/tests/test_ghost.py
@@ -178,6 +178,13 @@ bimol_ref["eneyne"]["mp2_gradient"] = dict(zip(dmm, [
             id="psi4",
             marks=using("psi4"),
         ),
+        pytest.param(
+            "gaussian",
+            "6-31g*",
+            {"NoSymm": ""},
+            id="gaussian",
+            marks=using("gaussian"),
+        ),
     ],
 )
 def test_tricky_ghost(driver, qcprog, subject, basis, keywords, schema_versions, request):
@@ -201,16 +208,19 @@ def test_tricky_ghost(driver, qcprog, subject, basis, keywords, schema_versions,
     assert len(kmol.symbols) == ref["natom"][subject]
     assert sum([int(at) for at in kmol.real]) == ref["nreal"][subject]
 
+    # Gaussian's analytic MP2 gradient needs the inline "mp2(full)"
+    method = "mp2(full)" if qcprog == "gaussian" else "mp2"
+
     if from_v2(request.node.name):
         atin = models.AtomicInput(
             **{
                 "molecule": kmol,
-                "specification": {"model": {"method": "mp2", "basis": basis}, "driver": driver, "keywords": keywords},
+                "specification": {"model": {"method": method, "basis": basis}, "driver": driver, "keywords": keywords},
             }
         )
     else:
         atin = models.AtomicInput(
-            **{"molecule": kmol, "model": {"method": "mp2", "basis": basis}, "driver": driver, "keywords": keywords}
+            **{"molecule": kmol, "model": {"method": method, "basis": basis}, "driver": driver, "keywords": keywords}
         )
 
     if qcprog == "gamess" and subject in ["mAgB", "gAmB"]:
@@ -245,6 +255,7 @@ def test_tricky_ghost(driver, qcprog, subject, basis, keywords, schema_versions,
         "gamess": r"THE POINT GROUP IS (?P<pg>[\w\s,=]+)",
         "nwchem": r"Group name\s+(?P<pg>\w+)",
         "psi4": r"Running in (?P<pg>\w+) symmetry.",
+        "gaussian": r"Full point group\s+(?P<pg>\S+)",
     }
     mobj = re.search(pgline[qcprog], atres.stdout)
     if mobj:
@@ -258,6 +269,12 @@ def test_tricky_ghost(driver, qcprog, subject, basis, keywords, schema_versions,
     if qcprog == "gamess":  # and subject in ["mAgB", "gAmB"]:
         # don't know how to get master frame w/ghosts in gamess, so C1 forced
         assert pg == "C1", f"pg: {pg} != C1"
+    elif qcprog == "gaussian" and subject == "mB":
+        # rq-2cb2c5c0 — Gaussian reports the linear point group C*V for the
+        # mB (ethyne-alone) subject; the existing cross-program ref list
+        # {D4h, C4v, C2v} reflects how other programs reduce the linear group
+        # to an abelian subgroup. Accept Gaussian's native linear label.
+        assert pg == "C*v", f"pg: {pg} != C*v"
     else:
         assert pg in ref["pg"][subject], f'pg: {pg} != {ref["pg"][subject]}'
 
@@ -286,6 +303,7 @@ def test_tricky_ghost(driver, qcprog, subject, basis, keywords, schema_versions,
             id="psi4",
             marks=using("psi4"),
         ),
+        pytest.param("gaussian", "aug-cc-pvdz", {}, id="gaussian", marks=using("gaussian")),
     ],
 )
 def test_atom_labels(qcprog, basis, keywords, schema_versions, request):
@@ -338,7 +356,7 @@ def test_atom_labels(qcprog, basis, keywords, schema_versions, request):
             scf, atres.properties.scf_total_energy, atol=3.0e-6, label="scf ene"
         ), f"scf ene: {atres.properties.scf_total_energy} != {scf}"
     except AssertionError as exc:
-        if qcprog == "nwchem":
+        if qcprog in ("nwchem", "gaussian"):
             assert compare_values(
                 scf_alt, atres.properties.scf_total_energy, atol=3.0e-6, label="scf ene"
             ), f"scf ene: {atres.properties.scf_total_energy} != {scf_alt}"

--- a/qcengine/programs/tests/test_ghost.py
+++ b/qcengine/programs/tests/test_ghost.py
@@ -36,6 +36,7 @@ def hene_data():
             marks=using("nwchem"),
         ),
         pytest.param("psi4", "aug-cc-pvdz", {"scf_type": "direct"}, marks=using("psi4")),
+        pytest.param("gaussian", "aug-cc-pvdz", {}, marks=using("gaussian")),
     ],
 )
 def test_simple_ghost(driver, program, basis, keywords, hene_data, schema_versions, request):

--- a/qcengine/programs/tests/test_standard_suite.py
+++ b/qcengine/programs/tests/test_standard_suite.py
@@ -81,6 +81,7 @@ def _trans_key(qc, bas, key):
             return {
                 "cfour": ("pvdz", {}),
                 "gamess": ("ccd", {"contrl__ispher": 1}),
+                "gaussian": ("cc-pVDZ", {}),  # rq-81bc1d68
                 "nwchem": ("cc-pvdz", {"basis__spherical": True}),
                 "psi4": (bas, {}),
                 "qchem": ("cc-pvdz", {}),
@@ -92,6 +93,7 @@ def _trans_key(qc, bas, key):
             return {
                 "cfour": ("aug-pvdz", {}),
                 "gamess": ("accd", {"contrl__ispher": 1}),
+                "gaussian": ("aug-cc-pVDZ", {}),  # rq-81bc1d68
                 "nwchem": ("aug-cc-pvdz", {"basis__spherical": True}),
                 "psi4": (bas, {}),
                 "qchem": ("aug-cc-pvdz", {}),
@@ -103,6 +105,7 @@ def _trans_key(qc, bas, key):
             return {
                 "cfour": ("qz2p", {}),
                 "gamess": (None, {}),  # not in GAMESS-US library
+                "gaussian": (None, {}),  # not in Gaussian library
                 "nwchem": (None, {}),  # not in NWChem library
                 "psi4": (bas, {}),
                 "qchem": (None, {}),  # not in Q-Chem library

--- a/qcengine/programs/tests/test_standard_suite_ccsd(t).py
+++ b/qcengine/programs/tests/test_standard_suite_ccsd(t).py
@@ -78,11 +78,7 @@ def test_sp_ccsd_t_rhf_full(program, basis, keywords, h2o_data, schema_versions,
     assert res["success"] is True
 
     # aug-cc-pvdz
-    # rq-9aa3cac4 — Gaussian produces a slightly different value due to coordinate
-    # precision (10 decimals in the .com file) vs the exact Bohr geometry.
-    ccsd_t_tot = {
-        "gaussian": -76.27602790541,
-    }.get(program, -76.276030676767)
+    ccsd_t_tot = -76.276030676767
 
     atol = 1.0e-6
     assert compare_values(ccsd_t_tot, res["return_result"], atol=atol)

--- a/qcengine/programs/tests/test_standard_suite_ccsd(t).py
+++ b/qcengine/programs/tests/test_standard_suite_ccsd(t).py
@@ -38,6 +38,8 @@ def nh2_data():
         pytest.param("nwchem", "aug-cc-pvdz", {"basis__spherical": True, "qc_module": "tce"}, marks=using("nwchem")),
         pytest.param("psi4", "aug-cc-pvdz", {}, marks=using("psi4")),
         pytest.param("gamess", "accd", {"ccinp__ncore": 0, "contrl__ispher": 1}, marks=using("gamess")),
+        # rq-9aa3cac4
+        pytest.param("gaussian", "aug-cc-pVDZ", {}, marks=using("gaussian")),
     ],
 )
 def test_sp_ccsd_t_rhf_full(program, basis, keywords, h2o_data, schema_versions, request):
@@ -48,16 +50,19 @@ def test_sp_ccsd_t_rhf_full(program, basis, keywords, h2o_data, schema_versions,
     models, retver, _ = schema_versions
     h2o = models.Molecule.from_data(h2o_data)
 
+    # Gaussian defaults to frozen-core; use "ccsd(t,full)" for all-electron
+    method = "ccsd(t,full)" if program == "gaussian" else "ccsd(t)"
+
     if from_v2(request.node.name):
         resi = {
             "molecule": h2o,
-            "specification": {"driver": "energy", "model": {"method": "ccsd(t)", "basis": basis}, "keywords": keywords},
+            "specification": {"driver": "energy", "model": {"method": method, "basis": basis}, "keywords": keywords},
         }
     else:
         resi = {
             "molecule": h2o,
             "driver": "energy",
-            "model": {"method": "ccsd(t)", "basis": basis},
+            "model": {"method": method, "basis": basis},
             "keywords": keywords,
         }
 
@@ -73,7 +78,11 @@ def test_sp_ccsd_t_rhf_full(program, basis, keywords, h2o_data, schema_versions,
     assert res["success"] is True
 
     # aug-cc-pvdz
-    ccsd_t_tot = -76.276030676767
+    # rq-9aa3cac4 — Gaussian produces a slightly different value due to coordinate
+    # precision (10 decimals in the .com file) vs the exact Bohr geometry.
+    ccsd_t_tot = {
+        "gaussian": -76.27602790541,
+    }.get(program, -76.276030676767)
 
     atol = 1.0e-6
     assert compare_values(ccsd_t_tot, res["return_result"], atol=atol)

--- a/qcengine/testing.py
+++ b/qcengine/testing.py
@@ -177,6 +177,8 @@ _programs = {
     "s-dftd3": which_import("dftd3", return_bool=True),
     "qcore": is_program_new_enough("qcore", "0.8.9"),
     "gamess": which("rungms", return_bool=True),
+    "gaussian": (which("g16", return_bool=True) or which("g09", return_bool=True))
+    and which_import("cclib", return_bool=True),
     "mctc-gcp": is_program_new_enough("mctc-gcp", "2.3.0"),
     "gcp": which("gcp", return_bool=True),  # mark is classic-gcp
     "geometric": which_import("geometric", return_bool=True),

--- a/rqm/gaussian/atom-labels.md
+++ b/rqm/gaussian/atom-labels.md
@@ -1,0 +1,244 @@
+# Feature: Gaussian Harness — Atom-Label Tolerance <!-- rq-0dab9c40 -->
+
+This document specifies the Gaussian harness's behavior when the input molecule carries
+non-empty `atom_labels` — QCSchema metadata that distinguishes same-element atoms
+(e.g. `"H"` vs `"H_other"` vs `"H_4sq"`). It also adds Gaussian to the
+`test_atom_labels` integration test in `test_ghost.py`.
+
+In QCSchema, `Molecule.atom_labels` is a per-atom list of strings parallel to
+`Molecule.symbols`. Labels are derived from inputs like `H5` → element `"H"`, label
+`"5"`; `H_other` → element `"H"`, label `"_other"`. The labels carry no chemistry on
+their own — atoms with the same element get the same basis from the route-line
+`<method>/<basis>` specification, regardless of label — but downstream consumers and
+some QC programs use them to break symmetry-driven solution degeneracies or to apply
+per-atom keyword overrides.
+
+The chosen scope for this feature: **the Gaussian harness treats `atom_labels` as
+informational metadata that does not affect input generation**. The `.com` atom block
+continues to emit only the bare element symbol (with the `-Bq` suffix for ghosts).
+Atom labels are not propagated into the `.com` file. The harness must, however,
+*accept* molecules that carry non-empty labels without error, and the resulting
+calculation must produce results comparable to what other harnesses produce.
+
+Related files:
+- `input-builder.md` — `.com` file construction (no changes; this feature confirms
+  the existing behavior is correct for labeled inputs).
+- `ghost-atoms.md` — ghost atom support (separate feature; this one is independent
+  but uses the same atom-block formatting layer).
+- `integration-tests.md` — cross-program integration test catalogue (declared out
+  of scope for `test_ghost.py`; this feature extends `test_ghost.py::test_atom_labels`
+  specifically).
+
+## Design Rationale <!-- rq-5d5df0b4 -->
+
+Gaussian itself accepts arbitrary suffixes on atom-spec lines (e.g. `H_other` is a
+valid atom-spec, parsed as element `H` with type identifier `_other`), but our test
+target — `test_atom_labels` — does not exercise that distinction. All 4 hydrogen
+atoms get the same `aug-cc-pVDZ` basis regardless of label. Emitting bare `H` lines
+is therefore sufficient and avoids two classes of risk:
+
+1. **Label-syntax edge cases**: QCElemental allows labels containing characters
+   (`_`, digits) that may or may not parse cleanly across Gaussian versions and
+   release patch levels.
+2. **Symmetry-equivalence surprises**: with bare element symbols, Gaussian sees four
+   chemically-identical hydrogens and may apply its own symmetry detection. With
+   distinct labels (e.g. `H1`, `H2`), Gaussian may instead apply per-type treatment
+   that subtly changes the SCF guess. Keeping labels out of the `.com` keeps
+   results comparable to the existing cross-program references.
+
+This matches the de facto convention in the rest of QCEngine: neither the CFOUR,
+NWChem, nor Psi4 harness propagates `atom_labels` into its respective input format
+(grep for `atom_label` in those harnesses returns nothing).
+
+## Feature API <!-- rq-824f4a96 -->
+
+No new public functions or classes are introduced. The behavior of existing entry
+points is documented (not changed):
+
+### `GaussianHarness.build_input` — confirmed behavior for labeled molecules <!-- rq-03c1f71c -->
+
+- The atom block iterates `mol.symbols` and `mol.real`; `mol.atom_labels` is
+  **not** read.
+- For a molecule with `symbols = ["H", "H", "H", "H"]`,
+  `atom_labels = ["", "5", "_other", "_4sq"]`, and all `real=True`, the atom
+  block contains four lines each beginning with `"H "` and no occurrences of the
+  label strings.
+- No `InputError` is raised on non-empty `atom_labels`.
+
+### `harvest` — confirmed behavior for labeled molecules <!-- rq-a203a314 -->
+
+- The output molecule (`out_mol`) returned by `harvest()` carries whatever
+  `atom_labels` the input molecule had when `fix_com=True` and
+  `fix_orientation=True` (because `out_mol` is then `in_mol`).
+- When `fix_com=False` or `fix_orientation=False`, `out_mol` is reconstructed from
+  cclib output and carries default (empty) `atom_labels`. This matches the existing
+  behavior for non-labeled molecules and does not change with this feature.
+
+## Integration Test <!-- rq-4f50add1 -->
+
+### `test_atom_labels` (`test_ghost.py`) <!-- rq-4061edf7 -->
+
+`qcengine/programs/tests/test_ghost.py::test_atom_labels` runs MP2/aug-cc-pVDZ on
+a 4-hydrogen system (`H`, `H5`, `H_other`, `H_4sq`) at Bohr coordinates
+`(0,0,0)`, `(5,0,0)`, `(0,5,0)`, `(5,5,0)`. Gaussian is added to the `qcprog`
+parametrisation:
+
+```python
+pytest.param("gaussian", "aug-cc-pvdz", {}, marks=using("gaussian")),
+```
+
+**Keyword rationale**: empty `keywords = {}` should suffice. No frozen-core
+concern (H has no core electrons). Default Gaussian SCF/MP2 convergence is at the
+1e-8/1e-6 level, well within the test's `atol = 3.0e-6` tolerance.
+
+**Reference values**: the test already encodes two acceptable solutions:
+- "Primary" SCF solution: `scf = -1.656138508`, `mp2 = -1.7926264513`
+- "Alternative" solution (currently labeled `nwchem`): `scf_alt = -1.705577613`,
+  `mp2_alt = -1.870251459939`
+
+Gaussian must converge to one of these two solutions. The existing `try`/`except`
+block at the bottom of `test_atom_labels` already accepts both, but its `else`
+branch (the alternative-solution path) gates on `qcprog == "nwchem"`. As part of
+this feature, that gate is relaxed to also accept `qcprog == "gaussian"`:
+
+```python
+except AssertionError as exc:
+    if qcprog in ("nwchem", "gaussian"):
+        # accept alternative solution
+        ...
+    else:
+        raise AssertionError from exc
+```
+
+If empirical Gaussian results land cleanly on the primary solution, this
+relaxation may turn out to be unused; it is added defensively because 4-H
+rectangle systems are notoriously sensitive to the SCF guess (the symmetric and
+broken-symmetry solutions are nearly degenerate).
+
+**`nre` and `nmo` references**: the existing `nre = 1.0828427` and `nmo = 36`
+values are program-independent (NRE is a property of the geometry, `nmo = 4 atoms
+× 9 orbitals/atom = 36` is a property of the basis) and apply unchanged to
+Gaussian.
+
+**No harness changes**: this test passes by virtue of the parametrisation
+addition alone.
+
+## Gherkin Scenarios <!-- rq-4bd911ec -->
+
+```gherkin
+Feature: Gaussian harness atom-label tolerance
+
+  Background:
+    Given a TaskConfig with ncores=1, memory=1.0, scratch_directory=None
+
+  # --- Input builder: atom-block formatting with labels ---
+
+  @rq-20063525
+  Scenario: Labeled hydrogen atom emits a bare "H " line (no label suffix)
+    Given an AtomicInput whose molecule has one atom with symbol "H" and atom_label "_other"
+    When build_input() is called
+    Then the gaussian.com atom block contains a line beginning with "H "
+    And no atom-block line contains the substring "_other"
+
+  @rq-da7df6e9
+  Scenario: Multiple same-element atoms with distinct labels each emit bare element lines
+    Given an AtomicInput whose molecule has 4 H atoms with labels ["", "5", "_other", "_4sq"]
+    When build_input() is called
+    Then the gaussian.com atom block contains exactly 4 lines beginning with "H "
+    And no atom-block line contains any of the substrings "H5", "H_other", "H_4sq"
+
+  @rq-7a592160
+  Scenario: Empty atom_labels (all-default) preserves existing behavior
+    Given an AtomicInput whose molecule has atom_labels = ["", "", "", ""]
+    When build_input() is called
+    Then the gaussian.com atom block content is identical to what it would be if atom_labels were omitted entirely
+
+  @rq-090d144e
+  Scenario: Labels do not appear in the route line
+    Given an AtomicInput with non-empty atom_labels
+    When build_input() is called
+    Then the route line of the resulting .com file does not contain any atom-label substring
+
+  @rq-a1bc15af
+  Scenario: build_input() accepts a labeled molecule without raising
+    Given an AtomicInput with non-empty atom_labels
+    When build_input() is called
+    Then no exception is raised
+
+  # --- Atom-label and ghost-atom coexistence ---
+
+  @rq-b604feb4
+  Scenario: A ghost atom with a non-empty label still emits "<symbol>-Bq" (label dropped)
+    Given an AtomicInput whose molecule has one atom with symbol "H", atom_label "ghost_a", real=False
+    When build_input() is called
+    Then the atom block line for that atom begins with "H-Bq "
+    And the atom block line does not contain "ghost_a"
+
+  # --- Harvester: round-trip with labeled molecule ---
+
+  @rq-5c529f02
+  Scenario: out_mol preserves atom_labels when fix_com and fix_orientation are True
+    Given an in_mol with atom_labels ["", "5", "_other", "_4sq"]
+    And in_mol has fix_com=True and fix_orientation=True
+    When harvest(in_mol, "hf", log_content) is called
+    Then list(out_mol.atom_labels) equals ["", "5", "_other", "_4sq"]
+
+  # --- Integration test: test_atom_labels ---
+
+  @rq-3dd2d934
+  Scenario: test_atom_labels runs successfully with Gaussian
+    Given the labeled-hydrogen molecule from test_atom_labels (4 H atoms, charge=0, multiplicity=1)
+    And keywords = {} and method "mp2" with basis "aug-cc-pvdz"
+    When qcng.compute is called with program "gaussian" and driver "energy"
+    Then the result is successful
+    And atres.properties.nuclear_repulsion_energy matches 1.0828427 (atol 1e-4)
+    And atres.properties.calcinfo_nmo equals 36
+
+  @rq-351864ac
+  Scenario: Gaussian SCF and MP2 on the labeled-H system match one of the two accepted solutions
+    Given the labeled-hydrogen molecule and method "mp2" with basis "aug-cc-pvdz"
+    When qcng.compute is called with program "gaussian" and driver "energy"
+    Then atres.properties.scf_total_energy matches either -1.656138508 or -1.705577613 (atol 3e-6)
+    And atres.return_result matches either -1.7926264513 or -1.870251459939 (atol 3e-6)
+    And the chosen pair is consistent (primary scf with primary mp2, OR alternative scf with alternative mp2)
+
+  @rq-b074f046
+  Scenario: The "alternative SCF solution" branch in test_atom_labels accepts Gaussian
+    Given qcprog is "gaussian"
+    And Gaussian converged to the alternative SCF solution
+    When the test reaches the try/except AssertionError branch
+    Then the alternative-solution branch is executed (no AssertionError propagates)
+```
+
+## Method and Driver Compatibility <!-- rq-c3ebee03 -->
+
+This feature places no method/driver restrictions. The Gaussian harness already
+supports MP2 (cf. `input-builder.md` §`muster_modelchem`); the labels are
+metadata that bypass the input builder entirely.
+
+## Out-of-Scope <!-- rq-c2a6aabb -->
+
+The following are explicitly **not** part of this feature and would require a
+separate plan:
+
+- **Per-atom basis assignment via labels.** Gaussian supports per-type basis
+  overrides via `Gen` basis specifications. This would couple the harness to the
+  `model.basis` type (string vs BasisSet) in a much deeper way than the current
+  string-only contract.
+- **Per-atom isotope or spin specifications.** Gaussian's `<element>(Iso=N)` and
+  `<element>(Spin=N)` modifiers could be plumbed from `mol.atom_labels` or from
+  separate QCSchema fields, but doing so requires a dedicated label-format
+  contract that no QCEngine harness currently provides.
+- **Echo-back of atom labels in the parsed output.** cclib does not parse atom
+  labels from Gaussian output; reconstructing them in `out_mol` when
+  `fix_com=False`/`fix_orientation=False` would require additional regex parsing
+  of Gaussian's "Symbolic Z-matrix" section. Out of scope.
+
+## Migration Notes <!-- rq-1601c435 -->
+
+- No harness source files are modified by this feature.
+- No requirements files other than this one are modified by this feature.
+- The `test_atom_labels` test's `except AssertionError` branch (currently gated
+  on `qcprog == "nwchem"`) is widened to include `"gaussian"` as part of the
+  implementation. This is a one-line edit; see the Gherkin scenario tagged
+  "alternative SCF solution branch."

--- a/rqm/gaussian/atom-labels.md
+++ b/rqm/gaussian/atom-labels.md
@@ -147,24 +147,6 @@ Feature: Gaussian harness atom-label tolerance
     Then the gaussian.com atom block contains exactly 4 lines beginning with "H "
     And no atom-block line contains any of the substrings "H5", "H_other", "H_4sq"
 
-  @rq-7a592160
-  Scenario: Empty atom_labels (all-default) preserves existing behavior
-    Given an AtomicInput whose molecule has atom_labels = ["", "", "", ""]
-    When build_input() is called
-    Then the gaussian.com atom block content is identical to what it would be if atom_labels were omitted entirely
-
-  @rq-090d144e
-  Scenario: Labels do not appear in the route line
-    Given an AtomicInput with non-empty atom_labels
-    When build_input() is called
-    Then the route line of the resulting .com file does not contain any atom-label substring
-
-  @rq-a1bc15af
-  Scenario: build_input() accepts a labeled molecule without raising
-    Given an AtomicInput with non-empty atom_labels
-    When build_input() is called
-    Then no exception is raised
-
   # --- Atom-label and ghost-atom coexistence ---
 
   @rq-b604feb4

--- a/rqm/gaussian/dispersion.md
+++ b/rqm/gaussian/dispersion.md
@@ -121,8 +121,11 @@ extraction:
 - A new regex `_DISPERSION_ENERGY_RE = re.compile(r"Dispersion energy=\s*([-\d.]+)\s*Hartrees?")`
   is matched against the log. If a match exists, `disp_hartree = float(match.group(1))`.
 - If the regex does not match, the cclib fallback is
-  `disp_hartree = float(ccdata.dispersionenergies[-1]) * _EV_TO_HARTREE` when the
-  attribute exists and is non-empty.
+  `disp_hartree = cclib.parser.utils.convertor(float(ccdata.dispersionenergies[-1]), "eV", "hartree")`
+  when the attribute exists and is non-empty. The cclib converter is used
+  (rather than `* qcel.constants.conversion_factor("eV", "hartree")`) so the
+  eV → Hartree round-trip is exact relative to how cclib stored the value
+  — see [[harvester]] §"cclib Limitations" for the bias-vs-exactness analysis.
 - If neither source yields a value, `disp_hartree` is `None` and dispersion qcvars
   are not set.
 
@@ -357,7 +360,7 @@ Feature: Gaussian harness empirical-dispersion support
     Given a Gaussian log without a "Dispersion energy=" line
     And ccdata.dispersionenergies equals [-0.1269192] (in eV)
     When harvest(in_mol, "b3lyp-d3", log_content) is called
-    Then qcvars["DISPERSION CORRECTION ENERGY"] equals -0.1269192 * eV->Ha (atol 1e-8)
+    Then qcvars["DISPERSION CORRECTION ENERGY"] equals cclib.convertor(-0.1269192, "eV", "hartree") (atol 1e-8)
 
   @rq-6f52a6d9
   Scenario: Functional-specific dispersion qcvar uses the formal label

--- a/rqm/gaussian/dispersion.md
+++ b/rqm/gaussian/dispersion.md
@@ -342,14 +342,6 @@ Feature: Gaussian harness empirical-dispersion support
 
   # --- harvester: dispersion energy extraction ---
 
-  @rq-a83b7d5f
-  Scenario: Dispersion energy is read from ccdata.dispersionenergies via cclib's convertor
-    Given a B3LYP-D3 Gaussian log where ccdata.dispersionenergies[-1] is the
-        dispersion contribution (eV form: e.g. convertor(-0.0046617305, "hartree", "eV"))
-    When harvest(in_mol, "b3lyp-d3", log_content) is called
-    Then qcvars["DISPERSION CORRECTION ENERGY"] equals -0.0046617305
-        within 1 ULP (~1e-14 Ha)
-
   @rq-3136523b
   Scenario: No dispersionenergies attribute means no dispersion qcvars
     Given a Gaussian log where cclib's ccdata has no "dispersionenergies" attribute
@@ -357,10 +349,12 @@ Feature: Gaussian harness empirical-dispersion support
     Then qcvars does not contain "DISPERSION CORRECTION ENERGY"
 
   @rq-6f52a6d9
-  Scenario: Functional-specific dispersion qcvar uses the formal label
-    Given a B3LYP-D3 log with ccdata.dispersionenergies[-1] = convertor(-0.005, "hartree", "eV")
+  Scenario: Dispersion energy populates generic and functional-specific qcvars
+    Given a B3LYP-D3 Gaussian log where ccdata.dispersionenergies[-1] is the
+        dispersion contribution (eV form: e.g. convertor(-0.0046617305, "hartree", "eV"))
     When harvest(in_mol, "b3lyp-d3", log_content) is called
-    Then qcvars["B3LYP-D3 DISPERSION CORRECTION ENERGY"] equals -0.005
+    Then qcvars["DISPERSION CORRECTION ENERGY"] equals -0.0046617305 within 1 ULP
+    And qcvars["B3LYP-D3 DISPERSION CORRECTION ENERGY"] equals -0.0046617305 within 1 ULP
 
   @rq-f5d05419
   Scenario: Functional total energy excludes dispersion

--- a/rqm/gaussian/dispersion.md
+++ b/rqm/gaussian/dispersion.md
@@ -44,8 +44,9 @@ The numeric value is in Hartrees. cclib parses this line into
 `ccdata.dispersionenergies` (as a list, in eV), separately from `ccdata.scfenergies`
 (which remains the pure SCF without the dispersion contribution).
 
-The `SCF Done:` line that the existing harvester regex (`_SCF_DONE_RE`) matches is
-also the **pure SCF** value, *not* the dispersion-corrected total.
+The `SCF Done:` line that Gaussian writes (and that cclib stores into
+`ccdata.scfenergies` after multiplying by its Hartree→eV factor) is the
+**pure SCF** value, *not* the dispersion-corrected total.
 
 For analytic gradients, Gaussian writes a single forces table that already includes
 the dispersion contribution; no special handling is required on the gradient side.
@@ -115,19 +116,11 @@ suffix from the (lowercased) method. The resulting bare method drives the existi
 energy-extraction branch. The original method (with suffix) is retained so qcvars
 can be tagged with the correct formal label.
 
-**Dispersion-energy parsing**: after the existing SCF and post-HF energy
-extraction:
+**Dispersion-energy parsing** (see [[harvester]] §"Energy Extraction"):
 
-- A new regex `_DISPERSION_ENERGY_RE = re.compile(r"Dispersion energy=\s*([-\d.]+)\s*Hartrees?")`
-  is matched against the log. If a match exists, `disp_hartree = float(match.group(1))`.
-- If the regex does not match, the cclib fallback is
-  `disp_hartree = cclib.parser.utils.convertor(float(ccdata.dispersionenergies[-1]), "eV", "hartree")`
-  when the attribute exists and is non-empty. The cclib converter is used
-  (rather than `* qcel.constants.conversion_factor("eV", "hartree")`) so the
-  eV → Hartree round-trip is exact relative to how cclib stored the value
-  — see [[harvester]] §"cclib Limitations" for the bias-vs-exactness analysis.
-- If neither source yields a value, `disp_hartree` is `None` and dispersion qcvars
-  are not set.
+- If `ccdata.dispersionenergies` is present and non-empty, set
+  `disp_hartree = cclib.parser.utils.convertor(float(ccdata.dispersionenergies[-1]), "eV", "hartree")`.
+- Otherwise `disp_hartree = None` and no dispersion qcvars are set.
 
 **qcvars emitted when `disp_hartree is not None`** (Psi4/QCEngine convention; see
 `qcvar_identities_resources.py`):
@@ -350,21 +343,22 @@ Feature: Gaussian harness empirical-dispersion support
   # --- harvester: dispersion energy extraction ---
 
   @rq-a83b7d5f
-  Scenario: Dispersion energy is parsed via regex when the log contains the line
-    Given a Gaussian log containing " Dispersion energy=       -0.0046617305 Hartrees."
+  Scenario: Dispersion energy is read from ccdata.dispersionenergies via cclib's convertor
+    Given a B3LYP-D3 Gaussian log where ccdata.dispersionenergies[-1] is the
+        dispersion contribution (eV form: e.g. convertor(-0.0046617305, "hartree", "eV"))
     When harvest(in_mol, "b3lyp-d3", log_content) is called
-    Then qcvars["DISPERSION CORRECTION ENERGY"] equals -0.0046617305 (atol 1e-12)
+    Then qcvars["DISPERSION CORRECTION ENERGY"] equals -0.0046617305
+        within 1 ULP (~1e-14 Ha)
 
   @rq-3136523b
-  Scenario: Dispersion energy falls back to ccdata.dispersionenergies when regex misses
-    Given a Gaussian log without a "Dispersion energy=" line
-    And ccdata.dispersionenergies equals [-0.1269192] (in eV)
+  Scenario: No dispersionenergies attribute means no dispersion qcvars
+    Given a Gaussian log where cclib's ccdata has no "dispersionenergies" attribute
     When harvest(in_mol, "b3lyp-d3", log_content) is called
-    Then qcvars["DISPERSION CORRECTION ENERGY"] equals cclib.convertor(-0.1269192, "eV", "hartree") (atol 1e-8)
+    Then qcvars does not contain "DISPERSION CORRECTION ENERGY"
 
   @rq-6f52a6d9
   Scenario: Functional-specific dispersion qcvar uses the formal label
-    Given a log with "Dispersion energy=  -0.005 Hartrees." for a B3LYP-D3 calculation
+    Given a B3LYP-D3 log with ccdata.dispersionenergies[-1] = convertor(-0.005, "hartree", "eV")
     When harvest(in_mol, "b3lyp-d3", log_content) is called
     Then qcvars["B3LYP-D3 DISPERSION CORRECTION ENERGY"] equals -0.005
 
@@ -378,7 +372,7 @@ Feature: Gaussian harness empirical-dispersion support
 
   @rq-e89c4144
   Scenario: BJ-damped variant uses parenthesised formal label
-    Given a B3LYP-D3(BJ) calculation log with "Dispersion energy=  -0.007 Hartrees."
+    Given a B3LYP-D3(BJ) calculation where ccdata.dispersionenergies[-1] = convertor(-0.007, "hartree", "eV")
     When harvest(in_mol, "b3lyp-d3bj", log_content) is called
     Then qcvars["B3LYP-D3(BJ) DISPERSION CORRECTION ENERGY"] equals -0.007
     And qcvars["B3LYP-D3(BJ) TOTAL ENERGY"] equals scf + disp
@@ -391,25 +385,25 @@ Feature: Gaussian harness empirical-dispersion support
     And qcvars["SCF TOTAL ENERGY"] equals qcvars["HF TOTAL ENERGY"]
 
   @rq-f49de098
-  Scenario: Methods without dispersion suffix do not get dispersion qcvars even if log has the line
-    Given a Gaussian log containing a "Dispersion energy=" line (e.g. user passed EmpiricalDispersion keyword)
+  Scenario: Methods without dispersion suffix still get the generic qcvar when dispersionenergies is present
+    Given a Gaussian log where ccdata.dispersionenergies is non-empty
+        (e.g. user passed EmpiricalDispersion as a keyword without using a method suffix)
     And the method passed to harvest is "b3lyp" (no dispersion suffix)
     When harvest(in_mol, "b3lyp", log_content) is called
-    Then qcvars["DISPERSION CORRECTION ENERGY"] is still populated
+    Then qcvars["DISPERSION CORRECTION ENERGY"] is populated
     And qcvars["CURRENT ENERGY"] equals scf + disp
     But no functional-specific "<FCTL>-<DASH>" qcvars are set (we cannot infer the dash level)
 
   @rq-df49b3b8
-  Scenario: No dispersion in log produces no dispersion qcvars
-    Given a Gaussian log without a "Dispersion energy=" line
-    And ccdata has no dispersionenergies attribute (or it's empty)
+  Scenario: No dispersionenergies attribute produces no dispersion qcvars
+    Given a Gaussian log where ccdata.dispersionenergies is absent (or empty)
     When harvest(in_mol, "b3lyp", log_content) is called
     Then no DISPERSION* qcvars are set
     And qcvars["CURRENT ENERGY"] equals qcvars["SCF TOTAL ENERGY"]
 
   @rq-93777ba8
   Scenario: NLC method (wB97M-V) does not emit dispersion qcvars
-    Given a wB97M-V calculation log (NLC self-consistent, no "Dispersion energy=" line)
+    Given a wB97M-V calculation log (NLC self-consistent; cclib's dispersionenergies attribute is absent)
     When harvest(in_mol, "wb97m-v", log_content) is called
     Then no DISPERSION qcvars are set
     And the existing pass-through DFT behaviour is preserved

--- a/rqm/gaussian/dispersion.md
+++ b/rqm/gaussian/dispersion.md
@@ -1,0 +1,510 @@
+# Feature: Gaussian Harness — Empirical Dispersion Support <!-- rq-17959824 -->
+
+This document specifies empirical-dispersion support for the Gaussian harness, covering
+both the input side (translating method strings like `b3lyp-d3` into Gaussian route
+keywords) and the output side (harvesting the `Dispersion energy=` line and emitting
+the standard QCEngine dispersion qcvars).
+
+Gaussian's empirical dispersion is invoked by the route-section keyword
+`EmpiricalDispersion=<G..>`, where the value selects the dispersion type:
+
+| QCEngine alias | Gaussian keyword value | Formal label | dashcoeff key |
+|----------------|------------------------|--------------|---------------|
+| `d2`, `d` | `GD2` | `D2` | `d2` |
+| `d3`, `d3zero`, `d32b`, `d3zero2b` | `GD3` | `D3` | `d3zero2b` |
+| `d3bj`, `d3bj2b` | `GD3BJ` | `D3(BJ)` | `d3bj2b` |
+
+Gaussian does not natively support `D3M`, `D3M(BJ)`, `D3OP`, `D4`, `-NL`, `CHG`,
+`DAS2009`, or `DAS2010`. Requests for these levels are rejected by the harness
+with `InputError`.
+
+Non-local-correlation DFT functionals (e.g. `wB97M-V`, `B97M-V`, `wB97X-V`) are
+**not** empirical-dispersion methods — their NLC contribution is part of the SCF
+(stored in cclib's `scfenergies` already) — and are handled by the existing
+pass-through DFT branch unchanged.
+
+Related files:
+- `input-builder.md` — `germinate.py` (`muster_modelchem` extended by this feature) and
+  `keywords.py` (`build_route_line`, no functional change but documented behaviour).
+- `harvester.md` — `harvester.py` (energy extraction extended by this feature).
+- `runner.md` — `runner.py` (conflict detection between method-suffix and
+  user-keyword `EmpiricalDispersion`).
+- `ghost-atoms.md`, `atom-labels.md` — unrelated.
+
+## Background: Gaussian Dispersion Output <!-- rq-29751017 -->
+
+When Gaussian runs a calculation with `EmpiricalDispersion=GD3` (or a GD2/GD3BJ
+analogue), the log contains a single line of the form:
+
+```
+ Dispersion energy=        -0.0046617305 Hartrees.
+```
+
+The numeric value is in Hartrees. cclib parses this line into
+`ccdata.dispersionenergies` (as a list, in eV), separately from `ccdata.scfenergies`
+(which remains the pure SCF without the dispersion contribution).
+
+The `SCF Done:` line that the existing harvester regex (`_SCF_DONE_RE`) matches is
+also the **pure SCF** value, *not* the dispersion-corrected total.
+
+For analytic gradients, Gaussian writes a single forces table that already includes
+the dispersion contribution; no special handling is required on the gradient side.
+
+## Feature API <!-- rq-7d1fb16e -->
+
+### Extended: `muster_modelchem(method, driver, multiplicity)` <!-- rq-0c1b5066 -->
+
+Located in `qcengine/programs/gaussian/germinate.py`.
+
+**New behaviour**:
+
+- If `method` (lower-cased) ends in `"-<alias>"` for some `alias` in
+  `qcengine.programs.empirical_dispersion_resources.get_dispersion_aliases()`:
+  - The functional name is the prefix before `"-<alias>"`.
+  - The canonical dashlevel key is `get_dispersion_aliases()[alias]`.
+  - The canonical key is looked up in the harness's `_GAUSSIAN_DISPERSION_MAP`
+    (defined in `germinate.py`):
+    ```python
+    _GAUSSIAN_DISPERSION_MAP = {
+        "d2":        ("GD2",   "D2"),
+        "d3zero2b":  ("GD3",   "D3"),
+        "d3bj2b":    ("GD3BJ", "D3(BJ)"),
+    }
+    ```
+    A canonical key not in this map raises `InputError` with a message naming the
+    requested level and the levels Gaussian supports.
+  - The returned dict gains two keys:
+    - `"dispersion_level"`: the formal label (e.g. `"D3"`, `"D3(BJ)"`, `"D2"`).
+    - `"functional_name"`: the upper-cased functional prefix (e.g. `"B3LYP"`).
+  - The Gaussian `EmpiricalDispersion=<G..>` token is added to the returned
+    `extra_keywords` dict.
+  - The returned `method_string` is the functional alone (e.g. `"B3LYP"`), **not**
+    including the dispersion suffix, because Gaussian's `<method>/<basis>` token
+    must name only the functional.
+
+- If `method` has no recognised dispersion suffix, all existing behaviour is
+  preserved (no `EmpiricalDispersion` added; `dispersion_level` and
+  `functional_name` keys are absent from the returned dict).
+
+**Open-shell handling**: the U prefix (for multiplicity > 1) is applied to the
+**functional** before the dispersion suffix is stripped/added back. E.g.
+`method="b3lyp-d3"` with multiplicity 2 produces `method_string="UB3LYP"` and
+`extra_keywords={"EmpiricalDispersion": "GD3"}`.
+
+### Extended: `build_input(input_model, config, template=None)` <!-- rq-59b816b7 -->
+
+Located in `qcengine/programs/gaussian/runner.py`.
+
+**Conflict check**: if `muster_modelchem` returned a non-None `dispersion_level`
+AND `input_model.specification.keywords` contains an `EmpiricalDispersion` key
+(case-insensitive), raise `InputError` with a message indicating that the
+dispersion type is overspecified.
+
+**Pass-through**: if `muster_modelchem` did **not** detect a dispersion suffix but
+the user explicitly passed `keywords["EmpiricalDispersion"] = "GD3"` (or similar),
+the harness emits the route line as before with the keyword pass-through; the
+harvester (see below) detects dispersion from the log itself, so qcvars are still
+emitted correctly.
+
+### Extended: `harvest(in_mol, method, log_content)` <!-- rq-1d5da737 -->
+
+Located in `qcengine/programs/gaussian/harvester.py`.
+
+**Method normalisation**: before energy extraction, strip any recognised dispersion
+suffix from the (lowercased) method. The resulting bare method drives the existing
+energy-extraction branch. The original method (with suffix) is retained so qcvars
+can be tagged with the correct formal label.
+
+**Dispersion-energy parsing**: after the existing SCF and post-HF energy
+extraction:
+
+- A new regex `_DISPERSION_ENERGY_RE = re.compile(r"Dispersion energy=\s*([-\d.]+)\s*Hartrees?")`
+  is matched against the log. If a match exists, `disp_hartree = float(match.group(1))`.
+- If the regex does not match, the cclib fallback is
+  `disp_hartree = float(ccdata.dispersionenergies[-1]) * _EV_TO_HARTREE` when the
+  attribute exists and is non-empty.
+- If neither source yields a value, `disp_hartree` is `None` and dispersion qcvars
+  are not set.
+
+**qcvars emitted when `disp_hartree is not None`** (Psi4/QCEngine convention; see
+`qcvar_identities_resources.py`):
+
+| Variable | Value |
+|----------|-------|
+| `"DISPERSION CORRECTION ENERGY"` | `disp_hartree` |
+| `"<FCTL>-<FORMAL> DISPERSION CORRECTION ENERGY"` | `disp_hartree` |
+| `"<FCTL>-<FORMAL> TOTAL ENERGY"` | `scf_hartree + disp_hartree` |
+| `"<FCTL> FUNCTIONAL TOTAL ENERGY"` | `scf_hartree` (alias for clarity) |
+| `"CURRENT ENERGY"` (DFT branch only) | `scf_hartree + disp_hartree` |
+
+Where `<FCTL>` is the upper-cased functional name and `<FORMAL>` is the formal
+dash label.
+
+**HF TOTAL ENERGY / SCF TOTAL ENERGY semantics** are unchanged: both refer to the
+pure SCF without dispersion. This is consistent with the QCEngine/Psi4 convention
+in which `"SCF TOTAL ENERGY"` excludes the empirical dispersion correction.
+
+**Gradient**: unchanged. Gaussian's analytic gradient already includes dispersion
+contributions; cclib's `grads` and the existing parsing path produce the correct
+total gradient.
+
+**Hessian**: same — cclib's `hessian` is the total. (Note: Gaussian supports
+analytic Hessians with D2/D3 but with restrictions for some method/basis combos;
+this is enforced at runtime by Gaussian and surfaced via the existing log-pattern
+dispatch.)
+
+## Method-Name Recognition Details <!-- rq-f357f8db -->
+
+The recognition step in `muster_modelchem` is:
+
+```python
+from qcengine.programs.empirical_dispersion_resources import get_dispersion_aliases, dashcoeff
+
+method_lower = method.lower()
+dispersion_level = None
+functional_name = None
+emp_disp_value = None
+
+aliases = get_dispersion_aliases()
+# Sort by descending length to prefer e.g. "d3bj" over "d3" + "bj"
+for alias in sorted(aliases, key=len, reverse=True):
+    suffix = f"-{alias}"
+    if method_lower.endswith(suffix):
+        canonical_key = aliases[alias]
+        if canonical_key not in _GAUSSIAN_DISPERSION_MAP:
+            raise InputError(
+                f"Dispersion level '{alias}' (canonical: {canonical_key}) is not "
+                f"natively supported by Gaussian. Supported levels: "
+                f"{sorted({fmt for _, fmt in _GAUSSIAN_DISPERSION_MAP.values()})}."
+            )
+        emp_disp_value, dispersion_level = _GAUSSIAN_DISPERSION_MAP[canonical_key]
+        functional_name = method[: -len(suffix)]
+        break
+```
+
+The "sort by descending length" rule ensures `b3lyp-d3bj` matches the `d3bj` alias
+(not `d3` followed by a stray `bj` mismatch). For two aliases of the same length
+that both match a tail, ties are broken by the first one encountered in the
+sorted iteration (consistent across runs because the alias dict is stable).
+
+## Open Cases <!-- rq-f237caf7 -->
+
+- Pure HF with dispersion (e.g. `hf-d3`): supported. The functional name is `HF`
+  and the route line is `#P HF/<basis> EmpiricalDispersion=GD3`.
+- Methods named with embedded hyphens that aren't dispersion suffixes (e.g.
+  hypothetical `cam-b3lyp`): the recognition step only strips a *trailing* hyphen
+  segment, and `b3lyp` is not in the alias map, so `cam-b3lyp` is left intact. No
+  false stripping.
+- Repeat tokens (e.g. `b3lyp-d3-d3`): the trailing `-d3` is stripped, leaving
+  `b3lyp-d3` as the functional. Gaussian will see `#P B3LYP-D3/...` which it does
+  not recognise, and will fail; the existing log-pattern dispatch surfaces this
+  as an `InputError`. We do not pre-validate.
+
+## Gherkin Scenarios <!-- rq-dea9f7c9 -->
+
+```gherkin
+Feature: Gaussian harness empirical-dispersion support
+
+  Background:
+    Given a TaskConfig with ncores=1, memory=1.0, scratch_directory=None
+
+  # --- germinate.muster_modelchem: method recognition ---
+
+  @rq-1bdc1372
+  Scenario: muster_modelchem strips "-d3" and emits EmpiricalDispersion=GD3
+    When muster_modelchem("b3lyp-d3", "energy", 1) is called
+    Then method_string equals "B3LYP"
+    And extra_keywords contains the entry "EmpiricalDispersion" -> "GD3"
+    And the returned dispersion_level equals "D3"
+    And the returned functional_name equals "B3LYP"
+
+  @rq-6a93ae95
+  Scenario: muster_modelchem strips "-d3bj" and emits EmpiricalDispersion=GD3BJ
+    When muster_modelchem("b3lyp-d3bj", "energy", 1) is called
+    Then method_string equals "B3LYP"
+    And extra_keywords contains the entry "EmpiricalDispersion" -> "GD3BJ"
+    And dispersion_level equals "D3(BJ)"
+
+  @rq-af4f9bf0
+  Scenario: muster_modelchem strips "-d2" and emits EmpiricalDispersion=GD2
+    When muster_modelchem("b3lyp-d2", "energy", 1) is called
+    Then method_string equals "B3LYP"
+    And extra_keywords["EmpiricalDispersion"] equals "GD2"
+    And dispersion_level equals "D2"
+
+  @rq-7c3a72b9
+  Scenario: muster_modelchem recognises canonical key alias "d3zero2b"
+    When muster_modelchem("b3lyp-d3zero2b", "energy", 1) is called
+    Then dispersion_level equals "D3"
+    And functional_name equals "B3LYP"
+
+  @rq-95aa6edf
+  Scenario: muster_modelchem recognises the bare alias "d" as D2
+    When muster_modelchem("b3lyp-d", "energy", 1) is called
+    Then dispersion_level equals "D2"
+
+  @rq-f4cbb515
+  Scenario: muster_modelchem leaves a non-dispersion method unchanged
+    When muster_modelchem("b3lyp", "energy", 1) is called
+    Then method_string equals "B3LYP"
+    And extra_keywords does not contain the key "EmpiricalDispersion"
+    And the returned dispersion_level is absent (or None)
+
+  @rq-4262d5f2
+  Scenario: muster_modelchem leaves a hyphenated non-dispersion method unchanged
+    When muster_modelchem("cam-b3lyp", "energy", 1) is called
+    Then method_string equals "CAM-B3LYP"
+    And no "EmpiricalDispersion" entry is added
+    And dispersion_level is absent
+
+  @rq-11602838
+  Scenario: HF with dispersion produces an HF functional
+    When muster_modelchem("hf-d3", "energy", 1) is called
+    Then method_string equals "HF"
+    And extra_keywords["EmpiricalDispersion"] equals "GD3"
+
+  # --- germinate.muster_modelchem: open-shell + dispersion ---
+
+  @rq-879110d8
+  Scenario: Doublet adds U prefix to functional before stripping dispersion
+    When muster_modelchem("b3lyp-d3", "energy", 2) is called
+    Then method_string equals "UB3LYP"
+    And extra_keywords["EmpiricalDispersion"] equals "GD3"
+    And dispersion_level equals "D3"
+    And functional_name equals "B3LYP"
+
+  @rq-e1150329
+  Scenario: ROHF + dispersion does not double-prefix U
+    When muster_modelchem("rohf-d3", "energy", 2) is called
+    Then method_string equals "ROHF"
+    And extra_keywords["EmpiricalDispersion"] equals "GD3"
+
+  # --- germinate.muster_modelchem: unsupported levels ---
+
+  @rq-d96c128f
+  Scenario: muster_modelchem raises InputError for D3M
+    When muster_modelchem("b3lyp-d3m", "energy", 1) is called
+    Then InputError is raised
+    And the error message mentions Gaussian's supported dispersion levels
+
+  @rq-95535d13
+  Scenario: muster_modelchem raises InputError for D3M(BJ)
+    When muster_modelchem("b3lyp-d3mbj", "energy", 1) is called
+    Then InputError is raised
+
+  @rq-09dd261d
+  Scenario: muster_modelchem raises InputError for D4
+    When muster_modelchem("b3lyp-d4", "energy", 1) is called
+    Then InputError is raised
+
+  @rq-e9a472db
+  Scenario: muster_modelchem raises InputError for OP damping
+    When muster_modelchem("b3lyp-d3op", "energy", 1) is called
+    Then InputError is raised
+
+  @rq-2de0fabe
+  Scenario: muster_modelchem raises InputError for -NL non-local dispersion alias
+    When muster_modelchem("b3lyp-nl", "energy", 1) is called
+    Then InputError is raised
+
+  # --- germinate.muster_modelchem: precedence rules ---
+
+  @rq-ef982ff3
+  Scenario: muster_modelchem prefers the longer suffix (d3bj over d3)
+    When muster_modelchem("b3lyp-d3bj", "energy", 1) is called
+    Then dispersion_level equals "D3(BJ)"
+    And functional_name equals "B3LYP"
+
+  # --- runner.build_input: conflict detection ---
+
+  @rq-540caf62
+  Scenario: Conflict between method suffix and user keyword raises InputError
+    Given an AtomicInput with method "b3lyp-d3" and keywords {"EmpiricalDispersion": "GD3BJ"}
+    When build_input() is called
+    Then InputError is raised
+    And the message indicates that EmpiricalDispersion is overspecified
+
+  @rq-44319e8c
+  Scenario: Conflict detection is case-insensitive on the keyword name
+    Given an AtomicInput with method "b3lyp-d3" and keywords {"empiricaldispersion": "GD3"}
+    When build_input() is called
+    Then InputError is raised
+
+  @rq-c68dde2e
+  Scenario: User keyword alone (no method suffix) passes through unchanged
+    Given an AtomicInput with method "b3lyp" and keywords {"EmpiricalDispersion": "GD3"}
+    When build_input() is called
+    Then the route line contains "EmpiricalDispersion=GD3"
+    And no InputError is raised
+
+  @rq-96507cf6
+  Scenario: Method suffix alone (no keyword) produces a single EmpiricalDispersion route token
+    Given an AtomicInput with method "b3lyp-d3" and keywords {}
+    When build_input() is called
+    Then the route line contains exactly one "EmpiricalDispersion=GD3" occurrence
+    And the method/basis token is "B3LYP/<basis>", not "B3LYP-D3/<basis>"
+
+  # --- harvester: dispersion energy extraction ---
+
+  @rq-a83b7d5f
+  Scenario: Dispersion energy is parsed via regex when the log contains the line
+    Given a Gaussian log containing " Dispersion energy=       -0.0046617305 Hartrees."
+    When harvest(in_mol, "b3lyp-d3", log_content) is called
+    Then qcvars["DISPERSION CORRECTION ENERGY"] equals -0.0046617305 (atol 1e-12)
+
+  @rq-3136523b
+  Scenario: Dispersion energy falls back to ccdata.dispersionenergies when regex misses
+    Given a Gaussian log without a "Dispersion energy=" line
+    And ccdata.dispersionenergies equals [-0.1269192] (in eV)
+    When harvest(in_mol, "b3lyp-d3", log_content) is called
+    Then qcvars["DISPERSION CORRECTION ENERGY"] equals -0.1269192 * eV->Ha (atol 1e-8)
+
+  @rq-6f52a6d9
+  Scenario: Functional-specific dispersion qcvar uses the formal label
+    Given a log with "Dispersion energy=  -0.005 Hartrees." for a B3LYP-D3 calculation
+    When harvest(in_mol, "b3lyp-d3", log_content) is called
+    Then qcvars["B3LYP-D3 DISPERSION CORRECTION ENERGY"] equals -0.005
+
+  @rq-f5d05419
+  Scenario: Functional total energy excludes dispersion
+    Given an SCF energy of -76.0 Ha and a dispersion energy of -0.005 Ha
+    When harvest(in_mol, "b3lyp-d3", log_content) is called
+    Then qcvars["B3LYP FUNCTIONAL TOTAL ENERGY"] equals -76.0
+    And qcvars["B3LYP-D3 TOTAL ENERGY"] equals -76.005
+    And qcvars["CURRENT ENERGY"] equals -76.005
+
+  @rq-e89c4144
+  Scenario: BJ-damped variant uses parenthesised formal label
+    Given a B3LYP-D3(BJ) calculation log with "Dispersion energy=  -0.007 Hartrees."
+    When harvest(in_mol, "b3lyp-d3bj", log_content) is called
+    Then qcvars["B3LYP-D3(BJ) DISPERSION CORRECTION ENERGY"] equals -0.007
+    And qcvars["B3LYP-D3(BJ) TOTAL ENERGY"] equals scf + disp
+
+  @rq-7211fb49
+  Scenario: SCF TOTAL ENERGY and HF TOTAL ENERGY exclude dispersion
+    Given a B3LYP-D3 calculation
+    When harvest is called
+    Then qcvars["HF TOTAL ENERGY"] equals the SCF value alone (no dispersion)
+    And qcvars["SCF TOTAL ENERGY"] equals qcvars["HF TOTAL ENERGY"]
+
+  @rq-f49de098
+  Scenario: Methods without dispersion suffix do not get dispersion qcvars even if log has the line
+    Given a Gaussian log containing a "Dispersion energy=" line (e.g. user passed EmpiricalDispersion keyword)
+    And the method passed to harvest is "b3lyp" (no dispersion suffix)
+    When harvest(in_mol, "b3lyp", log_content) is called
+    Then qcvars["DISPERSION CORRECTION ENERGY"] is still populated
+    And qcvars["CURRENT ENERGY"] equals scf + disp
+    But no functional-specific "<FCTL>-<DASH>" qcvars are set (we cannot infer the dash level)
+
+  @rq-df49b3b8
+  Scenario: No dispersion in log produces no dispersion qcvars
+    Given a Gaussian log without a "Dispersion energy=" line
+    And ccdata has no dispersionenergies attribute (or it's empty)
+    When harvest(in_mol, "b3lyp", log_content) is called
+    Then no DISPERSION* qcvars are set
+    And qcvars["CURRENT ENERGY"] equals qcvars["SCF TOTAL ENERGY"]
+
+  @rq-93777ba8
+  Scenario: NLC method (wB97M-V) does not emit dispersion qcvars
+    Given a wB97M-V calculation log (NLC self-consistent, no "Dispersion energy=" line)
+    When harvest(in_mol, "wb97m-v", log_content) is called
+    Then no DISPERSION qcvars are set
+    And the existing pass-through DFT behaviour is preserved
+
+  @rq-68840f83
+  Scenario: Gradient is unchanged when dispersion is present
+    Given a B3LYP-D3 gradient calculation
+    When harvest is called with driver "gradient"
+    Then the returned gradient is the full gradient (functional + dispersion)
+    And no separate "dispersion gradient" qcvar is exposed
+
+  # --- Integration test ---
+
+  @rq-0fe273a8
+  Scenario: End-to-end B3LYP-D3/6-31G* energy on water with real Gaussian
+    Given an AtomicInput for water (H2O) with method "b3lyp-d3", basis "6-31g*", driver "energy"
+    When qcng.compute is called with program "gaussian"
+    Then the result is successful
+    And qcvars["B3LYP-D3 DISPERSION CORRECTION ENERGY"] is approximately equal to the empirical reference value (atol 1e-6)
+    And qcvars["B3LYP-D3 TOTAL ENERGY"] is approximately equal to the empirical reference value (atol 1e-6)
+    And qcvars["B3LYP FUNCTIONAL TOTAL ENERGY"] is approximately equal to the empirical reference value (atol 1e-6)
+```
+
+## Integration Test <!-- rq-ce8f4843 -->
+
+A real-Gaussian integration test (`@using("gaussian")`) is added to
+`qcengine/programs/tests/test_gaussian.py`:
+
+```python
+@using("gaussian")
+def test_gaussian_b3lyp_d3_water(water):
+    """B3LYP-D3/6-31G* energy on water; verify dispersion qcvars are populated."""
+    inp = AtomicInput(
+        molecule=water,
+        specification=AtomicSpecification(
+            program="gaussian", driver="energy",
+            model={"method": "b3lyp-d3", "basis": "6-31g*"},
+        ),
+    )
+    res = qcng.compute(inp, "gaussian", raise_error=True)
+    qcvars = res.extras["qcvars"]
+    # Verify the standard dispersion qcvars are present and consistent.
+    assert "B3LYP-D3 DISPERSION CORRECTION ENERGY" in qcvars
+    assert "B3LYP-D3 TOTAL ENERGY" in qcvars
+    assert "B3LYP FUNCTIONAL TOTAL ENERGY" in qcvars
+    # SCF + dispersion == total
+    scf = float(qcvars["B3LYP FUNCTIONAL TOTAL ENERGY"])
+    disp = float(qcvars["B3LYP-D3 DISPERSION CORRECTION ENERGY"])
+    tot = float(qcvars["B3LYP-D3 TOTAL ENERGY"])
+    assert abs((scf + disp) - tot) < 1.0e-10
+```
+
+**Reference values** for the magnitude check on the dispersion contribution must
+be determined empirically by running Gaussian once during implementation; they
+are then hard-coded into the test with `atol = 1.0e-6`. The reference values
+depend on the Gaussian patch level (D3 parameter set may vary), but are stable
+within a major Gaussian revision.
+
+## Migration Notes <!-- rq-ea37df39 -->
+
+- No existing tests are altered; all current Gaussian tests use methods without
+  empirical dispersion and remain green.
+- The `_METHOD_MAP` in `germinate.py` is unchanged. Dispersion-bearing method
+  strings flow through the new branch *before* the existing `_METHOD_MAP` lookup,
+  so the existing HF/MP2/CCSD entries continue to apply to the stripped
+  functional name. (E.g. `mp2-d3` is recognised as MP2 + D3.)
+- The `qcvar_identities_resources.py` solver already declares the relationship
+  `<FCTL>-<DASH> TOTAL ENERGY = <FCTL> FUNCTIONAL TOTAL ENERGY + <FCTL>-<DASH> DISPERSION CORRECTION ENERGY`
+  for `B3LYP`, `B3LYP5`, `PBE`, `B97`, `BLYP`, `BP86`, `PBE0`, `WPBE` × `-D2`,
+  `-D3`, `-D3(BJ)`, `-D3M`, `-D3M(BJ)`. Functionals outside this list still get
+  the qcvars emitted but the solver won't auto-derive missing siblings.
+- Public API surface is unchanged. No new functions or classes are introduced;
+  the changes are confined to extending the existing entry points.
+
+## Out-of-Scope <!-- rq-06ce6129 -->
+
+- **D4 support** — requires a separate executable (`dftd4`) and the existing
+  `dftd_ng.py` harness handles it. Gaussian itself does not invoke D4.
+- **D3M / D3OP** — Gaussian does not implement these dispersion-damping
+  variants. Users can run the SCF in Gaussian and apply the dispersion
+  correction post-hoc via the dedicated `dftd3`/`mp2d` harness.
+- **NLC-functional plumbing** — wB97M-V et al. are pass-through DFT methods
+  that already work with the existing harness; no dispersion qcvars are
+  emitted because there is no empirical dispersion contribution.
+- **Counterpoise + dispersion** — Gaussian supports `Counterpoise=N` together
+  with `EmpiricalDispersion`, but the dispersion contribution behaves differently
+  for ghost atoms (depending on the dispersion model). Out of scope for this
+  feature; the existing ghost-atom support remains valid for non-dispersion
+  calculations.
+- **Hessian with dispersion** — Gaussian's analytic Hessian supports some
+  dispersion levels but not all. We do not pre-validate; runtime failures
+  surface via the existing log-pattern dispatch.
+
+## References <!-- rq-29bb67d8 -->
+
+- Grimme et al., J. Chem. Phys. 132, 154104 (2010) — D3 paper.
+- Grimme, Ehrlich, Goerigk, J. Comput. Chem. 32, 1456 (2011) — D3(BJ) paper.
+- QCEngine `empirical_dispersion_resources.py` — the canonical alias table and
+  parameter database used here.
+- Psi4's psivars convention for dispersion — the qcvar naming scheme followed
+  by this feature.

--- a/rqm/gaussian/e2e-coverage.md
+++ b/rqm/gaussian/e2e-coverage.md
@@ -1,0 +1,310 @@
+# Feature: Gaussian Harness — End-to-End Coverage Tests <!-- rq-a9ab12b3 -->
+
+This document specifies seven standalone end-to-end tests for the Gaussian harness,
+all added to `qcengine/programs/tests/test_gaussian.py` and gated behind
+`@using("gaussian")`. Each test exercises a code path that currently has no
+real-Gaussian coverage (mocked unit tests aside) and that would silently regress
+if cclib output formats, harness regex parsing, or method/driver routing changed.
+
+These are not parametrisations of existing cross-program tests (those live in
+`integration-tests.md`); they are additional standalone tests that fill gaps in
+the per-harness coverage matrix.
+
+Related files:
+- `harvester.md` — harvester behaviour exercised by these tests
+- `runner.md` — runner method/driver routing
+- `dispersion.md` — dispersion-handling tests (the Hessian and gradient extensions of
+  the existing `test_gaussian_b3lyp_d3_water` energy test)
+- `integration-tests.md` — cross-program integration tests (out of scope here)
+
+## Coverage Gaps Closed by This Feature <!-- rq-7472fc74 -->
+
+The harness's end-to-end coverage matrix (method × driver) currently has the
+following holes that this feature fills:
+
+| Method | Energy | Gradient | Hessian | Properties |
+|--------|--------|----------|---------|------------|
+| HF     | ✓ | ✓ | **NEW (T1)** | **NEW (T2)** |
+| Plain DFT (no dispersion) | **NEW (T3)** | — | — | — |
+| DFT-D | ✓ | **NEW (T4)** | **NEW (T7)** | — |
+| HF, single atom | **NEW (T6)** | — | — | — |
+| UHF, open-shell radical | **NEW (T5)** | — | — | — |
+
+(T1–T7 below.)
+
+## Feature API <!-- rq-86480a7b -->
+
+No new public functions or classes. Seven new pytest test functions in
+`qcengine/programs/tests/test_gaussian.py`, each decorated with
+`@using("gaussian")`, named:
+
+- `test_gaussian_hessian_hf_water` (T1) <!-- rq-54afb7b8 -->
+- `test_gaussian_properties_hf_water` (T2) <!-- rq-70b16c33 -->
+- `test_gaussian_dft_b3lyp_water` (T3) <!-- rq-3727e53b -->
+- `test_gaussian_b3lyp_d3_gradient_water` (T4) <!-- rq-66ca9a20 -->
+- `test_gaussian_uhf_nh2` (T5) <!-- rq-d06d7266 -->
+- `test_gaussian_single_atom_he` (T6) <!-- rq-cd65e68a -->
+- `test_gaussian_b3lyp_d3_hessian_water` (T7) <!-- rq-b8065553 -->
+
+## Reference Values <!-- rq-7c70da2a -->
+
+All reference values below were captured against Gaussian 16 Revision C.02 with
+the existing `water` fixture (charge 0, multiplicity 1; standard equilibrium
+geometry — see `_make_water_mol` in the test file) unless otherwise noted.
+Tolerances are stated per test.
+
+### T1: HF Hessian on water <!-- rq-6385e33d -->
+
+Method `HF`, basis `STO-3G`, driver `hessian`. Reference values (Hartree/Bohr²):
+
+- `return_result.shape == (9, 9)`
+- `numpy.trace(hess) ≈ 3.2315247000` (atol `1e-6`)
+- `numpy.linalg.norm(hess) ≈ 2.2444460940` (atol `1e-6`)
+- `hess[0, 0] ≈ -0.0560541000` (atol `1e-6`)
+- `hess[3, 3] ≈ -0.0223351000` (atol `1e-6`)
+- `hess[0, 1] ≈ 0.0` (atol `1e-10`)
+- Matrix is symmetric within `1e-10`: `numpy.allclose(hess, hess.T, atol=1e-10)`
+
+Hessian unit tests use a synthetic identity matrix; this test exercises the real
+`_parse_force_constants` regex parse, the D-exponent → float conversion via
+`_fortran_float`, the lower-triangle reconstruction, and the
+`mill.align_hessian` frame transformation, none of which are otherwise exercised
+end-to-end.
+
+### T2: HF properties on water <!-- rq-e199db9a -->
+
+Method `HF`, basis `STO-3G`, driver `properties`. Reference values:
+
+- `result.return_result` is a float (the total energy)
+- `qcvars["HF TOTAL ENERGY"] ≈ -74.962963201` (atol `1e-6`)
+- `qcvars["DIPOLE MOMENT"] ≈ 1.7252` Debye (atol `1e-3`)
+- `qcvars["MULLIKEN CHARGES"]` is a list of length 3
+- `sum(qcvars["MULLIKEN CHARGES"]) ≈ 0.0` (atol `1e-4`)
+- `qcvars["MULLIKEN CHARGES"][0] ≈ -0.366114` (oxygen, atol `1e-3`)
+
+Exercises the `properties` driver branch (Pop=Full route emission) and the
+harvester's `ccdata.moments[1]` and `ccdata.atomcharges["mulliken"]` extraction.
+
+### T3: Plain B3LYP energy on water <!-- rq-1e76932b -->
+
+Method `B3LYP`, basis `cc-pVDZ`, driver `energy`, no dispersion suffix. Reference values:
+
+- `result.return_result ≈ -76.4203540604` (atol `1e-6`)
+- `qcvars["HF TOTAL ENERGY"] ≈ -76.4203540604` (atol `1e-6` — the SCF energy IS the B3LYP energy when no dispersion)
+- `qcvars["CURRENT ENERGY"] ≈ -76.4203540604` (atol `1e-6`)
+- `"DISPERSION CORRECTION ENERGY"` is **not** present in qcvars
+- `"B3LYP-D3 DISPERSION CORRECTION ENERGY"` is **not** present in qcvars
+
+Confirms that the unknown-functional pass-through branch in `germinate.py`
+emits a usable route line, that Gaussian recognises `B3LYP` as a functional,
+and that the harvester does not emit spurious dispersion qcvars when no
+dispersion suffix was supplied.
+
+### T4: B3LYP-D3 gradient on water <!-- rq-80a8de50 -->
+
+Method `b3lyp-d3`, basis `6-31g*`, driver `gradient`. Reference values
+(Hartree/Bohr):
+
+- `result.return_result.shape == (3, 3)` (natoms × 3)
+- `result.return_result ≈`
+  ```
+  [[ 0.0,         0.0,        -0.01437422],
+   [ 0.0,        -0.00800138,  0.00718711],
+   [ 0.0,         0.00800138,  0.00718711]]
+  ```
+  with `atol = 1e-6`.
+- `qcvars["B3LYP-D3 DISPERSION CORRECTION ENERGY"] ≈ -0.0000078919` (atol `1e-6`)
+- `qcvars["B3LYP FUNCTIONAL TOTAL ENERGY"] ≈ -76.4087263383` (atol `1e-6`)
+- `qcvars["B3LYP-D3 TOTAL ENERGY"] ≈ -76.4087342302` (atol `1e-6`)
+
+Confirms that `EmpiricalDispersion=GD3` combined with `Force=NoStep` (the
+Gaussian gradient request emitted by `muster_modelchem`) produces a coherent
+gradient and that cclib's `grads` attribute already contains the
+dispersion-corrected total gradient.
+
+### T5: NH₂· UHF on cc-pVDZ <!-- rq-c38f1b61 -->
+
+Open-shell radical. Geometry (Å):
+```
+0 2
+N  0.000000000  0.000000000  0.140030000
+H  0.000000000  0.802300000 -0.490100000
+H  0.000000000 -0.802300000 -0.490100000
+```
+(r(N–H) ≈ 1.020 Å, ∠HNH ≈ 103.7°.)
+
+Method `HF`, basis `cc-pVDZ`, driver `energy`, charge 0, multiplicity 2.
+Reference values:
+
+- `result.return_result ≈ -55.5671259096` (atol `1e-6`)
+- `qcvars["HF TOTAL ENERGY"] ≈ -55.5671259096` (atol `1e-6`)
+- `native_files["input"]` (the .com file) contains the substring `"UHF/cc-pVDZ"`
+  (the U-prefix was auto-prepended by `muster_modelchem` for multiplicity > 1)
+- `native_files["input"]` contains the line `"0 2"` (charge/multiplicity)
+
+Exercises the U-prefix logic on a real open-shell calculation (the existing
+`test_hf_alignment` covers UHF but does not assert the .com-file U-prefix).
+
+### T6: Single-atom He HF/cc-pVDZ <!-- rq-954dd6f3 -->
+
+Method `HF`, basis `cc-pVDZ`, driver `energy`. Molecule: single He atom at
+origin, charge 0, multiplicity 1. Reference values:
+
+- `result.return_result ≈ -2.85516047724` (atol `1e-6`)
+- `result.properties.nuclear_repulsion_energy == 0.0` (exact)
+- `result.success is True`
+
+Edge case: validates that a single-atom system (no NRE, no bonds, special
+Gaussian handling for atoms) flows through the harness without geometry- or
+NRE-related off-by-one errors.
+
+### T7: B3LYP-D3 Hessian on water <!-- rq-dbf8a9a5 -->
+
+Method `b3lyp-d3`, basis `6-31g*`, driver `hessian`. Reference values:
+
+- `return_result.shape == (9, 9)`
+- `numpy.trace(hess) ≈ 2.3626060600` (atol `1e-6`)
+- `numpy.linalg.norm(hess) ≈ 1.5979941261` (atol `1e-6`)
+- `qcvars["B3LYP-D3 DISPERSION CORRECTION ENERGY"] ≈ -0.0000078919` (atol `1e-6`)
+- Matrix is symmetric: `numpy.allclose(hess, hess.T, atol=1e-10)`
+
+Cheap follow-on to T1 and T4: confirms the Hessian + dispersion coexistence
+case (Gaussian's analytic Hessian with `EmpiricalDispersion=GD3` succeeds and
+the harness handles the combined output).
+
+## Gherkin Scenarios <!-- rq-051e6b78 -->
+
+```gherkin
+Feature: Gaussian harness end-to-end coverage tests
+
+  Background:
+    Given the Gaussian executable (g16 or g09) is available on PATH
+    And cclib is importable
+    And the standard `water` fixture is used unless otherwise noted
+
+  # --- T1: HF Hessian ---
+
+  @rq-89896430
+  Scenario: HF/STO-3G Hessian on water has correct shape and reference values
+    Given an AtomicInput for water with method "HF", basis "STO-3G", driver "hessian"
+    When qcng.compute is called with program "gaussian"
+    Then the result is successful
+    And result.return_result is a 2D array of shape (9, 9)
+    And numpy.trace(return_result) is approximately 3.2315247 (atol 1e-6)
+    And numpy.linalg.norm(return_result) is approximately 2.244446094 (atol 1e-6)
+    And return_result is symmetric to within 1e-10
+    And return_result[0, 1] is approximately 0.0 (atol 1e-10)
+
+  # --- T2: HF properties ---
+
+  @rq-dc1bf912
+  Scenario: HF/STO-3G properties on water populates dipole and Mulliken charges
+    Given an AtomicInput for water with method "HF", basis "STO-3G", driver "properties"
+    When qcng.compute is called with program "gaussian"
+    Then the result is successful
+    And qcvars["HF TOTAL ENERGY"] is approximately -74.962963201 (atol 1e-6)
+    And qcvars["DIPOLE MOMENT"] is approximately 1.7252 Debye (atol 1e-3)
+    And qcvars["MULLIKEN CHARGES"] is a list of length 3
+    And sum(qcvars["MULLIKEN CHARGES"]) is approximately 0.0 (atol 1e-4)
+    And qcvars["MULLIKEN CHARGES"][0] is approximately -0.366114 (atol 1e-3)
+
+  # --- T3: Plain DFT (no dispersion) ---
+
+  @rq-af1fd6a9
+  Scenario: B3LYP/cc-pVDZ energy on water matches reference without emitting dispersion qcvars
+    Given an AtomicInput for water with method "B3LYP", basis "cc-pVDZ", driver "energy"
+    When qcng.compute is called with program "gaussian"
+    Then the result is successful
+    And result.return_result is approximately -76.4203540604 (atol 1e-6)
+    And qcvars["HF TOTAL ENERGY"] equals result.return_result (within 1e-10)
+    And qcvars["CURRENT ENERGY"] equals result.return_result (within 1e-10)
+    And "DISPERSION CORRECTION ENERGY" is not present in qcvars
+    And "B3LYP-D3 DISPERSION CORRECTION ENERGY" is not present in qcvars
+
+  # --- T4: DFT-D gradient ---
+
+  @rq-b10501a0
+  Scenario: B3LYP-D3/6-31G* gradient on water matches reference and exposes dispersion qcvars
+    Given an AtomicInput for water with method "b3lyp-d3", basis "6-31g*", driver "gradient"
+    When qcng.compute is called with program "gaussian"
+    Then the result is successful
+    And result.return_result is a 2D array of shape (3, 3)
+    And result.return_result matches the reference gradient (atol 1e-6)
+    And qcvars["B3LYP-D3 DISPERSION CORRECTION ENERGY"] is approximately -0.0000078919 (atol 1e-6)
+    And qcvars["B3LYP FUNCTIONAL TOTAL ENERGY"] is approximately -76.4087263383 (atol 1e-6)
+    And qcvars["B3LYP-D3 TOTAL ENERGY"] is approximately -76.4087342302 (atol 1e-6)
+
+  # --- T5: UHF open-shell ---
+
+  @rq-18a8cc19
+  Scenario: UHF/cc-pVDZ energy on NH2 radical matches reference and emits UHF route line
+    Given an AtomicInput for NH2 radical (charge=0, multiplicity=2) with method "HF", basis "cc-pVDZ", driver "energy"
+    When qcng.compute is called with program "gaussian"
+    Then the result is successful
+    And result.return_result is approximately -55.5671259096 (atol 1e-6)
+    And the input .com file (native_files["input"]) contains "UHF/cc-pVDZ"
+    And the input .com file contains a charge/multiplicity line "0 2"
+
+  # --- T6: Single-atom edge case ---
+
+  @rq-5c04235d
+  Scenario: HF/cc-pVDZ energy on a single He atom returns the expected value with NRE=0
+    Given an AtomicInput for a single He atom at origin with method "HF", basis "cc-pVDZ", driver "energy"
+    When qcng.compute is called with program "gaussian"
+    Then the result is successful
+    And result.return_result is approximately -2.85516047724 (atol 1e-6)
+    And result.properties.nuclear_repulsion_energy equals 0.0 (exactly)
+
+  # --- T7: DFT-D Hessian ---
+
+  @rq-cedda71e
+  Scenario: B3LYP-D3/6-31G* Hessian on water succeeds and emits the dispersion qcvar
+    Given an AtomicInput for water with method "b3lyp-d3", basis "6-31g*", driver "hessian"
+    When qcng.compute is called with program "gaussian"
+    Then the result is successful
+    And result.return_result is a 2D array of shape (9, 9)
+    And numpy.trace(return_result) is approximately 2.3626060600 (atol 1e-6)
+    And numpy.linalg.norm(return_result) is approximately 1.5979941261 (atol 1e-6)
+    And return_result is symmetric to within 1e-10
+    And qcvars["B3LYP-D3 DISPERSION CORRECTION ENERGY"] is approximately -0.0000078919 (atol 1e-6)
+```
+
+## Implementation Notes <!-- rq-1ed899e3 -->
+
+### Fixtures and helpers <!-- rq-c88cc8ec -->
+
+- The existing `water` fixture (`_make_water_mol`) is reused for T1, T2, T3, T4, T7.
+- A new `nh2_radical` fixture (or inline `Molecule.from_data(...)`) is added for T5.
+- A new `helium_atom` fixture (or inline) is added for T6.
+- All seven tests use the standard `@using("gaussian")` decorator and the existing
+  `qcng.compute(..., raise_error=True)` pattern.
+
+### Reference-value provenance <!-- rq-ce2ecf6a -->
+
+All reference values were captured against **Gaussian 16 Revision C.02** during
+planning. Minor patch-level Gaussian updates may shift values within the stated
+tolerance (`atol = 1e-6` is generous enough to absorb sub-µHartree changes in
+SCF, dispersion, and integration grids). If a future Gaussian release exceeds
+this tolerance, the test should be updated rather than the tolerance loosened —
+unexpected drift in reference values is itself worth investigating.
+
+### Test runtime budget <!-- rq-d42168a0 -->
+
+Estimated wall time for the full suite of 7 E2E tests on a single core,
+Gaussian 16 C.02:
+
+| Test | Approx. wall time |
+|------|-------------------|
+| T1 HF Hessian / STO-3G water | ~1 s |
+| T2 HF properties / STO-3G water | <1 s |
+| T3 B3LYP / cc-pVDZ water | ~2 s |
+| T4 B3LYP-D3 gradient / 6-31G* water | ~3 s |
+| T5 UHF / cc-pVDZ NH₂ | ~2 s |
+| T6 HF / cc-pVDZ He | <1 s |
+| T7 B3LYP-D3 Hessian / 6-31G* water | ~5 s |
+| **Total** | **~15 s** |
+
+This is comparable to the existing Gaussian integration test runtime
+(test_simple_ghost + test_tricky_ghost + test_atom_labels currently take
+~60 s) and fits well within CI budgets.
+

--- a/rqm/gaussian/ghost-atoms.md
+++ b/rqm/gaussian/ghost-atoms.md
@@ -328,18 +328,6 @@ Feature: Gaussian harness ghost-atom support
     Then the result is successful
     And properties.return_energy matches bimol_ref["eneyne"]["mp2"]["mB"] (atol 3e-6)
 
-  @rq-dc9a34d9
-  Scenario: pgline regex matches Gaussian's "Full point group" line for C2v
-    Given a Gaussian log containing a line like " Full point group                 C2V     NOp   4"
-    When the regex r"Full point group\s+(?P<pg>\S+)" is applied
-    Then the captured "pg" group is "C2V"
-
-  @rq-64be1785
-  Scenario: pgline regex matches Gaussian's "Full point group" line for linear C*V
-    Given a Gaussian log containing a line like " Full point group                 C*V     NOp   4"
-    When the regex r"Full point group\s+(?P<pg>\S+)" is applied
-    Then the captured "pg" group is "C*V"
-
   @rq-7e1b0bb4
   Scenario: test_tricky_ghost accepts Gaussian's linear PG for the mB subject
     Given qcprog is "gaussian" and subject is "mB"

--- a/rqm/gaussian/ghost-atoms.md
+++ b/rqm/gaussian/ghost-atoms.md
@@ -265,9 +265,98 @@ Feature: Gaussian harness ghost-atom support
     Then return_result has shape (2, 3)
     And the gradient on the real He atom matches the reference vector (atol 1e-6)
     And the gradient on the ghost Ne atom is approximately zero (atol 1e-6)
+
+  # --- test_tricky_ghost: eneyne + Ne, MP2 ---
+
+  @rq-c40101e6
+  Scenario: Method "mp2(full)" maps to "MP2(Full)" in the Gaussian route line
+    Given AtomicInput.specification.model.method is "mp2(full)"
+    When muster_modelchem("mp2(full)", "energy", 1) is called
+    Then the returned method_string is "MP2(Full)"
+
+  @rq-a9026c9f
+  Scenario: Method "mp2(full)" is normalised back to "mp2" by the harvester
+    Given a Gaussian log produced by a method "mp2(full)" calculation
+    When harvest(in_mol, "mp2(full)", log_content) is called
+    Then the MP2-specific qcvars (MP2 TOTAL ENERGY, MP2 CORRELATION ENERGY) are populated
+    And qcvars["CURRENT ENERGY"] equals MP2 TOTAL ENERGY
+
+  @rq-8fa7c4c3
+  Scenario: Gaussian "NoSymm" keyword forces C1 symmetry in the route line
+    Given user_keywords = {"NoSymm": ""}
+    When build_route_line is invoked
+    Then the route line contains the bare token "NoSymm"
+
+  @rq-3257a6f5
+  Scenario: MP2/6-31G* energy on eneyne dimer matches consensus reference
+    Given the dimer subject from eneyne_ne_qcschemamols() (10 real atoms, 0 ghosts)
+    And keywords = {"NoSymm": ""} and method = "mp2(full)"
+    When qcng.compute is called with program "gaussian", method "mp2", basis "6-31g*", driver "energy"
+    Then the result is successful
+    And properties.nuclear_repulsion_energy matches bimol_ref["eneyne"]["nre"]["dimer"] (atol 1e-4)
+    And properties.calcinfo_nbasis equals 72
+    And properties.calcinfo_nmo equals 72
+    And properties.return_energy matches bimol_ref["eneyne"]["mp2"]["dimer"] (atol 3e-6)
+
+  @rq-609268f8
+  Scenario: MP2/6-31G* gradient on eneyne dimer matches consensus reference
+    Given the dimer subject from eneyne_ne_qcschemamols()
+    And keywords = {"NoSymm": ""} and method = "mp2(full)"
+    When qcng.compute is called with driver "gradient"
+    Then return_result equals bimol_ref["eneyne"]["mp2_gradient"]["dimer"] (atol 3e-6)
+
+  @rq-d4e60dd2
+  Scenario: MP2/6-31G* energy on mAgB (real ethylene + ghost ethyne) matches reference
+    Given the mAgB subject (6 real + 4 ghost atoms)
+    And keywords = {"NoSymm": ""} and method = "mp2(full)"
+    When qcng.compute is called with driver "energy"
+    Then properties.return_energy matches bimol_ref["eneyne"]["mp2"]["mAgB"] (atol 3e-6)
+
+  @rq-31334859
+  Scenario: MP2/6-31G* energy on gAmB (ghost ethylene + real ethyne) matches reference
+    Given the gAmB subject (4 real + 6 ghost atoms)
+    And keywords = {"NoSymm": ""} and method = "mp2(full)"
+    When qcng.compute is called with driver "energy"
+    Then properties.return_energy matches bimol_ref["eneyne"]["mp2"]["gAmB"] (atol 3e-6)
+
+  @rq-a5593d5c
+  Scenario: MP2/6-31G* on mB (linear ethyne alone) returns the correct energy
+    Given the mB subject (4 real atoms, linear)
+    And keywords = {"NoSymm": ""} and method = "mp2(full)"
+    When qcng.compute is called with driver "energy"
+    Then the result is successful
+    And properties.return_energy matches bimol_ref["eneyne"]["mp2"]["mB"] (atol 3e-6)
+
+  @rq-dc9a34d9
+  Scenario: pgline regex matches Gaussian's "Full point group" line for C2v
+    Given a Gaussian log containing a line like " Full point group                 C2V     NOp   4"
+    When the regex r"Full point group\s+(?P<pg>\S+)" is applied
+    Then the captured "pg" group is "C2V"
+
+  @rq-64be1785
+  Scenario: pgline regex matches Gaussian's "Full point group" line for linear C*V
+    Given a Gaussian log containing a line like " Full point group                 C*V     NOp   4"
+    When the regex r"Full point group\s+(?P<pg>\S+)" is applied
+    Then the captured "pg" group is "C*V"
+
+  @rq-7e1b0bb4
+  Scenario: test_tricky_ghost accepts Gaussian's linear PG for the mB subject
+    Given qcprog is "gaussian" and subject is "mB"
+    And the test has parsed pg "C*v" from atres.stdout
+    When the test reaches the point-group assertion
+    Then the Gaussian/mB branch is taken (assert pg == "C*v"), not the default ref branch
+
+  @rq-6121b3e1
+  Scenario: test_tricky_ghost uses the default ref branch for non-mB Gaussian subjects
+    Given qcprog is "gaussian" and subject is "dimer"
+    And the test has parsed pg "C2v" from atres.stdout
+    When the test reaches the point-group assertion
+    Then the default branch is taken (assert pg in ref["pg"][subject])
 ```
 
 ## Integration Tests <!-- rq-c4439b82 -->
+
+### `test_simple_ghost` (He···Ne) <!-- rq-95dab09b -->
 
 `qcengine/programs/tests/test_ghost.py::test_simple_ghost` already parametrises a He
 real / Ne ghost system across cfour, gamess, nwchem, and psi4. As part of this feature,
@@ -285,6 +374,111 @@ The integration test asserts:
 
 No new integration-test infrastructure is required; the existing parametrisation is
 extended in place.
+
+### `test_tricky_ghost` (eneyne+Ne, MP2) <!-- rq-2cb2c5c0 -->
+
+`qcengine/programs/tests/test_ghost.py::test_tricky_ghost` exercises MP2/6-31G* on the
+ethylene–ethyne–Ne system across five "subjects" (`dimer`, `mA`, `mB`, `mAgB`, `gAmB`)
+that vary which fragments are real vs. ghost, and across `energy` and `gradient`
+drivers. As part of this feature, Gaussian is added to the `qcprog` parametrisation:
+
+```python
+pytest.param(
+    "gaussian",
+    "6-31g*",
+    {"NoSymm": ""},
+    id="gaussian",
+    marks=using("gaussian"),
+),
+```
+
+**Per-program method override**: the test overrides the QCSchema method for
+Gaussian only (other programs continue to use `"mp2"`):
+
+```python
+method = "mp2(full)" if qcprog == "gaussian" else "mp2"
+```
+
+**Keyword rationale**:
+
+- `"NoSymm": ""` — Gaussian uses symmetry to standardise the molecular orientation
+  by default; `NoSymm` (emitted as a bare token by `build_route_line`) tells
+  Gaussian not to use symmetry in the calculation. With `fix_com=True` and
+  `fix_orientation=True` already imposed on the input molecule, `NoSymm` keeps
+  Gaussian's internal frame aligned with the input frame for clean integration
+  accuracy. Note that `NoSymm` does **not** suppress the geometric point-group
+  printout — Gaussian still prints e.g. `Full point group  C*V` for linear
+  systems regardless.
+
+**Method-spec rationale (`mp2(full)`)**:
+
+Gaussian's MP2 freezes core orbitals by default (`NFC=4` for the
+ethylene+ethyne system, ~9.5 mHa offset from the all-electron reference). Two
+syntaxes exist for forcing all-electron MP2:
+
+1. `MP2=Full` as a separate route keyword. Works for energy, but Gaussian
+   refuses to compute analytic gradients with this form:
+   `"Post-SCF densities or gradients only with Real MP2, MP3, MP4SDQ, CI, CCD, and QCI."`
+2. `MP2(Full)/basis` with the option attached to the method spec inline. Works
+   for both energy and gradient.
+
+This feature adds a new `_METHOD_MAP` entry to `germinate.py` that maps the
+lower-case method string `"mp2(full)"` to the Gaussian token `"MP2(Full)"`,
+mirroring the existing `"ccsd(t,full)" → "CCSD(T,Full)"` convention. The
+harvester's `_METHOD_NORMALISE` dict in `harvester.py` is also extended so
+`"mp2(full)"` is normalised to `"mp2"` for energy-extraction purposes (the
+EUMP2 regex matches both forms).
+
+**Reference values** are reused from the existing `bimol_ref["eneyne"]` dict with
+the existing tolerances (`atol = 1.0e-4` for NRE, `atol = 3.0e-6` for energy and
+return-result comparison). If empirical verification during implementation reveals
+a systematic Gaussian-specific offset > 3.0e-6, the test should be amended to use a
+Gaussian-specific reference (with a comment explaining why); otherwise the existing
+references stand.
+
+**Point-group assertion**: the `pgline` dict at the bottom of `test_tricky_ghost`
+gains a Gaussian regex:
+
+```python
+"gaussian": r"Full point group\s+(?P<pg>\S+)",
+```
+
+The `\S+` form (rather than `\w+`) is required because Gaussian writes
+non-word characters (e.g. `*`) in linear point-group labels such as `C*V`.
+
+Gaussian's natural PG labels match the existing `bimol_ref["eneyne"]["pg"]`
+list for four of the five subjects (after the `pg.capitalize()` normalisation
+that already runs in the test):
+
+| subject | Gaussian | ref |
+|---------|----------|------|
+| dimer | C2V → C2v | "C2v" ✓ |
+| mA | C2V → C2v | ["D2h", "C2v"] ✓ |
+| mB | C*V → C*v | ["D4h", "C4v", "C2v"] ✗ |
+| mAgB | C2V → C2v | "C2v" ✓ |
+| gAmB | C2V → C2v | "C2v" ✓ |
+
+Only the `mB` subject (ethyne alone, linear) is problematic: Gaussian reports
+the natural linear point group `C*v`, whereas the existing consensus list
+records the abelian subgroups other programs reduce it to. The test grows a
+single Gaussian-specific branch that accepts `C*v` for `mB`:
+
+```python
+if qcprog == "gamess":
+    assert pg == "C1"
+elif qcprog == "gaussian" and subject == "mB":
+    assert pg == "C*v"
+else:
+    assert pg in ref["pg"][subject]
+```
+
+This preserves the original PG check for all other Gaussian subjects while
+avoiding a Gaussian-specific edit to the cross-program `bimol_ref["eneyne"]["pg"]`
+dict.
+
+**Out-of-scope**: no Gaussian-specific reference-data file is created. No harness
+changes are required — the existing ghost-atom support (this document) plus the
+existing user-keyword pass-through (`input-builder.md`) suffice.
 
 ## Migration Notes <!-- rq-df7eb0c3 -->
 

--- a/rqm/gaussian/ghost-atoms.md
+++ b/rqm/gaussian/ghost-atoms.md
@@ -1,0 +1,300 @@
+# Feature: Gaussian Harness — Ghost Atom Support <!-- rq-73c1f919 -->
+
+This document specifies ghost-atom support for the Gaussian harness. A "ghost atom" is
+an atom whose basis functions are placed at a position in space without a nucleus or
+electrons — used primarily for counterpoise (BSSE) corrections and basis-set studies.
+In a QCSchema `Molecule`, ghost atoms are marked by `real=False` at the matching index
+in the `real` array; their entry in `symbols` gives the element whose basis is to be
+placed at that position.
+
+This feature replaces the prior policy in [[input-builder]] that raised `InputError`
+on any molecule containing a ghost atom. The corresponding scenario in `input-builder.md`
+(formerly `@rq-5053204b`) is removed when this feature is implemented; the runner
+precheck at `qcengine/programs/gaussian/runner.py:183-184` is replaced by the build
+logic specified below.
+
+Related files:
+- `input-builder.md` — `.com` file construction (modified by this feature).
+- `harvester.md` — cclib-based output parsing (extended by this feature).
+- `integration-tests.md` — integration test catalogue (extended by this feature).
+
+## Background: Gaussian Ghost-Atom Syntax <!-- rq-dceb51f5 -->
+
+Gaussian (16 and 09) supports ghost atoms in the molecule specification by appending
+the suffix `-Bq` to the element symbol. The resulting atom contributes its basis
+functions but has zero nuclear charge and contributes no electrons. The route line
+and `model.basis` (e.g. `HF/6-31G*`) are unchanged; the element-based basis assignment
+applies to the ghost atom exactly as if it were real.
+
+Example atom block for an He···Ne system with a ghost Ne:
+
+```
+He    0.0000000000    0.0000000000    0.0000000000
+Ne-Bq 2.5000000000    0.0000000000    0.0000000000
+```
+
+In Gaussian's standard/input-orientation table, ghost atoms appear with their
+underlying element's atomic number in the "Atomic Number" column and a marker value
+of `1000` in the "Atomic Type" column (real atoms have type `0`). cclib parses the
+"Atomic Number" column but does **not** expose the "Atomic Type" column; consequently
+`ccdata.atomnos` contains the underlying-element atomic numbers for both real and
+ghost atoms (e.g. `[2, 10]` for He···Ne(ghost), not `[2, 0]`). Ghost atoms are
+otherwise present in `ccdata.atomcoords` and `ccdata.grads` (with zero forces) in
+input order.
+
+Because cclib does not differentiate ghosts from real atoms, the harvester treats
+`in_mol.real` as the sole source of truth for ghost designation.
+
+## Feature API <!-- rq-a78c68a8 -->
+
+This feature does not add new public functions or classes. It modifies the behavior of
+existing entry points:
+
+### Modified: `GaussianHarness.build_input(input_model, config, template=None)` <!-- rq-bd6cd9a4 -->
+
+Located at `qcengine/programs/gaussian/runner.py`.
+
+**Removed behavior**: the unconditional `InputError` for any molecule with
+`real=False` (rq-5053204b) is removed.
+
+**New behavior**:
+
+- The atom block (see [[input-builder]] §"Molecule Block Construction") is constructed
+  by iterating jointly over `mol.symbols`, `mol.real`, and the per-atom Ångström
+  coordinates.
+- For each atom `i`:
+  - If `mol.real[i]` is `True`, the line is `"<symbol> <x> <y> <z>"` (unchanged).
+  - If `mol.real[i]` is `False`, the line is `"<symbol>-Bq <x> <y> <z>"`.
+- Coordinate formatting (≥10 decimal places) is unchanged.
+- All other route-line and Link-0 behavior is unchanged.
+
+**Validation**: no additional pre-validation is performed. Molecules that consist
+entirely of ghost atoms, or that combine ghosts with method/driver combinations
+unsupported by Gaussian, are passed through to Gaussian; failures are surfaced via the
+existing log-pattern error dispatch (see [[runner]] §"Error dispatch").
+
+### Modified: `harvest(in_mol, method, log_content)` <!-- rq-f1d712bb -->
+
+Located at `qcengine/programs/gaussian/harvester.py`.
+
+The harvester is extended so that the parsed output molecule preserves the ghost
+designation present in `in_mol`:
+
+- **Output molecule construction**: `out_mol.real` is taken from `in_mol.real` rather
+  than defaulted to all-real. When ghosts are present, `out_mol.symbols` is taken
+  from `in_mol.symbols` rather than from cclib's `atomnos` (since `in_mol` is
+  authoritative for both ghost designation and element identity).
+
+- **Frame alignment** (cf. [[harvester]] §"Output Molecule Construction and Frame
+  Alignment"): the `align()` calls between `in_mol` and the cclib-parsed geometry use
+  `generic_ghosts=True`, matching the pattern already used by the NWChem harvester
+  (`qcengine/programs/nwchem/harvester.py:1260`).
+
+- **Nuclear-repulsion-energy cross-check** (cf. [[harvester]] §"Feature API → Raises",
+  rq-90604835): when ghost atoms are present, the cross-check compares NREs computed
+  over real atoms only. Concretely, construct real-only molecules from `in_mol` and
+  from the parsed geometry, compute the NRE of each via
+  `Molecule.nuclear_repulsion_energy()`, and apply the existing `1.0e-3` Hartree
+  tolerance. The behavior for molecules with no ghosts is unchanged.
+
+- **Atom-count sanity check**: after parsing, when ghost atoms are present in
+  `in_mol`, the harvester verifies that `len(ccdata.atomnos) == len(in_mol.symbols)`.
+  A mismatch indicates that Gaussian dropped or duplicated atoms during input parsing,
+  or that cclib's parse drifted; the harvester raises `ValueError` with a descriptive
+  message. (This check is performed only when ghosts are present, since it is the
+  cheapest cross-check available given that cclib cannot itself flag ghost atoms.)
+
+- **Gradient and Hessian transformations** are unchanged in form but operate over the
+  full atom array (real + ghost). Gaussian prints zero forces for ghost atoms; cclib
+  preserves this. Existing `mill.align_gradient()` / `mill.align_hessian()` calls
+  handle the all-atom arrays correctly when alignment is computed with
+  `generic_ghosts=True`.
+
+## Method and Driver Compatibility <!-- rq-4091a959 -->
+
+Gaussian itself imposes restrictions on which method+driver combinations may be used
+with ghost atoms (e.g. some post-HF analytic frequency methods do not support ghost
+atoms). This harness does **not** pre-validate such combinations. When Gaussian
+rejects a ghost-bearing input at runtime, the existing error dispatch in
+`GaussianHarness.compute()` will surface the failure as `InputError` or `UnknownError`
+based on the log pattern, per [[runner]].
+
+## Gherkin Scenarios <!-- rq-84b093c1 -->
+
+```gherkin
+Feature: Gaussian harness ghost-atom support
+
+  Background:
+    Given a TaskConfig with ncores=4, memory=8.0, scratch_directory=None, scratch_messy=False
+
+  # --- Input builder: atom-block formatting ---
+
+  @rq-2229f087
+  Scenario: Real atom emits a plain element symbol in the atom block
+    Given an AtomicInput whose molecule has one atom with symbol "H" and real=True
+    When build_input() is called
+    Then the gaussian.com atom block contains a line beginning with "H " (not "H-Bq ")
+
+  @rq-916e4919
+  Scenario: Ghost atom emits a "-Bq" suffix in the atom block
+    Given an AtomicInput whose molecule has one atom with symbol "H" and real=False
+    When build_input() is called
+    Then the gaussian.com atom block contains a line beginning with "H-Bq "
+
+  @rq-2a015edf
+  Scenario: Mixed real and ghost atoms in one molecule
+    Given an AtomicInput for He at origin (real=True) and Ne at (2.5, 0, 0) (real=False)
+    When build_input() is called
+    Then the atom block contains a line beginning with "He "
+    And the atom block contains a line beginning with "Ne-Bq "
+    And the atoms appear in input order
+
+  @rq-a100502c
+  Scenario: Route line is unchanged when ghost atoms are present
+    Given an AtomicInput for HF/6-31G* with two atoms, one of which has real=False
+    When build_input() is called
+    Then the route line is exactly "#P HF/6-31G*"
+
+  @rq-ce76f384
+  Scenario: All-ghost molecule produces an atom block with every line "-Bq"-suffixed
+    Given an AtomicInput whose molecule has two atoms, both with real=False
+    When build_input() is called
+    Then every atom-block coordinate line contains "-Bq"
+    And build_input() does not raise
+
+  @rq-ceef73bd
+  Scenario: Coordinate precision is preserved for ghost atoms
+    Given an AtomicInput whose molecule has a ghost atom at (1.23456789012, 0, 0) Å
+    When build_input() is called
+    Then the ghost atom's coordinate line contains at least 10 decimal digits
+
+  # --- Harvester: output molecule construction ---
+
+  @rq-b27d4aff
+  Scenario: out_mol.real is copied from in_mol when ghosts are present
+    Given an AtomicInput for He (real=True) and Ne (real=False)
+    And a Gaussian log produced by the corresponding HF/STO-3G calculation
+    When harvest(in_mol, "hf", log_content) is called
+    Then out_mol.real equals [True, False]
+
+  @rq-731f01ba
+  Scenario: out_mol.symbols are copied from in_mol for ghost positions
+    Given an AtomicInput for He (real=True) and Ne (real=False)
+    And a Gaussian log in which cclib reports atomnos == [2, 10]
+    When harvest(in_mol, "hf", log_content) is called
+    Then out_mol.symbols equals ["He", "Ne"]
+
+  @rq-7411efa0
+  Scenario: Atom count sanity check passes when cclib atom count matches in_mol
+    Given an in_mol with exactly one ghost atom (length 2)
+    And a Gaussian log where ccdata.atomnos has length 2
+    When harvest(in_mol, "hf", log_content) is called
+    Then no ValueError is raised
+
+  @rq-66067019
+  Scenario: Atom count mismatch raises ValueError when ghosts are present
+    Given an in_mol with exactly one ghost atom (length 2)
+    And a Gaussian log where ccdata.atomnos has length != 2
+    When harvest(in_mol, "hf", log_content) is called
+    Then ValueError is raised
+
+  # --- Harvester: nuclear repulsion energy cross-check ---
+
+  @rq-a69d0898
+  Scenario: NRE cross-check excludes ghost atoms when present
+    Given an in_mol containing real atom He and ghost atom Ne separated by 2.5 Å
+    And a Gaussian log whose standard-orientation geometry matches in_mol
+    When harvest(in_mol, "hf", log_content) is called
+    Then the NRE cross-check uses only the real atoms of both molecules
+    And no ValueError is raised
+
+  @rq-b57c882b
+  Scenario: NRE cross-check still catches geometry mismatches with ghosts present
+    Given an in_mol containing one real atom and one ghost atom
+    And a Gaussian log whose parsed real-atom geometry differs from in_mol
+    And the real-atom-only NRE of the parsed geometry differs by > 1e-3 Hartree from in_mol's
+    When harvest(in_mol, "hf", log_content) is called
+    Then ValueError is raised
+
+  @rq-e5a98119
+  Scenario: NRE cross-check is unchanged for all-real molecules
+    Given an in_mol with all real atoms and a matching parsed geometry
+    When harvest(in_mol, "hf", log_content) is called
+    Then the NRE cross-check is performed on the full molecules (no real-atom filtering needed)
+    And no ValueError is raised
+
+  # --- Harvester: gradient with ghost atoms ---
+
+  @rq-d97cc860
+  Scenario: Gradient array spans real and ghost atoms in input order
+    Given an AtomicInput for He···Ne (He real, Ne ghost) with driver=gradient
+    And a Gaussian Force log in which forces are printed for all 2 atoms
+    When harvest(in_mol, "hf", log_content) is called
+    Then grad has shape (6,)
+    And the gradient on the ghost atom is approximately zero
+
+  # --- Harvester: alignment with generic_ghosts ---
+
+  @rq-f8ce079b
+  Scenario: align() calls use generic_ghosts=True when ghosts are present
+    Given an in_mol with at least one ghost atom
+    When harvest(in_mol, "hf", log_content) is called
+    Then every Molecule.align() invocation in the harvester passes generic_ghosts=True
+
+  # --- Round-trip via compute() ---
+
+  @rq-04028610
+  Scenario: AtomicResult.molecule preserves ghost designation
+    Given an AtomicInput for He (real) and Ne (ghost) with HF/aug-cc-pVDZ energy
+    When GaussianHarness.compute() runs and terminates normally
+    Then the returned AtomicResult.molecule.real equals [True, False]
+    And the returned AtomicResult.molecule.symbols equals ["He", "Ne"]
+
+  @rq-24d73182
+  Scenario: Energy of a ghost-bearing system matches a reference value
+    Given the He···Ne system from test_simple_ghost (He real at origin, Ne ghost at (2.5, 0, 0) Å)
+    And HF/aug-cc-pVDZ with nocom/noreorient enforced
+    When GaussianHarness.compute(driver="energy") is called
+    Then return_result is approximately -2.8557143339397539 Hartree (atol 1e-6)
+    And properties.nuclear_repulsion_energy is approximately 0.0 (atol 1e-6)
+
+  @rq-04ed684d
+  Scenario: Gradient of a ghost-bearing system matches a reference vector
+    Given the same He···Ne system
+    When GaussianHarness.compute(driver="gradient") is called
+    Then return_result has shape (2, 3)
+    And the gradient on the real He atom matches the reference vector (atol 1e-6)
+    And the gradient on the ghost Ne atom is approximately zero (atol 1e-6)
+```
+
+## Integration Tests <!-- rq-c4439b82 -->
+
+`qcengine/programs/tests/test_ghost.py::test_simple_ghost` already parametrises a He
+real / Ne ghost system across cfour, gamess, nwchem, and psi4. As part of this feature,
+Gaussian is added to the parametrisation:
+
+```python
+pytest.param("gaussian", "aug-cc-pvdz", {}, marks=using("gaussian")),
+```
+
+The integration test asserts:
+- `nuclear_repulsion_energy` ≈ 0
+- `nbasis == 32` and `nmo == 32`
+- `return_energy` ≈ `-2.8557143339397539` (atol `1e-6`)
+- `return_result` for the gradient driver matches the reference gradient (atol `1e-6`)
+
+No new integration-test infrastructure is required; the existing parametrisation is
+extended in place.
+
+## Migration Notes <!-- rq-df7eb0c3 -->
+
+- The runner check at `qcengine/programs/gaussian/runner.py:183-184` (the
+  `InputError("The Gaussian harness does not support ghost atoms (real=False).")`
+  block) is removed in its entirety. The corresponding rq-5053204b scenario in
+  `input-builder.md` is removed at the same time.
+- `input-builder.md` §"Molecule Block Construction" is updated to specify the
+  `<symbol>-Bq` formatting for ghost atoms.
+- `harvester.md` is updated so that the output-molecule construction, NRE cross-check,
+  and alignment sections accommodate ghost atoms as specified above.
+- No public API surface changes; consumers who previously avoided ghost atoms will see
+  no behavioral change.

--- a/rqm/gaussian/ghost-atoms.md
+++ b/rqm/gaussian/ghost-atoms.md
@@ -98,7 +98,8 @@ designation present in `in_mol`:
   tolerance. The behavior for molecules with no ghosts is unchanged.
 
 - **Atom-count sanity check**: after parsing, when ghost atoms are present in
-  `in_mol`, the harvester verifies that `len(ccdata.atomnos) == len(in_mol.symbols)`.
+  `in_mol`, the harvester verifies that `ccdata.natom == len(in_mol.symbols)`
+  (using cclib's `natom` integer attribute rather than `len(ccdata.atomnos)`).
   A mismatch indicates that Gaussian dropped or duplicated atoms during input parsing,
   or that cclib's parse drifted; the harvester raises `ValueError` with a descriptive
   message. (This check is performed only when ghosts are present, since it is the
@@ -187,14 +188,14 @@ Feature: Gaussian harness ghost-atom support
   @rq-7411efa0
   Scenario: Atom count sanity check passes when cclib atom count matches in_mol
     Given an in_mol with exactly one ghost atom (length 2)
-    And a Gaussian log where ccdata.atomnos has length 2
+    And a Gaussian log where ccdata.natom == 2
     When harvest(in_mol, "hf", log_content) is called
     Then no ValueError is raised
 
   @rq-66067019
   Scenario: Atom count mismatch raises ValueError when ghosts are present
     Given an in_mol with exactly one ghost atom (length 2)
-    And a Gaussian log where ccdata.atomnos has length != 2
+    And a Gaussian log where ccdata.natom != 2
     When harvest(in_mol, "hf", log_content) is called
     Then ValueError is raised
 

--- a/rqm/gaussian/harvester.md
+++ b/rqm/gaussian/harvester.md
@@ -1,0 +1,281 @@
+# Feature: Gaussian Harness — Harvester <!-- rq-9d12489e -->
+
+This document specifies the output-parsing layer for the Gaussian harness. All parsing
+lives in `qcengine/programs/gaussian/harvester.py`. The harvester uses **cclib** as the
+primary parsing backend, supplemented by regex extraction for quantities that cclib does
+not expose (e.g. normal/abnormal termination, version identification, error messages).
+
+## cclib Integration <!-- rq-bb0a5d96 -->
+
+cclib is called once per log file via:
+
+```python
+import io
+import cclib
+
+ccdata = cclib.io.ccopen(io.StringIO(log_content)).parse()
+```
+
+The `ccdata` object exposes parsed attributes used as follows:
+
+| cclib attribute | Units (cclib) | Conversion | QCEngine usage |
+|-----------------|---------------|------------|----------------|
+| `ccdata.scfenergies[-1]` | eV | ÷ eV/Hartree | SCF/HF/DFT total energy |
+| `ccdata.mpenergies[-1][-1]` | eV | ÷ eV/Hartree | MP2 total energy |
+| `ccdata.ccenergies[-1]` | eV | ÷ eV/Hartree | CCSD or CCSD(T) total energy |
+| `ccdata.grads[-1]` | Hartree/Bohr | negate (forces → gradient) | Gradient array |
+| `ccdata.hessian` | Hartree/Bohr² | none | Hessian matrix |
+| `ccdata.atomcoords[-1]` | Ångström | × Bohr/Å | Geometry for output molecule |
+| `ccdata.atomnos` | atomic numbers | via qcel periodic table | Element symbols |
+| `ccdata.atommasses` | amu | none | Atomic masses |
+| `ccdata.moments[1]` | Debye | none | Dipole moment vector |
+| `ccdata.atomcharges["mulliken"]` | e | none | Mulliken partial charges |
+
+Energy conversion factor: `qcel.constants.conversion_factor("eV", "hartree")`.
+
+**Important**: Gaussian reports atomic **forces** (= −dE/dR) in its output; cclib
+preserves this sign convention in `ccdata.grads`. The gradient (= +dE/dR) is obtained by
+**negating** the forces array:
+
+```python
+gradient = -ccdata.grads[-1]   # shape (natoms, 3) → flatten to (3*natoms,)
+```
+
+## Regex Fallback <!-- rq-c20746b1 -->
+
+Regex is used for items cclib does not expose:
+
+| Item | Pattern |
+|------|---------|
+| Normal termination | `"Normal termination of Gaussian"` in log |
+| Abnormal termination | absence of the above line, or `"Error termination"` |
+| Gaussian version (for provenance) | `r"Gaussian\s+(\d+),\s+Revision\s+([\w.]+),"` |
+
+## Feature API <!-- rq-1a01df8f -->
+
+### `harvest(in_mol: Molecule, method: str, log_content: str) -> Tuple[PreservingDict, Optional[np.ndarray], Optional[np.ndarray], Molecule]` <!-- rq-d9434480 -->
+
+**Purpose**: parses the Gaussian log file and returns all QC data needed to construct an
+`AtomicResult`.
+
+**Parameters**:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `in_mol` | `qcelemental.models.Molecule` | The input molecule (used for alignment and NRE cross-check). |
+| `method` | `str` | Lowercase QCSchema method string (e.g. `"hf"`, `"mp2"`, `"b3lyp"`). |
+| `log_content` | `str` | Full text of `gaussian.log`. |
+
+**Returns** a 4-tuple `(qcvars, grad, hess, out_mol)`:
+
+| Element | Type | Description |
+|---------|------|-------------|
+| `qcvars` | `PreservingDict` | QC variables (see below). |
+| `grad` | `Optional[np.ndarray]` | Shape `(3*natoms,)` gradient in Hartree/Bohr, or `None`. |
+| `hess` | `Optional[np.ndarray]` | Shape `(3*natoms, 3*natoms)` Hessian in Hartree/Bohr², or `None`. |
+| `out_mol` | `Molecule` | Output molecule aligned to `in_mol`. |
+
+**Raises**:
+- `ValueError` if no coordinate information can be extracted from the log. <!-- rq-4336c3cd -->
+- `ValueError` if the nuclear repulsion energy of the parsed geometry deviates from <!-- rq-90604835 -->
+  `in_mol.nuclear_repulsion_energy()` by more than `1.0e-3` Hartree.
+- Any `cclib` exception is allowed to propagate (caller wraps in `UnknownError`).
+
+### QC Variables Populated <!-- rq-929a262a -->
+
+The following variables are placed in `qcvars` based on the method:
+
+**All calculations**:
+- `"NUCLEAR REPULSION ENERGY"` — from parsed geometry. <!-- rq-0753cd03 -->
+- `"HF TOTAL ENERGY"` — always set from `ccdata.scfenergies[-1]` (in Hartree). <!-- rq-37f40e92 -->
+- `"CURRENT ENERGY"` — set to the highest-level energy available (see below). <!-- rq-c5165f1f -->
+
+**Method-specific**:
+
+| Method | Variables set |
+|--------|--------------|
+| `"hf"` or `"scf"` or DFT | `"HF TOTAL ENERGY"`, `"CURRENT ENERGY"` |
+| `"mp2"` | `"MP2 CORRELATION ENERGY"` (= MP2 total − HF total), `"MP2 TOTAL ENERGY"`, `"CURRENT ENERGY"` |
+| `"ccsd"` | `"CCSD CORRELATION ENERGY"`, `"CCSD TOTAL ENERGY"`, `"CURRENT ENERGY"` |
+| `"ccsd(t)"` | `"CCSD CORRELATION ENERGY"`, `"CCSD TOTAL ENERGY"`, `"CCSD(T) CORRELATION ENERGY"`, `"CCSD(T) TOTAL ENERGY"`, `"CURRENT ENERGY"` |
+
+**Properties driver extras** (when cclib attributes are available):
+- `"MULLIKEN CHARGES"` — from `ccdata.atomcharges["mulliken"]`. <!-- rq-c7fd08b5 -->
+- `"DIPOLE MOMENT"` — magnitude of `ccdata.moments[1]` in Debye. <!-- rq-943856cc -->
+
+**Gradient** (when present):
+- The negated forces array (shape `(3*natoms,)`) is returned as `grad`; the runner sets
+  `"CURRENT GRADIENT"` and `"<METHOD> TOTAL GRADIENT"` in `qcvars`.
+
+**Hessian** (when present):
+- The Hessian matrix (shape `(3*natoms, 3*natoms)`) is returned as `hess`; the runner
+  sets `"CURRENT HESSIAN"` and `"<METHOD> TOTAL HESSIAN"` in `qcvars`.
+
+### Output Molecule Construction <!-- rq-8d6fc024 -->
+
+The output molecule is constructed from `ccdata.atomnos` and `ccdata.atomcoords[-1]`
+(converted from Ångström to Bohr), then aligned to `in_mol` using
+`in_mol.align(calc_mol, ...)` — the same pattern used by the GAMESS harvester.
+
+## Gherkin Scenarios <!-- rq-058819da -->
+
+```gherkin
+Feature: Gaussian harvester
+
+  Background:
+    Given an AtomicInput for water (3 atoms: O, H, H) with charge=0, multiplicity=1
+
+  # --- Energy parsing ---
+
+  @rq-71b27e68
+  Scenario: Parse HF total energy from a closed-shell log
+    Given a Gaussian log for HF/STO-3G single-point on water
+    And ccdata.scfenergies[-1] is -2041.3 eV
+    When harvest(in_mol, "hf", log_content) is called
+    Then qcvars["HF TOTAL ENERGY"] equals -2041.3 converted to Hartree
+    And qcvars["CURRENT ENERGY"] equals qcvars["HF TOTAL ENERGY"]
+
+  @rq-6bff3228
+  Scenario: Parse DFT total energy (treated as HF SCF energy by cclib)
+    Given a Gaussian log for B3LYP/6-31G* single-point on water
+    And ccdata.scfenergies[-1] is -2082.1 eV
+    When harvest(in_mol, "b3lyp", log_content) is called
+    Then qcvars["HF TOTAL ENERGY"] equals -2082.1 converted to Hartree
+    And qcvars["CURRENT ENERGY"] equals qcvars["HF TOTAL ENERGY"]
+
+  @rq-578bb785
+  Scenario: Parse MP2 total and correlation energies
+    Given a Gaussian log for MP2/cc-pVDZ on water
+    And ccdata.scfenergies[-1] is -2041.3 eV (HF energy)
+    And ccdata.mpenergies[-1][-1] is -2044.8 eV (MP2 total energy)
+    When harvest(in_mol, "mp2", log_content) is called
+    Then qcvars["HF TOTAL ENERGY"] equals -2041.3 converted to Hartree
+    And qcvars["MP2 TOTAL ENERGY"] equals -2044.8 converted to Hartree
+    And qcvars["MP2 CORRELATION ENERGY"] equals the difference (in Hartree)
+    And qcvars["CURRENT ENERGY"] equals qcvars["MP2 TOTAL ENERGY"]
+
+  @rq-1b7ae62e
+  Scenario: Parse CCSD total energy
+    Given a Gaussian log for CCSD/cc-pVDZ on water
+    And ccdata.scfenergies[-1] is -2041.3 eV
+    And ccdata.ccenergies[-1] is -2045.2 eV (CCSD total energy)
+    When harvest(in_mol, "ccsd", log_content) is called
+    Then qcvars["CCSD TOTAL ENERGY"] equals -2045.2 converted to Hartree
+    And qcvars["CCSD CORRELATION ENERGY"] equals the difference from HF (in Hartree)
+    And qcvars["CURRENT ENERGY"] equals qcvars["CCSD TOTAL ENERGY"]
+
+  @rq-eddef743
+  Scenario: Parse CCSD(T) total energy
+    Given a Gaussian log for CCSD(T)/cc-pVDZ on water
+    And ccdata.ccenergies[-1] is the CCSD(T) total energy
+    When harvest(in_mol, "ccsd(t)", log_content) is called
+    Then qcvars["CCSD(T) TOTAL ENERGY"] is set
+    And qcvars["CURRENT ENERGY"] equals qcvars["CCSD(T) TOTAL ENERGY"]
+
+  # --- Gradient parsing ---
+
+  @rq-36736115
+  Scenario: Parse gradient and negate forces
+    Given a Gaussian log for HF/STO-3G Force on water
+    And ccdata.grads[-1] has shape (3, 3) with values representing forces (Hartree/Bohr)
+    When harvest(in_mol, "hf", log_content) is called
+    Then grad equals -ccdata.grads[-1] flattened to shape (9,)
+    And each element of grad equals the negation of the corresponding force element
+
+  @rq-3b0adf96
+  Scenario: No gradient attribute in ccdata when running energy-only calculation
+    Given a Gaussian log for HF/STO-3G single-point (no Force keyword)
+    And ccdata has no grads attribute
+    When harvest(in_mol, "hf", log_content) is called
+    Then grad is None
+
+  # --- Hessian parsing ---
+
+  @rq-f2e32162
+  Scenario: Parse Hessian from frequency calculation
+    Given a Gaussian log for HF/STO-3G Freq on water
+    And ccdata.hessian has shape (9, 9)
+    When harvest(in_mol, "hf", log_content) is called
+    Then hess has shape (9, 9)
+    And hess equals ccdata.hessian
+
+  @rq-344f3432
+  Scenario: No Hessian when running energy-only or gradient calculation
+    Given a Gaussian log for HF/STO-3G without Freq
+    And ccdata has no hessian attribute
+    When harvest(in_mol, "hf", log_content) is called
+    Then hess is None
+
+  # --- Properties parsing ---
+
+  @rq-4c4a1542
+  Scenario: Parse dipole moment for properties driver
+    Given a Gaussian log with Pop=Full for HF/STO-3G on water
+    And ccdata.moments[1] is a vector with magnitude 1.85 Debye
+    When harvest(in_mol, "hf", log_content) is called
+    Then qcvars["DIPOLE MOMENT"] is approximately 1.85
+
+  @rq-ffae3fa6
+  Scenario: Parse Mulliken charges for properties driver
+    Given a Gaussian log with Pop=Full for HF/STO-3G on water
+    And ccdata.atomcharges["mulliken"] is a list of 3 floats
+    When harvest(in_mol, "hf", log_content) is called
+    Then qcvars["MULLIKEN CHARGES"] is a list of length 3
+
+  @rq-53f8ed12
+  Scenario: Missing Mulliken charges do not raise an error
+    Given a Gaussian log without Pop=Full
+    And ccdata.atomcharges is empty or absent
+    When harvest(in_mol, "hf", log_content) is called
+    Then no error is raised
+    And "MULLIKEN CHARGES" is not present in qcvars
+
+  # --- Geometry and molecule output ---
+
+  @rq-a76c3d7b
+  Scenario: Output molecule geometry is constructed from ccdata
+    Given ccdata.atomcoords[-1] contains the final Cartesian coordinates (Angstrom)
+    And ccdata.atomnos contains [8, 1, 1] for water
+    When harvest(in_mol, "hf", log_content) is called
+    Then out_mol is a valid Molecule with symbols ["O", "H", "H"]
+
+  @rq-a9194afb
+  Scenario: Nuclear repulsion energy cross-check passes for consistent geometry
+    Given the parsed geometry and in_mol have matching nuclear repulsion energies
+    When harvest(in_mol, "hf", log_content) is called
+    Then no ValueError is raised
+
+  @rq-0b4cf843
+  Scenario: Nuclear repulsion energy mismatch raises ValueError
+    Given the parsed geometry has a nuclear repulsion energy differing from in_mol by > 1e-3 Hartree
+    When harvest(in_mol, "hf", log_content) is called
+    Then ValueError is raised
+
+  # --- Error conditions ---
+
+  @rq-b7c7b8cb
+  Scenario: Log with no coordinate data raises ValueError
+    Given a Gaussian log file from which cclib cannot extract atomic coordinates
+    When harvest(in_mol, "hf", log_content) is called
+    Then ValueError is raised
+
+  @rq-bb775969
+  Scenario: cclib parse failure propagates as-is
+    Given a log_content string that cclib.io.ccopen cannot parse
+    When harvest(in_mol, "hf", log_content) is called
+    Then the cclib exception propagates to the caller
+
+  # --- Normal termination check (regex) ---
+
+  @rq-90141f40
+  Scenario: Normal termination line is present in a successful log
+    Given a log file containing "Normal termination of Gaussian"
+    When the log is inspected for normal termination
+    Then the termination is classified as normal
+
+  @rq-12c41d5e
+  Scenario: Absent normal termination line is classified as abnormal
+    Given a log file that does not contain "Normal termination of Gaussian"
+    When the log is inspected for normal termination
+    Then the termination is classified as abnormal
+```

--- a/rqm/gaussian/harvester.md
+++ b/rqm/gaussian/harvester.md
@@ -83,6 +83,15 @@ Regex is used for items cclib does not expose:
 
 ### QC Variables Populated <!-- rq-929a262a -->
 
+> **Priority note:** The `properties` field on `AtomicResult` (populated via
+> `build_atomicproperties`) is the proper QCSchema interface for consumers.
+> `extras["qcvars"]` is retained for diagnostics and compatibility with other
+> harnesses, but `properties` mappings are the primary contract.  All energy,
+> gradient, and hessian variables listed below have existing mappings in
+> `qcvars_to_atomicproperties`.  `"MULLIKEN CHARGES"` and `"DIPOLE MOMENT"`
+> do not have `properties` mappings (the dipole mapping expects a vector
+> `"HF DIPOLE"`, not the scalar magnitude stored here).
+
 The following variables are placed in `qcvars` based on the method:
 
 **All calculations**:

--- a/rqm/gaussian/harvester.md
+++ b/rqm/gaussian/harvester.md
@@ -52,6 +52,14 @@ cross-program alignment tests (`atol = 2e-7`).
 "Direct Energy Parsing" below). cclib energy attributes are used only as a fallback
 if the regex fails to match.
 
+> **Considered alternative:** Using `cclib.parser.utils.convertor(ccdata.scfenergies[-1],
+> 'eV', 'hartree')` produces a lossless round-trip (cclib's own forward and reverse
+> factors are exact inverses). This was rejected in favour of direct parsing because:
+> (a) it couples the harvester to cclib's internal conversion remaining self-consistent
+> across future versions, (b) direct log parsing captures the full precision printed by
+> Gaussian (up to 12 significant digits), and (c) cclib provides no public API contract
+> guaranteeing lossless eV↔Hartree round-trips.
+
 **2. Hessian not extracted by cclib:**
 
 cclib does not parse the "Force constants in Cartesian coordinates" block from

--- a/rqm/gaussian/harvester.md
+++ b/rqm/gaussian/harvester.md
@@ -20,9 +20,10 @@ The `ccdata` object exposes parsed attributes used as follows:
 
 | cclib attribute | Units (cclib) | Conversion | QCEngine usage |
 |-----------------|---------------|------------|----------------|
-| `ccdata.scfenergies[-1]` | eV | `cclib.parser.utils.convertor("eV"→"hartree")` (fallback only) | SCF/HF/DFT total energy |
-| `ccdata.mpenergies[-1][-1]` | eV | `cclib...convertor` (fallback only) | MP2 total energy |
-| `ccdata.ccenergies[-1]` | eV | `cclib...convertor` (fallback only) | CCSD or CCSD(T) total energy |
+| `ccdata.scfenergies[-1]` | eV | `cclib.parser.utils.convertor("eV"→"hartree")` | SCF/HF/DFT total energy |
+| `ccdata.mpenergies[-1][-1]` | eV | `cclib.parser.utils.convertor("eV"→"hartree")` | MP2 total energy |
+| `ccdata.ccenergies[-1]` | eV | `cclib.parser.utils.convertor("eV"→"hartree")` | CCSD or CCSD(T) total energy |
+| `ccdata.dispersionenergies[-1]` | eV | `cclib.parser.utils.convertor("eV"→"hartree")` | Empirical dispersion correction (see [[dispersion]]) |
 | `ccdata.grads[-1]` | Hartree/Bohr | negate (forces → gradient) | Gradient array |
 | `ccdata.atomcoords[-1]` | Ångström | × Bohr/Å | Geometry for output molecule (standard orientation) |
 | `ccdata.atomnos` | atomic numbers | via qcel periodic table | Element symbols (no-ghost branch only) |
@@ -33,39 +34,43 @@ The `ccdata` object exposes parsed attributes used as follows:
 | `ccdata.moments[1]` | Debye | none | Dipole moment vector |
 | `ccdata.atomcharges["mulliken"]` | e | none | Mulliken partial charges |
 
-### cclib Limitations <!-- rq-f6537c40 -->
+### cclib Energy Precision <!-- rq-f6537c40 -->
 
-Two significant cclib limitations require direct log parsing as the primary strategy
-for energies and the Hessian:
+cclib stores parsed energies in electron volts. For Gaussian, the parser
+reads the Hartree value from a line such as `SCF Done: E(RHF) =
+-76.0571491640 A.U.`, calls `utils.float()` on the token (just `float()` with
+D-exponent handling), multiplies by cclib's Hartree→eV factor (`27.21138505`),
+and stores the result on `ccdata.scfenergies` (and analogously on
+`mpenergies`, `ccenergies`, `dispersionenergies`).
 
-**1. Energy precision loss when reversing cclib's eV storage with a foreign factor:**
+The harvester reverses this with `cclib.parser.utils.convertor(x, "eV",
+"hartree")`, which uses the same `27.21138505` factor in both directions
+inside cclib's `_convertor` dict. The round-trip precision is:
 
-cclib internally stores energies in electron volts. It parses the Hartree value
-from the Gaussian log, multiplies by its internal Hartree→eV factor
-(`27.21138505`), and stores the result on `ccdata.scfenergies`, `ccdata.mpenergies`,
-`ccdata.ccenergies`, and `ccdata.dispersionenergies`. If the harvester reverses
-this with qcelemental's factor (`qcel.constants.conversion_factor("eV", "hartree")`
-= `0.036749322481536`, corresponding to `27.21138602` Hartree→eV — the values
-disagree at the 8th decimal place because they were derived from different
-CODATA cycles), the round-trip introduces a relative error of approximately
-`3.6e-9`. For typical SCF energies (~100 Hartree) that's an absolute error of
-~3.6e-6 Hartree, exceeding the cross-program tolerances (`atol = 2e-7`) and
-the empirical-dispersion test tolerances.
+| Step | Loss |
+|------|------|
+| Gaussian text → Python `float` via `utils.float()` | none (the text fits within IEEE-754 double precision) |
+| `× cclib's Hartree→eV factor` | none beyond 1 ULP of float multiplication |
+| `× cclib's eV→Hartree factor` (via `cclib.parser.utils.convertor`) | none beyond 1 ULP |
+| **End-to-end Ha → eV → Ha round-trip** | **≤ 1 ULP (~1×10⁻¹⁴ Ha for ~100-Ha energies); often exactly 0** |
 
-**Resolution (two layers):**
+This is 7+ orders of magnitude below any tolerance the test suite cares
+about (e.g. `atol = 2e-7` for cross-program alignment).
 
-1. *Primary path:* energies are parsed directly from the Gaussian log via regex
-   (see "Direct Energy Parsing" below). This preserves Gaussian's full printed
-   precision (up to 12 significant digits) and avoids cclib's eV detour entirely.
-2. *Fallback path:* when the regex misses, the harvester reads the eV-stored
-   value from `ccdata` and converts back via `cclib.parser.utils.convertor(x,
-   "eV", "hartree")` — cclib's own converter, which uses the same `27.21138505`
-   factor in both directions. The forward/reverse pair is structurally exact
-   (single factor, both directions in the same `_convertor` dict), so the
-   round-trip introduces zero round-trip error and is forward-compatible with
-   any future CODATA refresh inside cclib.
+The reverse step **must** use `cclib.parser.utils.convertor` rather than
+`qcel.constants.conversion_factor("eV", "hartree")`: qcel and cclib carry
+different CODATA Hartree↔eV factors (qcel: `27.21138602`; cclib:
+`27.21138505`), and reversing cclib's eV-stored value with qcel's factor
+introduces a `~3.6×10⁻⁶ Ha` bias for typical SCF energies that exceeds the
+cross-program tolerance.
 
-**2. Full Cartesian Hessian not extracted by cclib:**
+All SCF, MP*, CC, and dispersion energies are read directly from cclib's
+parsed attributes (`ccdata.scfenergies`, `ccdata.mpenergies`,
+`ccdata.ccenergies`, `ccdata.dispersionenergies`) via this converter. No
+log-text regex is used for energies — see "Regex Use" below for the items
+that warrant regex.
+
+### cclib Limitation: Full Cartesian Hessian not extracted <!-- rq-a3c37e5d -->
 
 cclib's Gaussian parser does populate `ccdata.vibfconsts` (per-normal-mode reduced
 force constants, shape `(nmodes,)`) from the `"Frc consts --"` lines of a `Freq`
@@ -94,23 +99,37 @@ preserves this sign convention in `ccdata.grads`. The gradient (= +dE/dR) is obt
 gradient = -ccdata.grads[-1]   # shape (natoms, 3)
 ```
 
-## Direct Energy Parsing <!-- rq-c20746b1 -->
+## Energy Extraction <!-- rq-c20746b1 -->
 
-Energies are parsed directly from the Gaussian log in Hartree to avoid the cclib eV
-round-trip. The following regex patterns are used:
+Energies are read from cclib's parsed attributes and converted eV → Hartree
+via `cclib.parser.utils.convertor`. The per-method attribute mapping is:
 
-| Energy | Regex | Format |
-|--------|-------|--------|
-| SCF/HF/DFT | `r"SCF Done:\s+E\(\S+\)\s*=\s*([-\d.]+)"` | Plain float |
-| MP2 | `r"EUMP2\s*=\s*([-\d.DE+]+)"` | Fortran D-exponent |
-| CCSD(T) | `r"CCSD\(T\)=\s*([-\d.DE+]+)"` | Fortran D-exponent |
-| CCSD | `r"DE\(Corr\)=\s*[-\d.]+\s+E\(CORR\)=\s*([-\d.]+)"` (last match) | Plain float |
+| Method | cclib source | qcvars set |
+|--------|--------------|------------|
+| `"hf"` / `"scf"` / DFT (default) | `ccdata.scfenergies[-1]` | `HF TOTAL ENERGY`, `SCF TOTAL ENERGY`, `CURRENT REFERENCE ENERGY`, `CURRENT ENERGY` |
+| `"mp2"` | `ccdata.mpenergies[-1][-1]` | adds `MP2 TOTAL ENERGY`, `MP2 CORRELATION ENERGY`; `CURRENT ENERGY` = MP2 total |
+| `"ccsd"` | `ccdata.ccenergies[-1]` | adds `CCSD TOTAL ENERGY`, `CCSD CORRELATION ENERGY`; `CURRENT ENERGY` = CCSD total |
+| `"ccsd(t)"` | `ccdata.ccenergies[-1]` | adds `CCSD(T) TOTAL ENERGY`, `CCSD(T) CORRELATION ENERGY`; `CURRENT ENERGY` = CCSD(T) total |
+| `"b3lyp-d3"` (etc., dispersion suffix) | `scfenergies[-1]` + `dispersionenergies[-1]` | per `dispersion.md` |
 
-Fortran D-exponent values (e.g. `-0.76276030623D+02`) are converted by replacing
-`D` with `E` before calling `float()`.
+**`mpenergies[-1][-1]`** retrieves the highest-order Møller–Plesset energy
+cclib stored for the last step (e.g. `[[MP2]]` for an MP2-only job).
 
-If a regex does not match, the harvester falls back to cclib's eV-based energy with
-the qcelemental conversion factor.
+**`ccenergies[-1]`** retrieves the highest-level coupled-cluster energy:
+the CCSD total for a CCSD job, the CCSD(T) total for a CCSD(T) job. cclib
+does not separately store the intermediate CCSD value inside a CCSD(T) job,
+so no CCSD qcvar is surfaced inside a CCSD(T) run.
+
+**Error handling:** if the cclib attribute the method requires is absent
+(`hasattr` is false) or empty (zero-length array), the harvester raises
+`ValueError(...)` with a message naming the missing attribute. The runner
+wraps this in `UnknownError`.
+
+**Method-string normalisation:** `"ccsd(t,full)" → "ccsd(t)"` and
+`"mp2(full)" → "mp2"` are applied at the top of `harvest()` so the above
+branching matches. Dispersion suffixes (e.g. `"b3lyp-d3"`) are stripped to
+recover the functional name; the unknown-functional branch falls through to
+the SCF/DFT case.
 
 ## Hessian Parsing <!-- rq-c5b27d26 -->
 
@@ -130,13 +149,19 @@ orientation. This is significant for frame alignment:
   standard/calc frame. The Hessian must be transformed from input→calc frame using
   `in_mol.align(calc_mol)`.
 
-## Other Regex Items <!-- rq-0743e952 -->
+## Regex Use <!-- rq-0743e952 -->
 
-| Item | Pattern |
-|------|---------|
-| Normal termination | `"Normal termination of Gaussian"` in log |
-| Abnormal termination | absence of the above line, or `"Error termination"` |
-| Gaussian version (for provenance) | `r"Gaussian\s+(\d+),\s+Revision\s+([\w.]+),"` |
+Log-text regex is used only for the following non-energy items:
+
+| Item | Pattern | Why regex (not cclib) |
+|------|---------|-----------------------|
+| Normal termination | `"Normal termination of Gaussian"` substring | cclib doesn't surface a success/failure flag |
+| Abnormal termination | absence of the above line, or `"Error termination"` | same |
+| Gaussian version (for provenance) | `r"Gaussian\s+(\d+),\s+Revision\s+([\w.]+),"` | extracted from the startup banner before any cclib parse |
+| Hessian (Cartesian, full 3N×3N) | `"Force constants in Cartesian coordinates:"` block, parsed by `_parse_force_constants()` | cclib does not populate `ccdata.hessian` for Gaussian (see "cclib Limitation: Full Cartesian Hessian not extracted") |
+
+The Fortran D-exponent helper `_fortran_float()` is retained for the Hessian
+block.
 
 ## Feature API <!-- rq-1a01df8f -->
 
@@ -183,7 +208,7 @@ The following variables are placed in `qcvars` based on the method:
 
 **All calculations**:
 - `"NUCLEAR REPULSION ENERGY"` — from parsed geometry. <!-- rq-0753cd03 -->
-- `"HF TOTAL ENERGY"` — from direct log parsing (SCF Done line), falling back to `ccdata.scfenergies[-1]` converted from eV. <!-- rq-37f40e92 -->
+- `"HF TOTAL ENERGY"` — from `ccdata.scfenergies[-1]` converted via `cclib.parser.utils.convertor("eV", "hartree")`. <!-- rq-37f40e92 -->
 - `"SCF TOTAL ENERGY"` — same value as `"HF TOTAL ENERGY"` (required by standard suite contracts). <!-- rq-f59a07b8 -->
 - `"CURRENT REFERENCE ENERGY"` — same value as `"HF TOTAL ENERGY"` (required by standard suite contracts). <!-- rq-0d2711f1 -->
 - `"CURRENT ENERGY"` — set to the highest-level energy available (see below). <!-- rq-c5165f1f -->
@@ -200,7 +225,7 @@ The following variables are placed in `qcvars` based on the method:
 | `"hf"` or `"scf"` or DFT | `"HF TOTAL ENERGY"`, `"CURRENT ENERGY"` |
 | `"mp2"` | `"MP2 CORRELATION ENERGY"` (= MP2 total − HF total), `"MP2 TOTAL ENERGY"`, `"CURRENT ENERGY"` |
 | `"ccsd"` | `"CCSD CORRELATION ENERGY"`, `"CCSD TOTAL ENERGY"`, `"CURRENT ENERGY"` |
-| `"ccsd(t)"` | `"CCSD CORRELATION ENERGY"`, `"CCSD TOTAL ENERGY"`, `"CCSD(T) CORRELATION ENERGY"`, `"CCSD(T) TOTAL ENERGY"`, `"CURRENT ENERGY"` |
+| `"ccsd(t)"` | `"CCSD(T) CORRELATION ENERGY"`, `"CCSD(T) TOTAL ENERGY"`, `"CURRENT ENERGY"` (cclib does not separately store the CCSD intermediate inside a CCSD(T) job, so no `"CCSD TOTAL ENERGY"` is set) |
 
 **Properties driver extras** (when cclib attributes are available):
 - `"MULLIKEN CHARGES"` — from `ccdata.atomcharges["mulliken"]`. <!-- rq-c7fd08b5 -->
@@ -387,6 +412,72 @@ Feature: Gaussian harvester
     Given a log_content string that cclib.io.ccopen cannot parse
     When harvest(in_mol, "hf", log_content) is called
     Then the cclib exception propagates to the caller
+
+  # --- Missing cclib energy attributes ---
+
+  @rq-28b5b1b3
+  Scenario: Missing scfenergies for an HF/DFT job raises ValueError
+    Given a cclib parse where ccdata has no "scfenergies" attribute (or it is empty)
+    When harvest(in_mol, "hf", log_content) is called
+    Then ValueError is raised
+    And the message names "scfenergies"
+
+  @rq-69740b1b
+  Scenario: Missing mpenergies for an MP2 job raises ValueError
+    Given a cclib parse where scfenergies is populated but mpenergies is absent
+    When harvest(in_mol, "mp2", log_content) is called
+    Then ValueError is raised
+    And the message names "mpenergies"
+
+  @rq-2abaea4c
+  Scenario: Missing ccenergies for a CCSD job raises ValueError
+    Given a cclib parse where scfenergies is populated but ccenergies is absent
+    When harvest(in_mol, "ccsd", log_content) is called
+    Then ValueError is raised
+    And the message names "ccenergies"
+
+  @rq-e05f5cfe
+  Scenario: Missing ccenergies for a CCSD(T) job raises ValueError
+    Given a cclib parse where scfenergies is populated but ccenergies is absent
+    When harvest(in_mol, "ccsd(t)", log_content) is called
+    Then ValueError is raised
+
+  # --- Numerical consistency ---
+
+  @rq-2816c5f6
+  Scenario: SCF energy round-trips through cclib's convertor exactly
+    Given a Gaussian log with "SCF Done: E(RHF) = -76.0571491640 A.U."
+    And cclib stores ccdata.scfenergies[-1] = convertor(-76.0571491640, "hartree", "eV")
+    When harvest(in_mol, "hf", log_content) is called
+    Then qcvars["HF TOTAL ENERGY"] equals -76.0571491640 within 1 ULP (~1e-14 Hartree)
+
+  @rq-dd7024df
+  Scenario: MP2 total energy is read from mpenergies[-1][-1]
+    Given a Gaussian MP2 log where ccdata.mpenergies[-1] has one entry MP2
+    When harvest(in_mol, "mp2", log_content) is called
+    Then qcvars["MP2 TOTAL ENERGY"] equals convertor(mpenergies[-1][-1], "eV", "hartree")
+
+  @rq-4d653775
+  Scenario: CCSD(T) total energy is read from ccenergies[-1]
+    Given a Gaussian CCSD(T) log where ccdata.ccenergies[-1] is the CCSD(T) total
+    When harvest(in_mol, "ccsd(t)", log_content) is called
+    Then qcvars["CCSD(T) TOTAL ENERGY"] equals convertor(ccenergies[-1], "eV", "hartree")
+    And qcvars does NOT contain "CCSD TOTAL ENERGY"
+
+  @rq-44289c40
+  Scenario: Dispersion energy is read from ccdata.dispersionenergies
+    Given a B3LYP-D3 log where ccdata.dispersionenergies[-1] is the dispersion contribution (eV)
+    When harvest(in_mol, "b3lyp-d3", log_content) is called
+    Then qcvars["DISPERSION CORRECTION ENERGY"] equals convertor(dispersionenergies[-1], "eV", "hartree")
+
+  # --- Source-level structure ---
+
+  @rq-7edf875d
+  Scenario: No log-text regex is used for SCF, MP*, CC, or dispersion energies
+    Given an inspection of the harvester source
+    Then the module contains no `_SCF_DONE_RE`, `_MP2_ENERGY_RE`, `_CCSD_ENERGY_RE`,
+        `_CCSD_T_ENERGY_RE`, or `_DISPERSION_ENERGY_RE` constants
+    And the Fortran D-exponent helper `_fortran_float()` is retained for Hessian parsing
 
   # --- Normal termination check (regex) ---
 

--- a/rqm/gaussian/harvester.md
+++ b/rqm/gaussian/harvester.md
@@ -20,30 +20,98 @@ The `ccdata` object exposes parsed attributes used as follows:
 
 | cclib attribute | Units (cclib) | Conversion | QCEngine usage |
 |-----------------|---------------|------------|----------------|
-| `ccdata.scfenergies[-1]` | eV | ÷ eV/Hartree | SCF/HF/DFT total energy |
-| `ccdata.mpenergies[-1][-1]` | eV | ÷ eV/Hartree | MP2 total energy |
-| `ccdata.ccenergies[-1]` | eV | ÷ eV/Hartree | CCSD or CCSD(T) total energy |
+| `ccdata.scfenergies[-1]` | eV | (fallback only) | SCF/HF/DFT total energy |
+| `ccdata.mpenergies[-1][-1]` | eV | (fallback only) | MP2 total energy |
+| `ccdata.ccenergies[-1]` | eV | (fallback only) | CCSD or CCSD(T) total energy |
 | `ccdata.grads[-1]` | Hartree/Bohr | negate (forces → gradient) | Gradient array |
-| `ccdata.hessian` | Hartree/Bohr² | none | Hessian matrix |
-| `ccdata.atomcoords[-1]` | Ångström | × Bohr/Å | Geometry for output molecule |
+| `ccdata.atomcoords[-1]` | Ångström | × Bohr/Å | Geometry for output molecule (standard orientation) |
 | `ccdata.atomnos` | atomic numbers | via qcel periodic table | Element symbols |
-| `ccdata.atommasses` | amu | none | Atomic masses |
+| `ccdata.nbasis` | integer | none | Number of basis functions |
+| `ccdata.nmo` | integer | none | Number of molecular orbitals |
+| `ccdata.homos` | integer array | +1 for count | N alpha/beta electrons |
 | `ccdata.moments[1]` | Debye | none | Dipole moment vector |
 | `ccdata.atomcharges["mulliken"]` | e | none | Mulliken partial charges |
 
-Energy conversion factor: `qcel.constants.conversion_factor("eV", "hartree")`.
+### cclib Limitations <!-- rq-f6537c40 -->
+
+Two significant cclib limitations require direct log parsing as the primary strategy
+for energies and the Hessian:
+
+**1. Energy precision loss (eV conversion factor mismatch):**
+
+cclib internally stores energies in electron volts (eV). It parses the Hartree value
+from the Gaussian log, multiplies by its own Hartree→eV factor (`27.21138505`), and
+stores the result. When the harvester converts back to Hartree using qcelemental's
+factor (`qcel.constants.conversion_factor("eV", "hartree")` = `0.036749322481536`,
+corresponding to `27.21138602` Hartree→eV), the round-trip introduces a relative error
+of approximately `3.6e-9`. For typical SCF energies (~100 Hartree), this produces
+absolute errors of ~3.6e-7 Hartree, which exceeds the tolerances required by the
+cross-program alignment tests (`atol = 2e-7`).
+
+**Resolution:** Energies are parsed directly from the Gaussian log via regex (see
+"Direct Energy Parsing" below). cclib energy attributes are used only as a fallback
+if the regex fails to match.
+
+**2. Hessian not extracted by cclib:**
+
+cclib does not parse the "Force constants in Cartesian coordinates" block from
+Gaussian frequency (`Freq`) calculations. The `ccdata.hessian` attribute is always
+absent for Gaussian logs.
+
+**Resolution:** The Hessian is parsed directly from the log via `_parse_force_constants()`
+(see "Hessian Parsing" below).
+
+### Coordinate Frame <!-- rq-f4900ee1 -->
+
+cclib's `atomcoords[-1]` returns geometry in Gaussian's **standard orientation**
+(the internally reoriented frame). This affects frame alignment logic — see
+"Output Molecule Construction" below.
 
 **Important**: Gaussian reports atomic **forces** (= −dE/dR) in its output; cclib
 preserves this sign convention in `ccdata.grads`. The gradient (= +dE/dR) is obtained by
 **negating** the forces array:
 
 ```python
-gradient = -ccdata.grads[-1]   # shape (natoms, 3) → flatten to (3*natoms,)
+gradient = -ccdata.grads[-1]   # shape (natoms, 3)
 ```
 
-## Regex Fallback <!-- rq-c20746b1 -->
+## Direct Energy Parsing <!-- rq-c20746b1 -->
 
-Regex is used for items cclib does not expose:
+Energies are parsed directly from the Gaussian log in Hartree to avoid the cclib eV
+round-trip. The following regex patterns are used:
+
+| Energy | Regex | Format |
+|--------|-------|--------|
+| SCF/HF/DFT | `r"SCF Done:\s+E\(\S+\)\s*=\s*([-\d.]+)"` | Plain float |
+| MP2 | `r"EUMP2\s*=\s*([-\d.DE+]+)"` | Fortran D-exponent |
+| CCSD(T) | `r"CCSD\(T\)=\s*([-\d.DE+]+)"` | Fortran D-exponent |
+| CCSD | `r"DE\(Corr\)=\s*[-\d.]+\s+E\(CORR\)=\s*([-\d.]+)"` (last match) | Plain float |
+
+Fortran D-exponent values (e.g. `-0.76276030623D+02`) are converted by replacing
+`D` with `E` before calling `float()`.
+
+If a regex does not match, the harvester falls back to cclib's eV-based energy with
+the qcelemental conversion factor.
+
+## Hessian Parsing <!-- rq-c5b27d26 -->
+
+The Hessian is parsed from the "Force constants in Cartesian coordinates:" block in
+the Gaussian Freq log. This block contains the lower triangle of the symmetric
+force constant matrix in Fortran D-exponent format, printed in column groups of 5.
+
+The parser (`_parse_force_constants`) reconstructs the full `(3N, 3N)` symmetric matrix.
+
+**Coordinate frame for force constants:** Gaussian prints force constants in the
+**input orientation** (the coordinates from the `.com` file), NOT in the standard
+orientation. This is significant for frame alignment:
+
+- When `fix_com=True` and `fix_orientation=True`: the return molecule is `in_mol`
+  (input frame) and the Hessian is already in the input frame — no rotation needed.
+- When `fix_com=False` or `fix_orientation=False`: the return molecule is in the
+  standard/calc frame. The Hessian must be transformed from input→calc frame using
+  `in_mol.align(calc_mol)`.
+
+## Other Regex Items <!-- rq-0743e952 -->
 
 | Item | Pattern |
 |------|---------|
@@ -63,7 +131,7 @@ Regex is used for items cclib does not expose:
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `in_mol` | `qcelemental.models.Molecule` | The input molecule (used for alignment and NRE cross-check). |
-| `method` | `str` | Lowercase QCSchema method string (e.g. `"hf"`, `"mp2"`, `"b3lyp"`). |
+| `method` | `str` | Lowercase QCSchema method string (e.g. `"hf"`, `"mp2"`, `"b3lyp"`, `"ccsd(t,full)"`). Gaussian-specific sub-options like `,full` are normalised internally (e.g. `"ccsd(t,full)"` → `"ccsd(t)"` for energy extraction). |
 | `log_content` | `str` | Full text of `gaussian.log`. |
 
 **Returns** a 4-tuple `(qcvars, grad, hess, out_mol)`:
@@ -96,8 +164,15 @@ The following variables are placed in `qcvars` based on the method:
 
 **All calculations**:
 - `"NUCLEAR REPULSION ENERGY"` — from parsed geometry. <!-- rq-0753cd03 -->
-- `"HF TOTAL ENERGY"` — always set from `ccdata.scfenergies[-1]` (in Hartree). <!-- rq-37f40e92 -->
+- `"HF TOTAL ENERGY"` — from direct log parsing (SCF Done line), falling back to `ccdata.scfenergies[-1]` converted from eV. <!-- rq-37f40e92 -->
+- `"SCF TOTAL ENERGY"` — same value as `"HF TOTAL ENERGY"` (required by standard suite contracts). <!-- rq-f59a07b8 -->
+- `"CURRENT REFERENCE ENERGY"` — same value as `"HF TOTAL ENERGY"` (required by standard suite contracts). <!-- rq-0d2711f1 -->
 - `"CURRENT ENERGY"` — set to the highest-level energy available (see below). <!-- rq-c5165f1f -->
+- `"N ATOMS"` — from `len(ccdata.atomnos)`. <!-- rq-463ef385 -->
+- `"N BASIS FUNCTIONS"` — from `ccdata.nbasis` (when available). <!-- rq-17e8c0f7 -->
+- `"N MOLECULAR ORBITALS"` — from `ccdata.nmo` (when available). <!-- rq-7f2c22fd -->
+- `"N ALPHA ELECTRONS"` — from `ccdata.homos[0] + 1`. <!-- rq-6453046a -->
+- `"N BETA ELECTRONS"` — from `ccdata.homos[-1] + 1` (or same as alpha for closed-shell). <!-- rq-0cdd386d -->
 
 **Method-specific**:
 
@@ -113,18 +188,38 @@ The following variables are placed in `qcvars` based on the method:
 - `"DIPOLE MOMENT"` — magnitude of `ccdata.moments[1]` in Debye. <!-- rq-943856cc -->
 
 **Gradient** (when present):
-- The negated forces array (shape `(3*natoms,)`) is returned as `grad`; the runner sets
-  `"CURRENT GRADIENT"` and `"<METHOD> TOTAL GRADIENT"` in `qcvars`.
+- The negated forces array is transformed via `mill.align_gradient()` and returned as
+  `grad` with shape `(3*natoms,)`. The runner stores this in `qcvars` as
+  `"CURRENT GRADIENT"` and `"<METHOD> TOTAL GRADIENT"` with shape `(natoms, 3)`.
 
 **Hessian** (when present):
-- The Hessian matrix (shape `(3*natoms, 3*natoms)`) is returned as `hess`; the runner
-  sets `"CURRENT HESSIAN"` and `"<METHOD> TOTAL HESSIAN"` in `qcvars`.
+- Parsed from the log's "Force constants in Cartesian coordinates" block (see
+  "Hessian Parsing" above), transformed to the output molecule frame as needed,
+  and returned as `hess` with shape `(3*natoms, 3*natoms)`. The runner sets
+  `"CURRENT HESSIAN"` and `"<METHOD> TOTAL HESSIAN"` in `qcvars`.
 
-### Output Molecule Construction <!-- rq-8d6fc024 -->
+### Output Molecule Construction and Frame Alignment <!-- rq-8d6fc024 -->
 
 The output molecule is constructed from `ccdata.atomnos` and `ccdata.atomcoords[-1]`
-(converted from Ångström to Bohr), then aligned to `in_mol` using
-`in_mol.align(calc_mol, ...)` — the same pattern used by the GAMESS harvester.
+(converted from Ångström to Bohr) as `calc_mol`. Note that cclib returns coordinates in
+Gaussian's **standard orientation** (internally reoriented), not the input orientation.
+
+Frame handling follows the same pattern as the GAMESS harvester:
+
+- **`fix_com=True` and `fix_orientation=True`**: the return molecule is `in_mol`
+  (preserving the input frame). An alignment mill is computed via
+  `calc_mol.align(in_mol)` and applied to the gradient to transform it from standard
+  orientation to the input frame. The Hessian (from direct log parsing) is already in
+  the input frame and requires no rotation.
+
+- **Otherwise** (free frame): the return molecule is produced by
+  `in_mol.align(calc_mol)` (adopting the standard orientation frame). The gradient
+  mill is identity (no transformation needed since cclib's gradient is already in
+  standard orientation). The Hessian must be transformed from input→standard frame
+  via `in_mol.align(calc_mol)`.
+
+The `mill.align_gradient()` and `mill.align_hessian()` methods handle atom reordering
+and rotation as needed.
 
 ## Gherkin Scenarios <!-- rq-058819da -->
 

--- a/rqm/gaussian/harvester.md
+++ b/rqm/gaussian/harvester.md
@@ -60,14 +60,20 @@ if the regex fails to match.
 > Gaussian (up to 12 significant digits), and (c) cclib provides no public API contract
 > guaranteeing lossless eV↔Hartree round-trips.
 
-**2. Hessian not extracted by cclib:**
+**2. Full Cartesian Hessian not extracted by cclib:**
 
-cclib does not parse the "Force constants in Cartesian coordinates" block from
-Gaussian frequency (`Freq`) calculations. The `ccdata.hessian` attribute is always
-absent for Gaussian logs.
+cclib's Gaussian parser does populate `ccdata.vibfconsts` (per-normal-mode reduced
+force constants, shape `(nmodes,)`) from the `"Frc consts --"` lines of a `Freq`
+job. It does **not**, however, populate `ccdata.hessian` (the full `3N × 3N`
+Cartesian Hessian matrix) for Gaussian logs — that attribute is only assigned by
+parsers for programs whose output prints the full matrix in a format cclib
+recognises. The "Force constants in Cartesian coordinates" lower-triangular block
+that Gaussian prints is not parsed by cclib.
 
-**Resolution:** The Hessian is parsed directly from the log via `_parse_force_constants()`
-(see "Hessian Parsing" below).
+**Resolution:** The full Cartesian Hessian is parsed directly from the log via
+`_parse_force_constants()` (see "Hessian Parsing" below). `ccdata.vibfconsts` is
+not used by this harvester — the full matrix is required for QCSchema's
+`return_result` and downstream consumers.
 
 ### Coordinate Frame <!-- rq-f4900ee1 -->
 

--- a/rqm/gaussian/harvester.md
+++ b/rqm/gaussian/harvester.md
@@ -20,9 +20,9 @@ The `ccdata` object exposes parsed attributes used as follows:
 
 | cclib attribute | Units (cclib) | Conversion | QCEngine usage |
 |-----------------|---------------|------------|----------------|
-| `ccdata.scfenergies[-1]` | eV | (fallback only) | SCF/HF/DFT total energy |
-| `ccdata.mpenergies[-1][-1]` | eV | (fallback only) | MP2 total energy |
-| `ccdata.ccenergies[-1]` | eV | (fallback only) | CCSD or CCSD(T) total energy |
+| `ccdata.scfenergies[-1]` | eV | `cclib.parser.utils.convertor("eV"→"hartree")` (fallback only) | SCF/HF/DFT total energy |
+| `ccdata.mpenergies[-1][-1]` | eV | `cclib...convertor` (fallback only) | MP2 total energy |
+| `ccdata.ccenergies[-1]` | eV | `cclib...convertor` (fallback only) | CCSD or CCSD(T) total energy |
 | `ccdata.grads[-1]` | Hartree/Bohr | negate (forces → gradient) | Gradient array |
 | `ccdata.atomcoords[-1]` | Ångström | × Bohr/Å | Geometry for output molecule (standard orientation) |
 | `ccdata.atomnos` | atomic numbers | via qcel periodic table | Element symbols (no-ghost branch only) |
@@ -38,28 +38,32 @@ The `ccdata` object exposes parsed attributes used as follows:
 Two significant cclib limitations require direct log parsing as the primary strategy
 for energies and the Hessian:
 
-**1. Energy precision loss (eV conversion factor mismatch):**
+**1. Energy precision loss when reversing cclib's eV storage with a foreign factor:**
 
-cclib internally stores energies in electron volts (eV). It parses the Hartree value
-from the Gaussian log, multiplies by its own Hartree→eV factor (`27.21138505`), and
-stores the result. When the harvester converts back to Hartree using qcelemental's
-factor (`qcel.constants.conversion_factor("eV", "hartree")` = `0.036749322481536`,
-corresponding to `27.21138602` Hartree→eV), the round-trip introduces a relative error
-of approximately `3.6e-9`. For typical SCF energies (~100 Hartree), this produces
-absolute errors of ~3.6e-7 Hartree, which exceeds the tolerances required by the
-cross-program alignment tests (`atol = 2e-7`).
+cclib internally stores energies in electron volts. It parses the Hartree value
+from the Gaussian log, multiplies by its internal Hartree→eV factor
+(`27.21138505`), and stores the result on `ccdata.scfenergies`, `ccdata.mpenergies`,
+`ccdata.ccenergies`, and `ccdata.dispersionenergies`. If the harvester reverses
+this with qcelemental's factor (`qcel.constants.conversion_factor("eV", "hartree")`
+= `0.036749322481536`, corresponding to `27.21138602` Hartree→eV — the values
+disagree at the 8th decimal place because they were derived from different
+CODATA cycles), the round-trip introduces a relative error of approximately
+`3.6e-9`. For typical SCF energies (~100 Hartree) that's an absolute error of
+~3.6e-6 Hartree, exceeding the cross-program tolerances (`atol = 2e-7`) and
+the empirical-dispersion test tolerances.
 
-**Resolution:** Energies are parsed directly from the Gaussian log via regex (see
-"Direct Energy Parsing" below). cclib energy attributes are used only as a fallback
-if the regex fails to match.
+**Resolution (two layers):**
 
-> **Considered alternative:** Using `cclib.parser.utils.convertor(ccdata.scfenergies[-1],
-> 'eV', 'hartree')` produces a lossless round-trip (cclib's own forward and reverse
-> factors are exact inverses). This was rejected in favour of direct parsing because:
-> (a) it couples the harvester to cclib's internal conversion remaining self-consistent
-> across future versions, (b) direct log parsing captures the full precision printed by
-> Gaussian (up to 12 significant digits), and (c) cclib provides no public API contract
-> guaranteeing lossless eV↔Hartree round-trips.
+1. *Primary path:* energies are parsed directly from the Gaussian log via regex
+   (see "Direct Energy Parsing" below). This preserves Gaussian's full printed
+   precision (up to 12 significant digits) and avoids cclib's eV detour entirely.
+2. *Fallback path:* when the regex misses, the harvester reads the eV-stored
+   value from `ccdata` and converts back via `cclib.parser.utils.convertor(x,
+   "eV", "hartree")` — cclib's own converter, which uses the same `27.21138505`
+   factor in both directions. The forward/reverse pair is structurally exact
+   (single factor, both directions in the same `_convertor` dict), so the
+   round-trip introduces zero round-trip error and is forward-compatible with
+   any future CODATA refresh inside cclib.
 
 **2. Full Cartesian Hessian not extracted by cclib:**
 

--- a/rqm/gaussian/harvester.md
+++ b/rqm/gaussian/harvester.md
@@ -25,7 +25,8 @@ The `ccdata` object exposes parsed attributes used as follows:
 | `ccdata.ccenergies[-1]` | eV | (fallback only) | CCSD or CCSD(T) total energy |
 | `ccdata.grads[-1]` | Hartree/Bohr | negate (forces → gradient) | Gradient array |
 | `ccdata.atomcoords[-1]` | Ångström | × Bohr/Å | Geometry for output molecule (standard orientation) |
-| `ccdata.atomnos` | atomic numbers | via qcel periodic table | Element symbols |
+| `ccdata.atomnos` | atomic numbers | via qcel periodic table | Element symbols (no-ghost branch only) |
+| `ccdata.natom` | integer | none | Atom count for the sanity check and downstream sizing (preferred over `len(atomnos)`) |
 | `ccdata.nbasis` | integer | none | Number of basis functions |
 | `ccdata.nmo` | integer | none | Number of molecular orbitals |
 | `ccdata.homos` | integer array | +1 for count | N alpha/beta electrons |
@@ -182,7 +183,7 @@ The following variables are placed in `qcvars` based on the method:
 - `"SCF TOTAL ENERGY"` — same value as `"HF TOTAL ENERGY"` (required by standard suite contracts). <!-- rq-f59a07b8 -->
 - `"CURRENT REFERENCE ENERGY"` — same value as `"HF TOTAL ENERGY"` (required by standard suite contracts). <!-- rq-0d2711f1 -->
 - `"CURRENT ENERGY"` — set to the highest-level energy available (see below). <!-- rq-c5165f1f -->
-- `"N ATOMS"` — from `len(ccdata.atomnos)`. <!-- rq-463ef385 -->
+- `"N ATOMS"` — from `ccdata.natom`. <!-- rq-463ef385 -->
 - `"N BASIS FUNCTIONS"` — from `ccdata.nbasis` (when available). <!-- rq-17e8c0f7 -->
 - `"N MOLECULAR ORBITALS"` — from `ccdata.nmo` (when available). <!-- rq-7f2c22fd -->
 - `"N ALPHA ELECTRONS"` — from `ccdata.homos[0] + 1`. <!-- rq-6453046a -->

--- a/rqm/gaussian/harvester.md
+++ b/rqm/gaussian/harvester.md
@@ -464,20 +464,7 @@ Feature: Gaussian harvester
     Then qcvars["CCSD(T) TOTAL ENERGY"] equals convertor(ccenergies[-1], "eV", "hartree")
     And qcvars does NOT contain "CCSD TOTAL ENERGY"
 
-  @rq-44289c40
-  Scenario: Dispersion energy is read from ccdata.dispersionenergies
-    Given a B3LYP-D3 log where ccdata.dispersionenergies[-1] is the dispersion contribution (eV)
-    When harvest(in_mol, "b3lyp-d3", log_content) is called
-    Then qcvars["DISPERSION CORRECTION ENERGY"] equals convertor(dispersionenergies[-1], "eV", "hartree")
-
-  # --- Source-level structure ---
-
-  @rq-7edf875d
-  Scenario: No log-text regex is used for SCF, MP*, CC, or dispersion energies
-    Given an inspection of the harvester source
-    Then the module contains no `_SCF_DONE_RE`, `_MP2_ENERGY_RE`, `_CCSD_ENERGY_RE`,
-        `_CCSD_T_ENERGY_RE`, or `_DISPERSION_ENERGY_RE` constants
-    And the Fortran D-exponent helper `_fortran_float()` is retained for Hessian parsing
+  # (Dispersion-energy extraction Gherkin is owned by [[dispersion]].)
 
   # --- Normal termination check (regex) ---
 

--- a/rqm/gaussian/input-builder.md
+++ b/rqm/gaussian/input-builder.md
@@ -1,0 +1,347 @@
+# Feature: Gaussian Harness — Input Builder <!-- rq-9cdf3f7d -->
+
+This document specifies the input-file construction layer for the Gaussian harness.
+It covers two modules:
+
+- `qcengine/programs/gaussian/germinate.py` — maps QCSchema method/driver/multiplicity
+  to Gaussian route-section components.
+- `qcengine/programs/gaussian/keywords.py` — assembles the Gaussian `.com` file from
+  Link 0 directives, the route section, and the molecule block.
+
+The runner calls these modules from `build_input()` (see `runner.md`).
+
+## Gaussian Input File Format <!-- rq-9ec1917a -->
+
+A Gaussian `.com` file has five sections, separated by blank lines:
+
+```
+%NProcShared=<N>
+%Mem=<M>GB
+#P <method>/<basis> <job_type> [<extra_keywords>]
+
+<title>
+
+<charge> <multiplicity>
+<symbol> <x> <y> <z>
+...
+
+```
+
+- **Link 0** (`%` lines): processor and memory directives.
+- **Route section** (`#` line): method, basis, job type, and additional keywords.
+- **Title card**: a single non-blank line (may be `"QCEngine Gaussian calculation"`).
+- **Charge/multiplicity**: on one line, space-separated integers.
+- **Atom block**: element symbol followed by three Cartesian coordinates in Ångström,
+  one atom per line.
+- A trailing blank line terminates the molecule section.
+
+## Feature API <!-- rq-2ad053f2 -->
+
+### `muster_modelchem(method: str, driver: str, multiplicity: int) -> Dict[str, Any]` <!-- rq-ef62979b -->
+
+Located in `qcengine/programs/gaussian/germinate.py`.
+
+**Purpose**: converts the QCSchema `method`, `driver`, and molecular `multiplicity` into
+the Gaussian route-section keywords needed to describe the calculation.
+
+**Parameters**:
+- `method` — method string from `AtomicInput.model.method` (case-insensitive). <!-- rq-a88c706f -->
+- `driver` — one of `"energy"`, `"gradient"`, `"hessian"`, `"properties"`. <!-- rq-b49bb2a2 -->
+- `multiplicity` — from `AtomicInput.molecule.molecular_multiplicity`. <!-- rq-4d763c6d -->
+
+**Returns** a dict with keys:
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `"method_string"` | `str` | The Gaussian method token, e.g. `"B3LYP"`, `"UMP2"`. |
+| `"job_type"` | `str` | Gaussian job-type keyword appended to the route section. |
+| `"extra_keywords"` | `Dict[str, str]` | Additional route-section tokens (e.g. `{"Pop": "Full"}`). |
+
+**Method mapping** (case-insensitive input):
+
+| Input method | Gaussian method token | Notes |
+|--------------|-----------------------|-------|
+| `"hf"` or `"scf"` | `"HF"` | |
+| `"mp2"` | `"MP2"` | |
+| `"ccsd"` | `"CCSD"` | |
+| `"ccsd(t)"` | `"CCSD(T)"` | |
+| anything else | passed through verbatim (uppercased) | Treated as a DFT functional or Gaussian-native method; not validated. |
+
+**Driver → job_type mapping**:
+
+| Driver | `job_type` |
+|--------|-----------|
+| `"energy"` | `""` (no extra keyword; Gaussian defaults to single-point) |
+| `"gradient"` | `"Force=NoStep"` |
+| `"hessian"` | `"Freq"` |
+| `"properties"` | `""` (Pop=Full added via `extra_keywords`) |
+
+**Open-shell handling** (mirrors the Psi4 pattern):
+
+If `multiplicity > 1` and the method string (after uppercasing) does not already begin
+with `"U"` or `"RO"`, the prefix `"U"` is automatically prepended (e.g. `"HF"` →
+`"UHF"`, `"B3LYP"` → `"UB3LYP"`). This matches Gaussian's unrestricted-reference
+naming convention.
+
+If `multiplicity == 1`, the method string is used as-is (closed-shell reference assumed
+unless the user explicitly provides `"U..."` or `"RO..."` in the method name).
+
+**Properties driver extras**:
+
+When `driver == "properties"`, `extra_keywords` includes `{"Pop": "Full"}` so that
+Mulliken charges and dipole moment are printed in the log.
+
+**Raises**:
+
+- `InputError` — if `driver` is not one of the four supported values. <!-- rq-86c27356 -->
+
+---
+
+### `build_com_file(link0: Dict[str, Any], route_line: str, title: str, charge: int, multiplicity: int, atom_block: str) -> str` <!-- rq-0052a2c7 -->
+
+Located in `qcengine/programs/gaussian/keywords.py`.
+
+**Purpose**: assembles all sections of a Gaussian `.com` file into a single string.
+
+**Parameters**:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `link0` | `dict` | Key/value pairs written as `%Key=Value` lines. Keys are `"NProcShared"` and `"Mem"`. |
+| `route_line` | `str` | Full route section string (already formatted, starting with `#P`). |
+| `title` | `str` | Title card (single line). |
+| `charge` | `int` | Molecular charge. |
+| `multiplicity` | `int` | Spin multiplicity. |
+| `atom_block` | `str` | Newline-separated lines of `"<symbol> <x> <y> <z>"` in Ångström. |
+
+**Returns** the complete `.com` file as a string with a trailing newline.
+
+**Link 0 directives**:
+
+| Keyword | Source | Format |
+|---------|--------|--------|
+| `%NProcShared` | `config.ncores` | `%NProcShared=<N>` |
+| `%Mem` | `max(1, int(config.memory))` GB | `%Mem=<N>GB` |
+
+---
+
+### `build_route_line(method_string: str, basis: str, job_type: str, extra_keywords: Dict[str, str], user_keywords: Dict[str, Any]) -> str` <!-- rq-3c343d2a -->
+
+Located in `qcengine/programs/gaussian/keywords.py`.
+
+**Purpose**: formats the `#P` route section line.
+
+**Behaviour**:
+- Starts with `#P <method_string>/<basis>`.
+- Appends `job_type` if non-empty.
+- Appends each `(key, value)` pair from `extra_keywords` as `Key=Value` (or bare `Key`
+  if value is empty).
+- Appends pass-through keywords from `user_keywords`: any key not in the reserved set
+  `{"memory", "nprocs"}` is appended verbatim as `Key=Value` (or bare `Key` if value is
+  falsy).
+
+**Example output**:
+
+```
+#P B3LYP/6-31G* Force=NoStep
+#P UMP2/cc-pVDZ Freq
+#P CCSD(T)/cc-pVTZ
+#P HF/STO-3G Pop=Full
+```
+
+## Molecule Block Construction <!-- rq-74e0110c -->
+
+The atom block is obtained from `input_model.molecule.to_string(dtype="xyz", units="angstrom")`,
+keeping only the coordinate lines (i.e. stripping the atom-count and comment lines
+present in the XYZ format), or equivalently by iterating over `molecule.symbols` and
+`molecule.geometry` (converting from Bohr to Ångström).
+
+Coordinates must be written with sufficient decimal places (at least 10) to preserve
+numerical precision.
+
+Ghost atoms (`real=False` in the molecule) are not supported; `InputError` is raised if
+any atom is a ghost atom.
+
+## Gherkin Scenarios <!-- rq-cc549245 -->
+
+```gherkin
+Feature: Gaussian input builder
+
+  Background:
+    Given a TaskConfig with ncores=4, memory=8.0, scratch_directory=None, scratch_messy=False
+
+  # --- muster_modelchem: method mapping ---
+
+  @rq-0199bb02
+  Scenario: HF method maps to "HF" method string
+    When muster_modelchem("hf", "energy", 1) is called
+    Then method_string is "HF"
+    And job_type is ""
+    And extra_keywords is {}
+
+  @rq-7049aaa5
+  Scenario: SCF is an alias for HF
+    When muster_modelchem("scf", "energy", 1) is called
+    Then method_string is "HF"
+
+  @rq-546faafb
+  Scenario: MP2 method maps to "MP2"
+    When muster_modelchem("mp2", "energy", 1) is called
+    Then method_string is "MP2"
+
+  @rq-2052a2fa
+  Scenario: CCSD method maps to "CCSD"
+    When muster_modelchem("ccsd", "energy", 1) is called
+    Then method_string is "CCSD"
+
+  @rq-92492893
+  Scenario: CCSD(T) method maps to "CCSD(T)"
+    When muster_modelchem("ccsd(t)", "energy", 1) is called
+    Then method_string is "CCSD(T)"
+
+  @rq-851d782c
+  Scenario: Unknown method is passed through verbatim (uppercased)
+    When muster_modelchem("B3LYP", "energy", 1) is called
+    Then method_string is "B3LYP"
+
+  @rq-079b1e22
+  Scenario: Method matching is case-insensitive
+    When muster_modelchem("CCSD(T)", "energy", 1) is called
+    Then method_string is "CCSD(T)"
+
+  # --- muster_modelchem: driver mapping ---
+
+  @rq-c266b9bb
+  Scenario: Energy driver produces no job-type keyword
+    When muster_modelchem("hf", "energy", 1) is called
+    Then job_type is ""
+
+  @rq-f1c116db
+  Scenario: Gradient driver produces "Force=NoStep"
+    When muster_modelchem("hf", "gradient", 1) is called
+    Then job_type is "Force=NoStep"
+
+  @rq-82942b90
+  Scenario: Hessian driver produces "Freq"
+    When muster_modelchem("hf", "hessian", 1) is called
+    Then job_type is "Freq"
+
+  @rq-f512b60b
+  Scenario: Properties driver produces Pop=Full in extra_keywords
+    When muster_modelchem("hf", "properties", 1) is called
+    Then job_type is ""
+    And extra_keywords contains {"Pop": "Full"}
+
+  @rq-e008c6fe
+  Scenario: Unsupported driver raises InputError
+    When muster_modelchem("hf", "optimization", 1) is called
+    Then InputError is raised
+
+  # --- muster_modelchem: open-shell handling ---
+
+  @rq-972b6470
+  Scenario: Singlet uses method name as-is (no U prefix)
+    When muster_modelchem("hf", "energy", 1) is called
+    Then method_string is "HF"
+
+  @rq-6d73bb9e
+  Scenario: Doublet automatically prepends U to HF
+    When muster_modelchem("hf", "energy", 2) is called
+    Then method_string is "UHF"
+
+  @rq-c946c285
+  Scenario: Triplet automatically prepends U to B3LYP
+    When muster_modelchem("B3LYP", "energy", 3) is called
+    Then method_string is "UB3LYP"
+
+  @rq-25c4ad49
+  Scenario: Method already starting with U is not double-prefixed
+    When muster_modelchem("UHF", "energy", 2) is called
+    Then method_string is "UHF"
+
+  @rq-fe13245b
+  Scenario: Method starting with RO is not prefixed with U
+    When muster_modelchem("ROHF", "energy", 2) is called
+    Then method_string is "ROHF"
+
+  # --- build_route_line ---
+
+  @rq-af032242
+  Scenario: Route line for closed-shell HF energy
+    When build_route_line("HF", "STO-3G", "", {}, {}) is called
+    Then the result is "#P HF/STO-3G"
+
+  @rq-9acd1ce5
+  Scenario: Route line for gradient calculation
+    When build_route_line("HF", "STO-3G", "Force=NoStep", {}, {}) is called
+    Then the result starts with "#P HF/STO-3G"
+    And the result contains "Force=NoStep"
+
+  @rq-cd0d6637
+  Scenario: Route line for properties calculation includes Pop=Full
+    When build_route_line("HF", "STO-3G", "", {"Pop": "Full"}, {}) is called
+    Then the result contains "Pop=Full"
+
+  @rq-7152455e
+  Scenario: User keyword is appended to route line
+    When build_route_line("HF", "STO-3G", "", {}, {"SCF": "Tight"}) is called
+    Then the result contains "SCF=Tight"
+
+  @rq-e7897f09
+  Scenario: Reserved user keywords (memory, nprocs) are not appended to route line
+    When build_route_line("HF", "STO-3G", "", {}, {"memory": "8GB", "nprocs": "4"}) is called
+    Then the result does not contain "memory"
+    And the result does not contain "nprocs"
+
+  # --- build_com_file ---
+
+  @rq-d7e8161d
+  Scenario: Link 0 section contains NProcShared and Mem directives
+    When build_com_file({"NProcShared": 4, "Mem": "8GB"}, "#P HF/STO-3G", "title", 0, 1, "H 0.0 0.0 0.0\nH 0.0 0.0 0.74") is called
+    Then the result starts with "%NProcShared=4\n%Mem=8GB"
+
+  @rq-342a2ca3
+  Scenario: Charge and multiplicity are on one line in the molecule section
+    When build_com_file is called with charge=1 and multiplicity=2
+    Then the result contains a line "1 2"
+
+  @rq-b819d8e0
+  Scenario: Atom coordinates appear in Angstrom with at least 10 decimal places
+    When build_com_file is called with atom_block for water
+    Then each coordinate line contains at least 10 decimal digits
+
+  @rq-23d8b2c6
+  Scenario: The .com file ends with a trailing blank line
+    When build_com_file is called
+    Then the returned string ends with "\n\n"
+
+  # --- Ghost atoms ---
+
+  @rq-5053204b
+  Scenario: Ghost atoms in the molecule raise InputError
+    Given an AtomicInput whose molecule contains a ghost atom (real=False)
+    When build_input() is called
+    Then InputError is raised
+
+  # --- BasisSet object ---
+
+  @rq-0aa99076
+  Scenario: BasisSet object for model.basis raises InputError
+    Given an AtomicInput whose model.basis is a BasisSet object
+    When build_input() is called
+    Then InputError is raised
+
+  # --- Memory and cores ---
+
+  @rq-db92093a
+  Scenario: Memory directive rounds down to nearest integer GB (minimum 1)
+    Given config.memory is 0.5 (GiB)
+    When build_com_file is called
+    Then the Link 0 section contains "%Mem=1GB"
+
+  @rq-4ad16d95
+  Scenario: Memory directive uses integer GB for whole-number memory
+    Given config.memory is 8.0 (GiB)
+    When build_com_file is called
+    Then the Link 0 section contains "%Mem=8GB"
+```

--- a/rqm/gaussian/input-builder.md
+++ b/rqm/gaussian/input-builder.md
@@ -159,8 +159,9 @@ present in the XYZ format), or equivalently by iterating over `molecule.symbols`
 Coordinates must be written with sufficient decimal places (at least 10) to preserve
 numerical precision.
 
-Ghost atoms (`real=False` in the molecule) are not supported; `InputError` is raised if
-any atom is a ghost atom.
+Ghost atoms (`real=False` in the molecule) are supported: the atom symbol is emitted as
+`<symbol>-Bq` (e.g. `Ne-Bq`) rather than `<symbol>`. See [[ghost-atoms]] for the full
+specification of ghost-atom behavior across the input builder and harvester.
 
 ## Gherkin Scenarios <!-- rq-cc549245 -->
 
@@ -316,12 +317,7 @@ Feature: Gaussian input builder
     Then the returned string ends with "\n\n"
 
   # --- Ghost atoms ---
-
-  @rq-5053204b
-  Scenario: Ghost atoms in the molecule raise InputError
-    Given an AtomicInput whose molecule contains a ghost atom (real=False)
-    When build_input() is called
-    Then InputError is raised
+  # Ghost-atom scenarios are owned by ghost-atoms.md (see [[ghost-atoms]]).
 
   # --- BasisSet object ---
 

--- a/rqm/gaussian/integration-tests.md
+++ b/rqm/gaussian/integration-tests.md
@@ -1,0 +1,370 @@
+# Feature: Gaussian Harness --- Cross-Program Integration Tests <!-- rq-0f585dce -->
+
+This document specifies the integration of the Gaussian harness into the existing
+cross-program test suites in `qcengine/programs/tests/`. These tests validate that
+Gaussian conforms to the same interfaces and conventions as other harnesses (CFOUR,
+GAMESS, NWChem, Psi4).
+
+Ghost atom tests (`test_ghost.py`) are out of scope for this document.
+
+Related requirements files:
+- `runner.md` --- GaussianHarness class and `_defaults`
+- `input-builder.md` --- `.com` file construction
+- `harvester.md` --- cclib-based output parsing
+
+## Prerequisite: native_files Key Convention <!-- rq-bb7d680f -->
+
+The existing `parse_output` method in `runner.py` constructs `native_files` with
+program-specific keys (`"gaussian.com"`, `"gaussian.log"`). The cross-program
+`test_protocol_native` test expects:
+
+- An `"input"` key for the input file (matching CFOUR, GAMESS, NWChem, Psi4).
+- Additional output files keyed by their natural names (e.g. `"gaussian.log"`).
+- The `outfiles` dict from `execute()` already contains the `"input"` key (set in
+  `compute()` at line 160 of `runner.py`).
+
+**Required change**: `parse_output` must switch from a hardcoded `native_files` dict to
+the `{k: v for k, v in outfiles.items() if v is not None}` pattern used by every other
+harness. After popping `"stdout"` and `"stderr"`, the remaining keys (`"input"`,
+`"gaussian.log"`) become the native files. The `"gaussian.com"` key is dropped in
+favour of the standard `"input"` key.
+
+## Canonical Methods Entry <!-- rq-e71357c5 -->
+
+Gaussian must be added to the `_canonical_methods` list in `test_canonical_config.py`:
+
+```python
+pytest.param("gaussian", {"method": "hf", "basis": "STO-3G"}, {}, marks=using("gaussian")),
+```
+
+This entry is shared by `test_local_options_memory_gib`, `test_local_options_scratch`,
+`test_local_options_ncores`, and `test_protocol_native`.
+
+The `_get_molecule` helper returns `"hydrogen"` by default, which is suitable for
+Gaussian HF/STO-3G.
+
+## Test Integrations <!-- rq-8070c4fd -->
+
+### `test_local_options_memory_gib` (`test_canonical_config.py`) <!-- rq-0edebcd3 -->
+
+Validates that memory configuration flows through to the program.
+
+The Gaussian harness has `managed_memory=True`, so a `stdout_ref` regex is required.
+Gaussian writes memory to its `.com` file as `%Mem=<N>GB` and this text appears in
+`ret.stdout` via the log or input echo. However, Gaussian's primary evidence of memory
+is in the input file (Link 0 section), not in stdout. The log file echoes the route but
+not the Link 0 section.
+
+**Required `stdout_ref` entry**: A regex that matches the memory setting in the
+Gaussian log output. Gaussian echoes a line like
+`%NProc...` and memory information in the log. If the log does not reliably echo
+`%Mem`, the harness may need to append the input file content to `stdout` (as CFOUR
+does with a "freebie" pattern), or the `stdout_ref` should match a line that Gaussian
+always prints showing the memory available. The exact pattern must be determined
+empirically by inspecting a real Gaussian log.
+
+**Required `memory_trickery` entry** (for the `"dsl"` parametrization): Gaussian does
+not have a native keyword that sets memory in its route line (memory is a Link 0
+command, not a route keyword), so the `memory_trickery` dict for Gaussian should be
+empty `{}`, matching the Psi4 pattern:
+```python
+"gaussian": {},
+```
+
+### `test_local_options_scratch` (`test_canonical_config.py`) <!-- rq-815d5fee -->
+
+Validates that scratch directory configuration flows through to the program.
+
+The Gaussian harness has `scratch=True`.
+
+**Required `scratch_sample` entry**: A glob pattern for a file left behind in the
+scratch directory when `scratch_messy=True`. The Gaussian log file is the natural
+choice:
+```python
+"gaussian": "*/gaussian.log",
+```
+
+**Required `stdout_ref` entry**: A regex that matches scratch-related output. Gaussian
+does not print its scratch directory path in the log. Use a "freebie" pattern (a string
+that always appears in Gaussian output), matching the CFOUR/GAMESS/NWChem convention:
+```python
+"gaussian": "Gaussian, Inc.",
+```
+
+### `test_local_options_ncores` (`test_canonical_config.py`) <!-- rq-3a18d6af -->
+
+Validates that thread/core configuration flows through to the program.
+
+The Gaussian harness has `thread_parallel=True`, so a `stdout_ref` regex is required.
+
+**Required `stdout_ref` entry**: Gaussian writes `%NProcShared=<N>` to the Link 0
+section of the `.com` file and the log file header echoes `Will use up to <N>
+processors` or a similar line. The exact pattern must be determined empirically. A
+candidate regex:
+```python
+"gaussian": rf"NProcShared={ncores}",
+```
+This requires the input echo or log to contain the NProcShared value. If it does not
+appear in stdout, an alternative freebie pattern may be needed, with a comment
+explaining why.
+
+### `test_protocol_native` (`test_canonical_fields.py`) <!-- rq-c01c892e -->
+
+Validates the `native_files` protocol (`"none"`, `"input"`, `"all"`).
+
+**Depends on** the native_files key convention fix described above.
+
+**Required `input_ref` entry**: A regex matching content in the Gaussian input file
+(stored under the `"input"` key). The `.com` file always contains the route line:
+```python
+"gaussian": rf"#\s*HF/STO-3G",
+```
+
+**Required `all_ref` entry**: A tuple `(filename, regex)` for an ancillary output file
+present when `native == "all"`. The Gaussian log is the natural choice:
+```python
+"gaussian": ("gaussian.log", rf"Normal termination of Gaussian"),
+```
+
+### `test_hf_alignment` (`test_alignment.py`) <!-- rq-81bc1d68 -->
+
+Validates that output molecule geometry is correctly aligned to the input molecule
+across energy, gradient, and hessian drivers, with randomised input frame scrambling.
+Tests both RHF (closed-shell) and UHF (open-shell) references.
+
+**Required `inp` parametrizations**:
+
+RHF:
+```python
+pytest.param(
+    {"call": "gaussian", "reference": "rhf", "fcae": "ae", "keywords": {}},
+    id="hf  rhf ae: gaussian",
+    marks=using("gaussian"),
+),
+```
+
+UHF:
+```python
+pytest.param(
+    {"call": "gaussian", "reference": "uhf", "fcae": "ae", "keywords": {}},
+    id="hf  uhf ae: gaussian",
+    marks=using("gaussian"),
+),
+```
+
+No special keywords are needed: the Gaussian harness auto-prepends `"U"` to the method
+for open-shell systems (multiplicity > 1), and basis set names are passed through
+directly.
+
+**Reference data**: The standard suite reference file
+(`standard_suite_ref.py`) must include Gaussian HF energy and gradient/hessian
+reference values for the test molecules (`hf`, `bh3p`, `h2o`, `nh2`) at the
+`cc-pVDZ` and `aug-cc-pVDZ` basis sets. These values must be determined empirically
+by running Gaussian.
+
+### `test_sp_ccsd_t_rhf_full` (`test_standard_suite_ccsd(t).py`) <!-- rq-9aa3cac4 -->
+
+Validates CCSD(T) single-point energy on water (RHF reference) against a known value.
+
+**Required parametrization**:
+```python
+pytest.param("gaussian", "aug-cc-pVDZ", {}, marks=using("gaussian")),
+```
+
+**Reference value**: Gaussian will produce a CCSD(T)/aug-cc-pVDZ energy for water that
+may differ slightly from the values produced by other programs (the existing reference
+is -76.276030676767 Hartree). A Gaussian-specific reference value must be determined
+empirically by running the calculation, then hard-coded into the test with the same
+`atol = 1.0e-6` tolerance.
+
+## Gherkin Scenarios <!-- rq-e7c13c1e -->
+
+```gherkin
+Feature: Gaussian cross-program integration tests
+
+  Background:
+    Given the Gaussian executable (g16 or g09) is available on PATH
+    And cclib is importable
+    And GaussianHarness is registered in _canonical_methods as ("gaussian", {"method": "hf", "basis": "STO-3G"}, {})
+
+  # --- Canonical methods entry ---
+
+  @rq-647b596c
+  Scenario: Gaussian appears in _canonical_methods
+    When _canonical_methods is inspected
+    Then it contains a pytest.param for "gaussian" with model {"method": "hf", "basis": "STO-3G"}
+
+  # --- native_files key convention ---
+
+  @rq-f13e0d24
+  Scenario: parse_output uses standard "input" key in native_files
+    Given a successful HF/STO-3G energy calculation on hydrogen
+    When GaussianHarness.compute() returns an AtomicResult
+    Then native_files contains the key "input" (not "gaussian.com")
+    And native_files["input"] contains the .com file content
+    And native_files contains the key "gaussian.log"
+    And native_files does not contain the keys "stdout" or "stderr"
+
+  # --- Memory test ---
+
+  @rq-65cb367e
+  Scenario: Memory configuration is applied with 1.555 GiB total node memory
+    Given a TaskConfig with memory = 1.555 GiB and ncores = 1
+    When a HF/STO-3G energy calculation on hydrogen is run through qcng.compute
+    Then the result is successful
+    And the Gaussian input or output contains evidence of the memory setting
+
+  @rq-2aa0e9e1
+  Scenario: Memory configuration is not overridden by conflicting DSL keywords
+    Given a TaskConfig with memory = 1.555 GiB
+    And no conflicting memory keyword is provided (Gaussian memory is Link 0, not a route keyword)
+    When a HF/STO-3G energy calculation on hydrogen is run
+    Then the result is successful
+    And the memory setting matches the TaskConfig value
+
+  # --- Scratch test ---
+
+  @rq-71824b99
+  Scenario: Scratch directory is used and files are left behind when scratch_messy=True
+    Given a TaskConfig with a custom scratch_directory and scratch_messy = True
+    When a HF/STO-3G energy calculation on hydrogen is run through qcng.compute
+    Then the result is successful
+    And the file "*/gaussian.log" exists in the scratch directory
+
+  # --- Ncores test ---
+
+  @rq-519fbe49
+  Scenario: Single-core execution succeeds
+    Given a TaskConfig with ncores = 1
+    When a HF/STO-3G energy calculation on hydrogen is run through qcng.compute
+    Then the result is successful
+
+  @rq-4252ac2d
+  Scenario: Multi-core execution succeeds and ncores is reflected in output
+    Given a TaskConfig with ncores = 3
+    When a HF/STO-3G energy calculation on hydrogen is run through qcng.compute
+    Then the result is successful
+    And the Gaussian output contains evidence that 3 processors were requested
+
+  # --- native_files protocol ---
+
+  @rq-8df082e3
+  Scenario: native_files protocol "none" returns empty native_files
+    Given an AtomicInput with protocols.native_files = "none"
+    When a HF/STO-3G gradient calculation on hydrogen is run through qcng.compute
+    Then the result is successful
+    And native_files is empty
+
+  @rq-923b3212
+  Scenario: native_files protocol "input" returns only the input file
+    Given an AtomicInput with protocols.native_files = "input"
+    When a HF/STO-3G gradient calculation on hydrogen is run through qcng.compute
+    Then the result is successful
+    And native_files contains exactly the key "input"
+    And native_files["input"] matches the regex "#\s*HF/STO-3G"
+
+  @rq-aa991a3a
+  Scenario: native_files protocol "all" returns input and output files
+    Given an AtomicInput with protocols.native_files = "all"
+    When a HF/STO-3G gradient calculation on hydrogen is run through qcng.compute
+    Then the result is successful
+    And native_files contains the key "input"
+    And native_files contains the key "gaussian.log"
+    And native_files["gaussian.log"] matches the regex "Normal termination of Gaussian"
+
+  @rq-d87ddeb8
+  Scenario: native_files never contains "stdout" or "stderr"
+    Given an AtomicInput with protocols.native_files = "all"
+    When a HF/STO-3G gradient calculation on hydrogen is run through qcng.compute
+    Then native_files does not contain "stdout"
+    And native_files does not contain "stderr"
+    And extras does not contain "outfiles"
+
+  # --- HF Alignment (RHF) ---
+
+  @rq-ba0f397f
+  Scenario: RHF energy is invariant to input frame scrambling
+    Given a closed-shell molecule (e.g. h2o) with randomly scrambled Cartesian frame
+    And the input uses method "hf" with a cc-pVDZ or aug-cc-pVDZ basis
+    And keywords = {}
+    When qcng.compute is called with program "gaussian" and driver "energy"
+    Then the result is successful
+    And the return_result matches the reference energy within tolerance
+
+  @rq-637d486d
+  Scenario: RHF gradient is correctly aligned to the (scrambled) input frame
+    Given a closed-shell molecule with randomly scrambled Cartesian frame and fix_com=True, fix_orientation=True
+    And the input uses method "hf" with a cc-pVDZ basis
+    When qcng.compute is called with program "gaussian" and driver "gradient"
+    Then the result is successful
+    And the return_result gradient matches the reference gradient (transformed to the scrambled frame) within tolerance
+
+  @rq-87c8fb49
+  Scenario: RHF hessian is correctly aligned to the (scrambled) input frame
+    Given a closed-shell molecule with randomly scrambled Cartesian frame and fix_com=True, fix_orientation=True
+    And the input uses method "hf" with a cc-pVDZ basis
+    When qcng.compute is called with program "gaussian" and driver "hessian"
+    Then the result is successful
+    And the return_result hessian matches the reference hessian (transformed to the scrambled frame) within tolerance
+
+  @rq-6a889dea
+  Scenario: UHF energy is invariant to input frame scrambling
+    Given an open-shell molecule (e.g. nh2, multiplicity=2) with randomly scrambled Cartesian frame
+    And the input uses method "hf" with a cc-pVDZ or aug-cc-pVDZ basis
+    And keywords = {}
+    When qcng.compute is called with program "gaussian" and driver "energy"
+    Then the result is successful
+    And the return_result matches the reference UHF energy within tolerance
+
+  @rq-349bf8c3
+  Scenario: UHF gradient is correctly aligned to the (scrambled) input frame
+    Given an open-shell molecule with randomly scrambled Cartesian frame and fix_com=True, fix_orientation=True
+    And the input uses method "hf" with a cc-pVDZ basis
+    When qcng.compute is called with program "gaussian" and driver "gradient"
+    Then the result is successful
+    And the return_result gradient matches the reference UHF gradient within tolerance
+
+  @rq-5d9b0b40
+  Scenario: UHF hessian is correctly aligned to the (scrambled) input frame
+    Given an open-shell molecule with randomly scrambled Cartesian frame and fix_com=True, fix_orientation=True
+    And the input uses method "hf" with a cc-pVDZ basis
+    When qcng.compute is called with program "gaussian" and driver "hessian"
+    Then the result is successful
+    And the return_result hessian matches the reference UHF hessian within tolerance
+
+  # --- CCSD(T) standard suite ---
+
+  @rq-475c8796
+  Scenario: CCSD(T)/aug-cc-pVDZ RHF energy on water matches Gaussian-specific reference
+    Given the water molecule (H2O, charge=0, multiplicity=1) in Bohr coordinates
+    And the model is {"method": "ccsd(t)", "basis": "aug-cc-pVDZ"}
+    And keywords = {}
+    When qcng.compute is called with program "gaussian" and driver "energy"
+    Then the result is successful
+    And provenance is present
+    And return_result matches the Gaussian-specific CCSD(T) reference value within atol = 1.0e-6
+```
+
+## Implementation Notes <!-- rq-f28b3bed -->
+
+### Empirical Reference Values <!-- rq-56e891e7 -->
+
+The following reference values must be determined by running Gaussian before the
+tests can be finalised:
+
+1. **CCSD(T)/aug-cc-pVDZ water energy** --- for `test_sp_ccsd_t_rhf_full`.
+2. **HF/{cc-pVDZ,aug-cc-pVDZ} energies/gradients/hessians** for `hf`, `bh3p`, `h2o`,
+   `nh2` molecules --- for `test_hf_alignment` via `standard_suite_ref.py`.
+3. **`stdout_ref` patterns** for memory and ncores tests --- determined by inspecting
+   actual Gaussian log output for the relevant Link 0 echo lines.
+
+### Files Modified <!-- rq-6423b98b -->
+
+| File | Change |
+|------|--------|
+| `qcengine/programs/gaussian/runner.py` | Fix `parse_output` to use outfiles-passthrough pattern for `native_files` |
+| `qcengine/programs/tests/test_canonical_config.py` | Add Gaussian to `_canonical_methods`; add `stdout_ref`, `scratch_sample`, `memory_trickery` entries |
+| `qcengine/programs/tests/test_canonical_fields.py` | Add `input_ref` and `all_ref` entries for Gaussian |
+| `qcengine/programs/tests/test_alignment.py` | Add RHF and UHF `inp` parametrizations for Gaussian |
+| `qcengine/programs/tests/test_standard_suite_ccsd(t).py` | Add Gaussian parametrization with empirical reference value |
+| `qcengine/programs/tests/standard_suite_ref.py` | Add Gaussian HF reference data for alignment test molecules |

--- a/rqm/gaussian/runner.md
+++ b/rqm/gaussian/runner.md
@@ -1,0 +1,300 @@
+# Feature: Gaussian Harness — Runner <!-- rq-436a54d5 -->
+
+This document specifies the top-level harness class (`GaussianHarness`) that integrates
+Gaussian 16 (or Gaussian 09) into QCEngine. It follows the multi-file subdirectory
+pattern established by the GAMESS and NWChem harnesses. The harness lives under
+`qcengine/programs/gaussian/` and is registered alongside other programs in
+`qcengine/programs/base.py`.
+
+Related requirements files:
+- `input-builder.md` — `.com` file construction (germinate, keywords)
+- `harvester.md`     — cclib-based output parsing
+
+## Feature API <!-- rq-cf6fdf8a -->
+
+### Class `GaussianHarness(ProgramHarness)` <!-- rq-998da273 -->
+
+Located at `qcengine/programs/gaussian/runner.py`.
+
+**`_defaults`**:
+
+| Key              | Value       |
+|------------------|-------------|
+| `name`           | `"Gaussian"` |
+| `scratch`        | `True`      |
+| `thread_safe`    | `False`     |
+| `thread_parallel`| `True`      |
+| `node_parallel`  | `False`     |
+| `managed_memory` | `True`      |
+
+#### `found(raise_error: bool = False) -> bool`
+
+- Returns `True` if and only if **both** of the following hold:
+  1. `g16` or `g09` is present on `PATH` (checked in that priority order via `which`).
+  2. `cclib` is importable (checked via `which_import`).
+- If either condition fails and `raise_error=False`, returns `False`.
+- If either condition fails and `raise_error=True`, raises `ModuleNotFoundError` with a
+  descriptive install hint.
+- Does not execute any binary.
+
+#### `get_version() -> str`
+
+- Calls `found(raise_error=True)`.
+- Runs the located Gaussian executable with a blank `.com` input file; captures stdout.
+- Searches for a line matching `Gaussian <NN>, Revision <TAG>,` (e.g. `Gaussian 16,
+  Revision C.02,`) and returns a safe version string of the form `"<NN>.<TAG>"` (e.g.
+  `"16.C.02"`), produced via `safe_version`.
+- Caches the result in `version_cache: Dict[str, str]` keyed by the absolute executable
+  path so the binary is not re-executed within the same process.
+- Raises `UnknownError` if no matching version line is found in the output.
+
+#### `compute(input_model: AtomicInput, config: TaskConfig) -> AtomicResult`
+
+- Calls `found(raise_error=True)`.
+- Raises `InputError` immediately if `input_model.model.basis` is a `BasisSet` instance
+  (only string basis names are supported).
+- Calls `self.build_input(input_model, config)` to produce the job record.
+- Calls `self.execute(job_inputs)` to run Gaussian.
+- Inspects the collected log for known fatal error strings (see Error Dispatch below).
+- On success, calls `self.parse_output(outfiles, input_model)` and returns the result.
+
+**Error dispatch** (applied to log content before calling `parse_output`):
+
+| Pattern in log | Exception raised |
+|----------------|-----------------|
+| `"galloc: could not allocate memory"` | `ResourceError` |
+| `"Ernie: is not defined as a Gaussian input file"` or `"Ernie: unrecognized"` | `InputError` |
+| `"Error in internal coordinate system"` | `InputError` |
+| `"Normal termination"` absent and no matched pattern above | `UnknownError` |
+
+#### `build_input(input_model: AtomicInput, config: TaskConfig, template: Optional[str] = None) -> Dict[str, Any]`
+
+- Raises `InputError` if `input_model.model.basis` is a `BasisSet` instance or `None`.
+- Delegates method/driver/multiplicity mapping to `muster_modelchem()` (germinate.py).
+- Delegates `.com` file assembly to `build_com_file()` (keywords.py).
+- Returns a dict:
+  ```python
+  {
+      "infiles": {"gaussian.com": <formatted .com string>},
+      "command": [<absolute path to g16 or g09>],
+      "scratch_directory": config.scratch_directory,
+      "scratch_messy": config.scratch_messy,
+  }
+  ```
+
+#### `execute(inputs: Dict[str, Any], ...) -> Tuple[bool, Dict]`
+
+- Calls `qcengine.util.execute()` with:
+  - `inputs["command"]` as the command.
+  - `inputs["infiles"]` (containing `"gaussian.com"`) as input files.
+  - `["gaussian.log"]` as the list of output files to collect.
+  - `scratch_directory` and `scratch_messy` forwarded from `inputs`.
+- Returns `(success, dexe)` where `dexe["outfiles"]["gaussian.log"]` holds the full log
+  text and `dexe["stdout"]` / `dexe["stderr"]` hold the process streams.
+
+#### `parse_output(outfiles: Dict[str, str], input_model: AtomicInput) -> AtomicResult`
+
+- Pops `"stdout"`, `"stderr"`, and `"input"` from `outfiles` before passing the rest to
+  `harvest()`.
+- Calls `harvest(input_model.molecule, method, log_text)` from `harvester.py` to obtain
+  `(qcvars, grad, hess, mol)`.
+- Raises `UnknownError` (wrapping the raw exception) if `harvest()` raises.
+- When `grad is not None`, sets both `"CURRENT GRADIENT"` and
+  `"<METHOD_UPPER> TOTAL GRADIENT"` in `qcvars`.
+- When `hess is not None`, sets both `"CURRENT HESSIAN"` and
+  `"<METHOD_UPPER> TOTAL HESSIAN"` in `qcvars`.
+- Resolves `return_result` from `qcvars`:
+  - Driver `"properties"` → `qcvars["CURRENT ENERGY"]`
+  - All other drivers → `qcvars[f"CURRENT {driver.upper()}"]`
+- Raises `UnknownError` if the required `qcvars` key is absent.
+- Calls `build_out(qcvars)` and `build_atomicproperties(qcvars)`.
+- Returns:
+  ```python
+  AtomicResult(**{
+      **input_model.dict(),
+      "schema_version": 1,
+      "molecule": mol,
+      "extras": {**input_model.extras, "qcvars": qcvars_serialised},
+      "native_files": {"gaussian.com": input_text, "gaussian.log": log_text},
+      "properties": atprop,
+      "provenance": Provenance(creator="Gaussian", version=self.get_version(),
+                               routine="gaussian").dict(),
+      "return_result": retres,
+      "stderr": stderr,
+      "stdout": stdout,
+      "success": True,
+  })
+  ```
+
+### Registration <!-- rq-17196f6b -->
+
+`GaussianHarness` must be imported and registered in `qcengine/programs/base.py`:
+
+```python
+from .gaussian import GaussianHarness
+# ...
+register_program(GaussianHarness())
+```
+
+It must also be exported from `qcengine/programs/gaussian/__init__.py`.
+
+## Gaussian Executable Details <!-- rq-cb0f61f2 -->
+
+- Preferred executable: `g16`; fall back to `g09` if `g16` is not found.
+- Gaussian reads its input from a `.com` file passed as its sole command-line argument.
+- Gaussian writes its log to a file whose name derives from the `.com` file
+  (e.g. `gaussian.com` → `gaussian.log` in the scratch directory).
+- A non-zero exit code does **not** reliably signal failure; the log content is the
+  authoritative source of success/failure status.
+- `"Normal termination of Gaussian"` at the end of the log indicates success.
+
+## Gherkin Scenarios <!-- rq-2bd5902e -->
+
+```gherkin
+Feature: GaussianHarness runner
+
+  # --- found() ---
+
+  @rq-4cf7c460
+  Scenario: found() returns True when g16 and cclib are both available
+    Given "g16" is present on the PATH
+    And "cclib" is importable
+    When GaussianHarness.found() is called
+    Then it returns True
+
+  @rq-d3b8d8c3
+  Scenario: found() falls back to g09 when g16 is absent
+    Given "g16" is not on the PATH
+    And "g09" is present on the PATH
+    And "cclib" is importable
+    When GaussianHarness.found() is called
+    Then it returns True
+
+  @rq-8e21b7d7
+  Scenario: found() returns False when neither g16 nor g09 is on PATH
+    Given "g16" is not on the PATH
+    And "g09" is not on the PATH
+    When GaussianHarness.found() is called
+    Then it returns False
+
+  @rq-b5e72c6d
+  Scenario: found() returns False when cclib is not importable
+    Given "g16" is present on the PATH
+    But "cclib" is not importable
+    When GaussianHarness.found() is called
+    Then it returns False
+
+  @rq-bd98d417
+  Scenario: found(raise_error=True) raises ModuleNotFoundError when g16 is missing
+    Given "g16" is not on the PATH
+    And "g09" is not on the PATH
+    When GaussianHarness.found(raise_error=True) is called
+    Then ModuleNotFoundError is raised
+
+  @rq-242ef1d8
+  Scenario: found(raise_error=True) raises ModuleNotFoundError when cclib is missing
+    Given "g16" is present on the PATH
+    But "cclib" is not importable
+    When GaussianHarness.found(raise_error=True) is called
+    Then ModuleNotFoundError is raised
+
+  # --- get_version() ---
+
+  @rq-186c5060
+  Scenario: get_version() returns a normalised version string for Gaussian 16
+    Given "g16" is present on the PATH
+    And running g16 with blank input produces a line "Gaussian 16, Revision C.02,"
+    When GaussianHarness.get_version() is called
+    Then it returns "16.C.02"
+
+  @rq-850ede4f
+  Scenario: get_version() returns a normalised version string for Gaussian 09
+    Given only "g09" is present on the PATH
+    And running g09 with blank input produces a line "Gaussian 09, Revision D.01,"
+    When GaussianHarness.get_version() is called
+    Then it returns "09.D.01"
+
+  @rq-3e134642
+  Scenario: get_version() caches the result after the first call
+    Given "g16" is present on the PATH and has been queried once
+    When GaussianHarness.get_version() is called a second time
+    Then the Gaussian binary is not re-executed
+    And the same version string is returned
+
+  @rq-20d9a784
+  Scenario: get_version() raises UnknownError if version cannot be parsed
+    Given "g16" is present on the PATH
+    And running g16 produces output with no "Gaussian NN, Revision" line
+    When GaussianHarness.get_version() is called
+    Then UnknownError is raised
+
+  # --- compute() error paths ---
+
+  @rq-c77a2c13
+  Scenario: compute() raises InputError when model.basis is a BasisSet object
+    Given an AtomicInput whose model.basis is a BasisSet object (not a string)
+    When GaussianHarness.compute() is called
+    Then InputError is raised without executing Gaussian
+
+  @rq-165224fc
+  Scenario: compute() raises InputError when the log contains an unrecognised-keyword error
+    Given Gaussian runs and its log contains "Ernie: is not defined as a Gaussian input file"
+    When GaussianHarness.compute() is called
+    Then InputError is raised
+
+  @rq-edb73b83
+  Scenario: compute() raises InputError on internal coordinate error
+    Given Gaussian runs and its log contains "Error in internal coordinate system"
+    When GaussianHarness.compute() is called
+    Then InputError is raised
+
+  @rq-a4c449da
+  Scenario: compute() raises ResourceError on memory allocation failure
+    Given Gaussian runs and its log contains "galloc: could not allocate memory"
+    When GaussianHarness.compute() is called
+    Then ResourceError is raised
+
+  @rq-71aceb93
+  Scenario: compute() raises UnknownError on abnormal termination with no known pattern
+    Given Gaussian runs and its log does not contain "Normal termination"
+    And the log does not match any known error pattern
+    When GaussianHarness.compute() is called
+    Then UnknownError is raised
+
+  # --- compute() success paths ---
+
+  @rq-99807237
+  Scenario: compute() returns AtomicResult for a successful energy calculation
+    Given a valid AtomicInput for HF/STO-3G energy on water
+    And Gaussian terminates normally
+    When GaussianHarness.compute() is called
+    Then an AtomicResult is returned with success=True
+    And return_result is a float representing the total energy in Hartree
+    And native_files contains keys "gaussian.com" and "gaussian.log"
+    And provenance.creator equals "Gaussian"
+
+  @rq-e62578e2
+  Scenario: compute() returns AtomicResult with gradient for gradient driver
+    Given a valid AtomicInput for HF/STO-3G gradient on water (3 atoms)
+    And Gaussian terminates normally
+    When GaussianHarness.compute() is called
+    Then an AtomicResult is returned with success=True
+    And return_result is a flat list of 9 floats (3 atoms × 3 Cartesian components)
+
+  @rq-4d683dac
+  Scenario: compute() returns AtomicResult with Hessian for hessian driver
+    Given a valid AtomicInput for HF/STO-3G hessian on water (3 atoms)
+    And Gaussian terminates normally
+    When GaussianHarness.compute() is called
+    Then an AtomicResult is returned with success=True
+    And return_result is a flat list of 81 floats (9 × 9 Hessian)
+
+  @rq-1a051bc2
+  Scenario: compute() returns AtomicResult for properties driver
+    Given a valid AtomicInput for HF/STO-3G properties on water
+    And Gaussian terminates normally
+    When GaussianHarness.compute() is called
+    Then an AtomicResult is returned with success=True
+    And return_result is a float (the total energy)
+    And extras["qcvars"] contains "CURRENT ENERGY"
+```

--- a/rqm/gaussian/runner.md
+++ b/rqm/gaussian/runner.md
@@ -51,7 +51,7 @@ Located at `qcengine/programs/gaussian/runner.py`.
 #### `compute(input_model: AtomicInput, config: TaskConfig) -> AtomicResult`
 
 - Calls `found(raise_error=True)`.
-- Raises `InputError` immediately if `input_model.model.basis` is a `BasisSet` instance
+- Raises `InputError` immediately if `input_model.specification.model.basis` is a `BasisSet` instance
   (only string basis names are supported).
 - Calls `self.build_input(input_model, config)` to produce the job record.
 - Calls `self.execute(job_inputs)` to run Gaussian.
@@ -69,7 +69,7 @@ Located at `qcengine/programs/gaussian/runner.py`.
 
 #### `build_input(input_model: AtomicInput, config: TaskConfig, template: Optional[str] = None) -> Dict[str, Any]`
 
-- Raises `InputError` if `input_model.model.basis` is a `BasisSet` instance or `None`.
+- Raises `InputError` if `input_model.specification.model.basis` is a `BasisSet` instance or `None`.
 - Delegates method/driver/multiplicity mapping to `muster_modelchem()` (germinate.py).
 - Delegates `.com` file assembly to `build_com_file()` (keywords.py).
 - Returns a dict:
@@ -111,14 +111,14 @@ Located at `qcengine/programs/gaussian/runner.py`.
 - Returns:
   ```python
   AtomicResult(**{
-      **input_model.dict(),
-      "schema_version": 1,
+      "schema_version": 2,
+      "input_data": input_model,
       "molecule": mol,
-      "extras": {**input_model.extras, "qcvars": qcvars_serialised},
+      "extras": {**input_model.specification.extras, "qcvars": qcvars_serialised},
       "native_files": {"gaussian.com": input_text, "gaussian.log": log_text},
       "properties": atprop,
       "provenance": Provenance(creator="Gaussian", version=self.get_version(),
-                               routine="gaussian").dict(),
+                               routine="gaussian").model_dump(),
       "return_result": retres,
       "stderr": stderr,
       "stdout": stdout,

--- a/rqm/registry.json
+++ b/rqm/registry.json
@@ -1,0 +1,728 @@
+{
+  "rq-0052a2c7": {
+    "decl": "### `build_com_file(link0: Dict[str, Any], route_line: str, title: str, charge: int, multiplicity: int, atom_block: str) -> str`",
+    "file": "gaussian/input-builder",
+    "level": 3,
+    "refs": [],
+    "title": "`build_com_file(link0: Dict[str, Any], route_line: str, title: str, charge: int, multiplicity: int, atom_block: str) -> str`",
+    "type": "section"
+  },
+  "rq-0199bb02": {
+    "decl": "Scenario: HF method maps to \"HF\" method string",
+    "file": "gaussian/input-builder",
+    "refs": [],
+    "title": "HF method maps to \"HF\" method string",
+    "type": "scenario"
+  },
+  "rq-058819da": {
+    "decl": "## Gherkin Scenarios",
+    "file": "gaussian/harvester",
+    "level": 2,
+    "refs": [],
+    "title": "Gherkin Scenarios",
+    "type": "section"
+  },
+  "rq-0753cd03": {
+    "decl": "- `\"NUCLEAR REPULSION ENERGY\"` — from parsed geometry.",
+    "file": "gaussian/harvester",
+    "refs": [],
+    "title": "- `\"NUCLEAR REPULSION ENERGY\"` — from parsed geometry.",
+    "type": "api-item"
+  },
+  "rq-079b1e22": {
+    "decl": "Scenario: Method matching is case-insensitive",
+    "file": "gaussian/input-builder",
+    "refs": [],
+    "title": "Method matching is case-insensitive",
+    "type": "scenario"
+  },
+  "rq-0aa99076": {
+    "decl": "Scenario: BasisSet object for model.basis raises InputError",
+    "file": "gaussian/input-builder",
+    "refs": [],
+    "title": "BasisSet object for model.basis raises InputError",
+    "type": "scenario"
+  },
+  "rq-0b4cf843": {
+    "decl": "Scenario: Nuclear repulsion energy mismatch raises ValueError",
+    "file": "gaussian/harvester",
+    "refs": [],
+    "title": "Nuclear repulsion energy mismatch raises ValueError",
+    "type": "scenario"
+  },
+  "rq-12c41d5e": {
+    "decl": "Scenario: Absent normal termination line is classified as abnormal",
+    "file": "gaussian/harvester",
+    "refs": [],
+    "title": "Absent normal termination line is classified as abnormal",
+    "type": "scenario"
+  },
+  "rq-165224fc": {
+    "decl": "Scenario: compute() raises InputError when the log contains an unrecognised-keyword error",
+    "file": "gaussian/runner",
+    "refs": [],
+    "title": "compute() raises InputError when the log contains an unrecognised-keyword error",
+    "type": "scenario"
+  },
+  "rq-17196f6b": {
+    "decl": "### Registration",
+    "file": "gaussian/runner",
+    "level": 3,
+    "refs": [],
+    "title": "Registration",
+    "type": "section"
+  },
+  "rq-186c5060": {
+    "decl": "Scenario: get_version() returns a normalised version string for Gaussian 16",
+    "file": "gaussian/runner",
+    "refs": [],
+    "title": "get_version() returns a normalised version string for Gaussian 16",
+    "type": "scenario"
+  },
+  "rq-1a01df8f": {
+    "decl": "## Feature API",
+    "file": "gaussian/harvester",
+    "level": 2,
+    "refs": [],
+    "title": "Feature API",
+    "type": "section"
+  },
+  "rq-1a051bc2": {
+    "decl": "Scenario: compute() returns AtomicResult for properties driver",
+    "file": "gaussian/runner",
+    "refs": [],
+    "title": "compute() returns AtomicResult for properties driver",
+    "type": "scenario"
+  },
+  "rq-1b7ae62e": {
+    "decl": "Scenario: Parse CCSD total energy",
+    "file": "gaussian/harvester",
+    "refs": [],
+    "title": "Parse CCSD total energy",
+    "type": "scenario"
+  },
+  "rq-2052a2fa": {
+    "decl": "Scenario: CCSD method maps to \"CCSD\"",
+    "file": "gaussian/input-builder",
+    "refs": [],
+    "title": "CCSD method maps to \"CCSD\"",
+    "type": "scenario"
+  },
+  "rq-20d9a784": {
+    "decl": "Scenario: get_version() raises UnknownError if version cannot be parsed",
+    "file": "gaussian/runner",
+    "refs": [],
+    "title": "get_version() raises UnknownError if version cannot be parsed",
+    "type": "scenario"
+  },
+  "rq-23d8b2c6": {
+    "decl": "Scenario: The .com file ends with a trailing blank line",
+    "file": "gaussian/input-builder",
+    "refs": [],
+    "title": "The .com file ends with a trailing blank line",
+    "type": "scenario"
+  },
+  "rq-242ef1d8": {
+    "decl": "Scenario: found(raise_error=True) raises ModuleNotFoundError when cclib is missing",
+    "file": "gaussian/runner",
+    "refs": [],
+    "title": "found(raise_error=True) raises ModuleNotFoundError when cclib is missing",
+    "type": "scenario"
+  },
+  "rq-25c4ad49": {
+    "decl": "Scenario: Method already starting with U is not double-prefixed",
+    "file": "gaussian/input-builder",
+    "refs": [],
+    "title": "Method already starting with U is not double-prefixed",
+    "type": "scenario"
+  },
+  "rq-2ad053f2": {
+    "decl": "## Feature API",
+    "file": "gaussian/input-builder",
+    "level": 2,
+    "refs": [],
+    "title": "Feature API",
+    "type": "section"
+  },
+  "rq-2bd5902e": {
+    "decl": "## Gherkin Scenarios",
+    "file": "gaussian/runner",
+    "level": 2,
+    "refs": [],
+    "title": "Gherkin Scenarios",
+    "type": "section"
+  },
+  "rq-342a2ca3": {
+    "decl": "Scenario: Charge and multiplicity are on one line in the molecule section",
+    "file": "gaussian/input-builder",
+    "refs": [],
+    "title": "Charge and multiplicity are on one line in the molecule section",
+    "type": "scenario"
+  },
+  "rq-344f3432": {
+    "decl": "Scenario: No Hessian when running energy-only or gradient calculation",
+    "file": "gaussian/harvester",
+    "refs": [],
+    "title": "No Hessian when running energy-only or gradient calculation",
+    "type": "scenario"
+  },
+  "rq-36736115": {
+    "decl": "Scenario: Parse gradient and negate forces",
+    "file": "gaussian/harvester",
+    "refs": [],
+    "title": "Parse gradient and negate forces",
+    "type": "scenario"
+  },
+  "rq-37f40e92": {
+    "decl": "- `\"HF TOTAL ENERGY\"` — always set from `ccdata.scfenergies[-1]` (in Hartree).",
+    "file": "gaussian/harvester",
+    "refs": [],
+    "title": "- `\"HF TOTAL ENERGY\"` — always set from `ccdata.scfenergies[-1]` (in Hartree).",
+    "type": "api-item"
+  },
+  "rq-3b0adf96": {
+    "decl": "Scenario: No gradient attribute in ccdata when running energy-only calculation",
+    "file": "gaussian/harvester",
+    "refs": [],
+    "title": "No gradient attribute in ccdata when running energy-only calculation",
+    "type": "scenario"
+  },
+  "rq-3c343d2a": {
+    "decl": "### `build_route_line(method_string: str, basis: str, job_type: str, extra_keywords: Dict[str, str], user_keywords: Dict[str, Any]) -> str`",
+    "file": "gaussian/input-builder",
+    "level": 3,
+    "refs": [],
+    "title": "`build_route_line(method_string: str, basis: str, job_type: str, extra_keywords: Dict[str, str], user_keywords: Dict[str, Any]) -> str`",
+    "type": "section"
+  },
+  "rq-3e134642": {
+    "decl": "Scenario: get_version() caches the result after the first call",
+    "file": "gaussian/runner",
+    "refs": [],
+    "title": "get_version() caches the result after the first call",
+    "type": "scenario"
+  },
+  "rq-4336c3cd": {
+    "decl": "- `ValueError` if no coordinate information can be extracted from the log.",
+    "file": "gaussian/harvester",
+    "refs": [],
+    "title": "ValueError",
+    "type": "api-item"
+  },
+  "rq-436a54d5": {
+    "decl": "# Feature: Gaussian Harness — Runner",
+    "file": "gaussian/runner",
+    "refs": [],
+    "title": "Feature: Gaussian Harness — Runner",
+    "type": "file"
+  },
+  "rq-4ad16d95": {
+    "decl": "Scenario: Memory directive uses integer GB for whole-number memory",
+    "file": "gaussian/input-builder",
+    "refs": [],
+    "title": "Memory directive uses integer GB for whole-number memory",
+    "type": "scenario"
+  },
+  "rq-4c4a1542": {
+    "decl": "Scenario: Parse dipole moment for properties driver",
+    "file": "gaussian/harvester",
+    "refs": [],
+    "title": "Parse dipole moment for properties driver",
+    "type": "scenario"
+  },
+  "rq-4cf7c460": {
+    "decl": "Scenario: found() returns True when g16 and cclib are both available",
+    "file": "gaussian/runner",
+    "refs": [],
+    "title": "found() returns True when g16 and cclib are both available",
+    "type": "scenario"
+  },
+  "rq-4d683dac": {
+    "decl": "Scenario: compute() returns AtomicResult with Hessian for hessian driver",
+    "file": "gaussian/runner",
+    "refs": [],
+    "title": "compute() returns AtomicResult with Hessian for hessian driver",
+    "type": "scenario"
+  },
+  "rq-4d763c6d": {
+    "decl": "- `multiplicity` — from `AtomicInput.molecule.molecular_multiplicity`.",
+    "file": "gaussian/input-builder",
+    "refs": [],
+    "title": "multiplicity",
+    "type": "api-item"
+  },
+  "rq-5053204b": {
+    "decl": "Scenario: Ghost atoms in the molecule raise InputError",
+    "file": "gaussian/input-builder",
+    "refs": [],
+    "title": "Ghost atoms in the molecule raise InputError",
+    "type": "scenario"
+  },
+  "rq-53f8ed12": {
+    "decl": "Scenario: Missing Mulliken charges do not raise an error",
+    "file": "gaussian/harvester",
+    "refs": [],
+    "title": "Missing Mulliken charges do not raise an error",
+    "type": "scenario"
+  },
+  "rq-546faafb": {
+    "decl": "Scenario: MP2 method maps to \"MP2\"",
+    "file": "gaussian/input-builder",
+    "refs": [],
+    "title": "MP2 method maps to \"MP2\"",
+    "type": "scenario"
+  },
+  "rq-578bb785": {
+    "decl": "Scenario: Parse MP2 total and correlation energies",
+    "file": "gaussian/harvester",
+    "refs": [],
+    "title": "Parse MP2 total and correlation energies",
+    "type": "scenario"
+  },
+  "rq-6bff3228": {
+    "decl": "Scenario: Parse DFT total energy (treated as HF SCF energy by cclib)",
+    "file": "gaussian/harvester",
+    "refs": [],
+    "title": "Parse DFT total energy (treated as HF SCF energy by cclib)",
+    "type": "scenario"
+  },
+  "rq-6d73bb9e": {
+    "decl": "Scenario: Doublet automatically prepends U to HF",
+    "file": "gaussian/input-builder",
+    "refs": [],
+    "title": "Doublet automatically prepends U to HF",
+    "type": "scenario"
+  },
+  "rq-7049aaa5": {
+    "decl": "Scenario: SCF is an alias for HF",
+    "file": "gaussian/input-builder",
+    "refs": [],
+    "title": "SCF is an alias for HF",
+    "type": "scenario"
+  },
+  "rq-7152455e": {
+    "decl": "Scenario: User keyword is appended to route line",
+    "file": "gaussian/input-builder",
+    "refs": [],
+    "title": "User keyword is appended to route line",
+    "type": "scenario"
+  },
+  "rq-71aceb93": {
+    "decl": "Scenario: compute() raises UnknownError on abnormal termination with no known pattern",
+    "file": "gaussian/runner",
+    "refs": [],
+    "title": "compute() raises UnknownError on abnormal termination with no known pattern",
+    "type": "scenario"
+  },
+  "rq-71b27e68": {
+    "decl": "Scenario: Parse HF total energy from a closed-shell log",
+    "file": "gaussian/harvester",
+    "refs": [],
+    "title": "Parse HF total energy from a closed-shell log",
+    "type": "scenario"
+  },
+  "rq-74e0110c": {
+    "decl": "## Molecule Block Construction",
+    "file": "gaussian/input-builder",
+    "level": 2,
+    "refs": [],
+    "title": "Molecule Block Construction",
+    "type": "section"
+  },
+  "rq-82942b90": {
+    "decl": "Scenario: Hessian driver produces \"Freq\"",
+    "file": "gaussian/input-builder",
+    "refs": [],
+    "title": "Hessian driver produces \"Freq\"",
+    "type": "scenario"
+  },
+  "rq-850ede4f": {
+    "decl": "Scenario: get_version() returns a normalised version string for Gaussian 09",
+    "file": "gaussian/runner",
+    "refs": [],
+    "title": "get_version() returns a normalised version string for Gaussian 09",
+    "type": "scenario"
+  },
+  "rq-851d782c": {
+    "decl": "Scenario: Unknown method is passed through verbatim (uppercased)",
+    "file": "gaussian/input-builder",
+    "refs": [],
+    "title": "Unknown method is passed through verbatim (uppercased)",
+    "type": "scenario"
+  },
+  "rq-86c27356": {
+    "decl": "- `InputError` — if `driver` is not one of the four supported values.",
+    "file": "gaussian/input-builder",
+    "refs": [],
+    "title": "InputError",
+    "type": "api-item"
+  },
+  "rq-8d6fc024": {
+    "decl": "### Output Molecule Construction",
+    "file": "gaussian/harvester",
+    "level": 3,
+    "refs": [],
+    "title": "Output Molecule Construction",
+    "type": "section"
+  },
+  "rq-8e21b7d7": {
+    "decl": "Scenario: found() returns False when neither g16 nor g09 is on PATH",
+    "file": "gaussian/runner",
+    "refs": [],
+    "title": "found() returns False when neither g16 nor g09 is on PATH",
+    "type": "scenario"
+  },
+  "rq-90141f40": {
+    "decl": "Scenario: Normal termination line is present in a successful log",
+    "file": "gaussian/harvester",
+    "refs": [],
+    "title": "Normal termination line is present in a successful log",
+    "type": "scenario"
+  },
+  "rq-90604835": {
+    "decl": "- `ValueError` if the nuclear repulsion energy of the parsed geometry deviates from",
+    "file": "gaussian/harvester",
+    "refs": [],
+    "title": "ValueError",
+    "type": "api-item"
+  },
+  "rq-92492893": {
+    "decl": "Scenario: CCSD(T) method maps to \"CCSD(T)\"",
+    "file": "gaussian/input-builder",
+    "refs": [],
+    "title": "CCSD(T) method maps to \"CCSD(T)\"",
+    "type": "scenario"
+  },
+  "rq-929a262a": {
+    "decl": "### QC Variables Populated",
+    "file": "gaussian/harvester",
+    "level": 3,
+    "refs": [],
+    "title": "QC Variables Populated",
+    "type": "section"
+  },
+  "rq-943856cc": {
+    "decl": "- `\"DIPOLE MOMENT\"` — magnitude of `ccdata.moments[1]` in Debye.",
+    "file": "gaussian/harvester",
+    "refs": [],
+    "title": "- `\"DIPOLE MOMENT\"` — magnitude of `ccdata.moments[1]` in Debye.",
+    "type": "api-item"
+  },
+  "rq-972b6470": {
+    "decl": "Scenario: Singlet uses method name as-is (no U prefix)",
+    "file": "gaussian/input-builder",
+    "refs": [],
+    "title": "Singlet uses method name as-is (no U prefix)",
+    "type": "scenario"
+  },
+  "rq-99807237": {
+    "decl": "Scenario: compute() returns AtomicResult for a successful energy calculation",
+    "file": "gaussian/runner",
+    "refs": [],
+    "title": "compute() returns AtomicResult for a successful energy calculation",
+    "type": "scenario"
+  },
+  "rq-998da273": {
+    "decl": "### Class `GaussianHarness(ProgramHarness)`",
+    "file": "gaussian/runner",
+    "level": 3,
+    "refs": [],
+    "title": "Class `GaussianHarness(ProgramHarness)`",
+    "type": "section"
+  },
+  "rq-9acd1ce5": {
+    "decl": "Scenario: Route line for gradient calculation",
+    "file": "gaussian/input-builder",
+    "refs": [],
+    "title": "Route line for gradient calculation",
+    "type": "scenario"
+  },
+  "rq-9cdf3f7d": {
+    "decl": "# Feature: Gaussian Harness — Input Builder",
+    "file": "gaussian/input-builder",
+    "refs": [],
+    "title": "Feature: Gaussian Harness — Input Builder",
+    "type": "file"
+  },
+  "rq-9d12489e": {
+    "decl": "# Feature: Gaussian Harness — Harvester",
+    "file": "gaussian/harvester",
+    "refs": [],
+    "title": "Feature: Gaussian Harness — Harvester",
+    "type": "file"
+  },
+  "rq-9ec1917a": {
+    "decl": "## Gaussian Input File Format",
+    "file": "gaussian/input-builder",
+    "level": 2,
+    "refs": [],
+    "title": "Gaussian Input File Format",
+    "type": "section"
+  },
+  "rq-a4c449da": {
+    "decl": "Scenario: compute() raises ResourceError on memory allocation failure",
+    "file": "gaussian/runner",
+    "refs": [],
+    "title": "compute() raises ResourceError on memory allocation failure",
+    "type": "scenario"
+  },
+  "rq-a76c3d7b": {
+    "decl": "Scenario: Output molecule geometry is constructed from ccdata",
+    "file": "gaussian/harvester",
+    "refs": [],
+    "title": "Output molecule geometry is constructed from ccdata",
+    "type": "scenario"
+  },
+  "rq-a88c706f": {
+    "decl": "- `method` — method string from `AtomicInput.model.method` (case-insensitive).",
+    "file": "gaussian/input-builder",
+    "refs": [],
+    "title": "method",
+    "type": "api-item"
+  },
+  "rq-a9194afb": {
+    "decl": "Scenario: Nuclear repulsion energy cross-check passes for consistent geometry",
+    "file": "gaussian/harvester",
+    "refs": [],
+    "title": "Nuclear repulsion energy cross-check passes for consistent geometry",
+    "type": "scenario"
+  },
+  "rq-af032242": {
+    "decl": "Scenario: Route line for closed-shell HF energy",
+    "file": "gaussian/input-builder",
+    "refs": [],
+    "title": "Route line for closed-shell HF energy",
+    "type": "scenario"
+  },
+  "rq-b49bb2a2": {
+    "decl": "- `driver` — one of `\"energy\"`, `\"gradient\"`, `\"hessian\"`, `\"properties\"`.",
+    "file": "gaussian/input-builder",
+    "refs": [],
+    "title": "driver",
+    "type": "api-item"
+  },
+  "rq-b5e72c6d": {
+    "decl": "Scenario: found() returns False when cclib is not importable",
+    "file": "gaussian/runner",
+    "refs": [],
+    "title": "found() returns False when cclib is not importable",
+    "type": "scenario"
+  },
+  "rq-b7c7b8cb": {
+    "decl": "Scenario: Log with no coordinate data raises ValueError",
+    "file": "gaussian/harvester",
+    "refs": [],
+    "title": "Log with no coordinate data raises ValueError",
+    "type": "scenario"
+  },
+  "rq-b819d8e0": {
+    "decl": "Scenario: Atom coordinates appear in Angstrom with at least 10 decimal places",
+    "file": "gaussian/input-builder",
+    "refs": [],
+    "title": "Atom coordinates appear in Angstrom with at least 10 decimal places",
+    "type": "scenario"
+  },
+  "rq-bb0a5d96": {
+    "decl": "## cclib Integration",
+    "file": "gaussian/harvester",
+    "level": 2,
+    "refs": [],
+    "title": "cclib Integration",
+    "type": "section"
+  },
+  "rq-bb775969": {
+    "decl": "Scenario: cclib parse failure propagates as-is",
+    "file": "gaussian/harvester",
+    "refs": [],
+    "title": "cclib parse failure propagates as-is",
+    "type": "scenario"
+  },
+  "rq-bd98d417": {
+    "decl": "Scenario: found(raise_error=True) raises ModuleNotFoundError when g16 is missing",
+    "file": "gaussian/runner",
+    "refs": [],
+    "title": "found(raise_error=True) raises ModuleNotFoundError when g16 is missing",
+    "type": "scenario"
+  },
+  "rq-c20746b1": {
+    "decl": "## Regex Fallback",
+    "file": "gaussian/harvester",
+    "level": 2,
+    "refs": [],
+    "title": "Regex Fallback",
+    "type": "section"
+  },
+  "rq-c266b9bb": {
+    "decl": "Scenario: Energy driver produces no job-type keyword",
+    "file": "gaussian/input-builder",
+    "refs": [],
+    "title": "Energy driver produces no job-type keyword",
+    "type": "scenario"
+  },
+  "rq-c5165f1f": {
+    "decl": "- `\"CURRENT ENERGY\"` — set to the highest-level energy available (see below).",
+    "file": "gaussian/harvester",
+    "refs": [],
+    "title": "- `\"CURRENT ENERGY\"` — set to the highest-level energy available (see below).",
+    "type": "api-item"
+  },
+  "rq-c77a2c13": {
+    "decl": "Scenario: compute() raises InputError when model.basis is a BasisSet object",
+    "file": "gaussian/runner",
+    "refs": [],
+    "title": "compute() raises InputError when model.basis is a BasisSet object",
+    "type": "scenario"
+  },
+  "rq-c7fd08b5": {
+    "decl": "- `\"MULLIKEN CHARGES\"` — from `ccdata.atomcharges[\"mulliken\"]`.",
+    "file": "gaussian/harvester",
+    "refs": [],
+    "title": "- `\"MULLIKEN CHARGES\"` — from `ccdata.atomcharges[\"mulliken\"]`.",
+    "type": "api-item"
+  },
+  "rq-c946c285": {
+    "decl": "Scenario: Triplet automatically prepends U to B3LYP",
+    "file": "gaussian/input-builder",
+    "refs": [],
+    "title": "Triplet automatically prepends U to B3LYP",
+    "type": "scenario"
+  },
+  "rq-cb0f61f2": {
+    "decl": "## Gaussian Executable Details",
+    "file": "gaussian/runner",
+    "level": 2,
+    "refs": [],
+    "title": "Gaussian Executable Details",
+    "type": "section"
+  },
+  "rq-cc549245": {
+    "decl": "## Gherkin Scenarios",
+    "file": "gaussian/input-builder",
+    "level": 2,
+    "refs": [],
+    "title": "Gherkin Scenarios",
+    "type": "section"
+  },
+  "rq-cd0d6637": {
+    "decl": "Scenario: Route line for properties calculation includes Pop=Full",
+    "file": "gaussian/input-builder",
+    "refs": [],
+    "title": "Route line for properties calculation includes Pop=Full",
+    "type": "scenario"
+  },
+  "rq-cf6fdf8a": {
+    "decl": "## Feature API",
+    "file": "gaussian/runner",
+    "level": 2,
+    "refs": [],
+    "title": "Feature API",
+    "type": "section"
+  },
+  "rq-d3b8d8c3": {
+    "decl": "Scenario: found() falls back to g09 when g16 is absent",
+    "file": "gaussian/runner",
+    "refs": [],
+    "title": "found() falls back to g09 when g16 is absent",
+    "type": "scenario"
+  },
+  "rq-d7e8161d": {
+    "decl": "Scenario: Link 0 section contains NProcShared and Mem directives",
+    "file": "gaussian/input-builder",
+    "refs": [],
+    "title": "Link 0 section contains NProcShared and Mem directives",
+    "type": "scenario"
+  },
+  "rq-d9434480": {
+    "decl": "### `harvest(in_mol: Molecule, method: str, log_content: str) -> Tuple[PreservingDict, Optional[np.ndarray], Optional[np.ndarray], Molecule]`",
+    "file": "gaussian/harvester",
+    "level": 3,
+    "refs": [],
+    "title": "`harvest(in_mol: Molecule, method: str, log_content: str) -> Tuple[PreservingDict, Optional[np.ndarray], Optional[np.ndarray], Molecule]`",
+    "type": "section"
+  },
+  "rq-db92093a": {
+    "decl": "Scenario: Memory directive rounds down to nearest integer GB (minimum 1)",
+    "file": "gaussian/input-builder",
+    "refs": [],
+    "title": "Memory directive rounds down to nearest integer GB (minimum 1)",
+    "type": "scenario"
+  },
+  "rq-e008c6fe": {
+    "decl": "Scenario: Unsupported driver raises InputError",
+    "file": "gaussian/input-builder",
+    "refs": [],
+    "title": "Unsupported driver raises InputError",
+    "type": "scenario"
+  },
+  "rq-e62578e2": {
+    "decl": "Scenario: compute() returns AtomicResult with gradient for gradient driver",
+    "file": "gaussian/runner",
+    "refs": [],
+    "title": "compute() returns AtomicResult with gradient for gradient driver",
+    "type": "scenario"
+  },
+  "rq-e7897f09": {
+    "decl": "Scenario: Reserved user keywords (memory, nprocs) are not appended to route line",
+    "file": "gaussian/input-builder",
+    "refs": [],
+    "title": "Reserved user keywords (memory, nprocs) are not appended to route line",
+    "type": "scenario"
+  },
+  "rq-edb73b83": {
+    "decl": "Scenario: compute() raises InputError on internal coordinate error",
+    "file": "gaussian/runner",
+    "refs": [],
+    "title": "compute() raises InputError on internal coordinate error",
+    "type": "scenario"
+  },
+  "rq-eddef743": {
+    "decl": "Scenario: Parse CCSD(T) total energy",
+    "file": "gaussian/harvester",
+    "refs": [],
+    "title": "Parse CCSD(T) total energy",
+    "type": "scenario"
+  },
+  "rq-ef62979b": {
+    "decl": "### `muster_modelchem(method: str, driver: str, multiplicity: int) -> Dict[str, Any]`",
+    "file": "gaussian/input-builder",
+    "level": 3,
+    "refs": [],
+    "title": "`muster_modelchem(method: str, driver: str, multiplicity: int) -> Dict[str, Any]`",
+    "type": "section"
+  },
+  "rq-f1c116db": {
+    "decl": "Scenario: Gradient driver produces \"Force=NoStep\"",
+    "file": "gaussian/input-builder",
+    "refs": [],
+    "title": "Gradient driver produces \"Force=NoStep\"",
+    "type": "scenario"
+  },
+  "rq-f2e32162": {
+    "decl": "Scenario: Parse Hessian from frequency calculation",
+    "file": "gaussian/harvester",
+    "refs": [],
+    "title": "Parse Hessian from frequency calculation",
+    "type": "scenario"
+  },
+  "rq-f512b60b": {
+    "decl": "Scenario: Properties driver produces Pop=Full in extra_keywords",
+    "file": "gaussian/input-builder",
+    "refs": [],
+    "title": "Properties driver produces Pop=Full in extra_keywords",
+    "type": "scenario"
+  },
+  "rq-fe13245b": {
+    "decl": "Scenario: Method starting with RO is not prefixed with U",
+    "file": "gaussian/input-builder",
+    "refs": [],
+    "title": "Method starting with RO is not prefixed with U",
+    "type": "scenario"
+  },
+  "rq-ffae3fa6": {
+    "decl": "Scenario: Parse Mulliken charges for properties driver",
+    "file": "gaussian/harvester",
+    "refs": [],
+    "title": "Parse Mulliken charges for properties driver",
+    "type": "scenario"
+  }
+}

--- a/rqm/registry.json
+++ b/rqm/registry.json
@@ -50,6 +50,21 @@
     "title": "Nuclear repulsion energy mismatch raises ValueError",
     "type": "scenario"
   },
+  "rq-0edebcd3": {
+    "decl": "### `test_local_options_memory_gib` (`test_canonical_config.py`)",
+    "file": "gaussian/integration-tests",
+    "level": 3,
+    "refs": [],
+    "title": "`test_local_options_memory_gib` (`test_canonical_config.py`)",
+    "type": "section"
+  },
+  "rq-0f585dce": {
+    "decl": "# Feature: Gaussian Harness --- Cross-Program Integration Tests",
+    "file": "gaussian/integration-tests",
+    "refs": [],
+    "title": "Feature: Gaussian Harness --- Cross-Program Integration Tests",
+    "type": "file"
+  },
   "rq-12c41d5e": {
     "decl": "Scenario: Absent normal termination line is classified as abnormal",
     "file": "gaussian/harvester",
@@ -136,6 +151,13 @@
     "title": "Method already starting with U is not double-prefixed",
     "type": "scenario"
   },
+  "rq-2aa0e9e1": {
+    "decl": "Scenario: Memory configuration is not overridden by conflicting DSL keywords",
+    "file": "gaussian/integration-tests",
+    "refs": [],
+    "title": "Memory configuration is not overridden by conflicting DSL keywords",
+    "type": "scenario"
+  },
   "rq-2ad053f2": {
     "decl": "## Feature API",
     "file": "gaussian/input-builder",
@@ -166,6 +188,13 @@
     "title": "No Hessian when running energy-only or gradient calculation",
     "type": "scenario"
   },
+  "rq-349bf8c3": {
+    "decl": "Scenario: UHF gradient is correctly aligned to the (scrambled) input frame",
+    "file": "gaussian/integration-tests",
+    "refs": [],
+    "title": "UHF gradient is correctly aligned to the (scrambled) input frame",
+    "type": "scenario"
+  },
   "rq-36736115": {
     "decl": "Scenario: Parse gradient and negate forces",
     "file": "gaussian/harvester",
@@ -179,6 +208,14 @@
     "refs": [],
     "title": "- `\"HF TOTAL ENERGY\"` — always set from `ccdata.scfenergies[-1]` (in Hartree).",
     "type": "api-item"
+  },
+  "rq-3a18d6af": {
+    "decl": "### `test_local_options_ncores` (`test_canonical_config.py`)",
+    "file": "gaussian/integration-tests",
+    "level": 3,
+    "refs": [],
+    "title": "`test_local_options_ncores` (`test_canonical_config.py`)",
+    "type": "section"
   },
   "rq-3b0adf96": {
     "decl": "Scenario: No gradient attribute in ccdata when running energy-only calculation",
@@ -202,6 +239,13 @@
     "title": "get_version() caches the result after the first call",
     "type": "scenario"
   },
+  "rq-4252ac2d": {
+    "decl": "Scenario: Multi-core execution succeeds and ncores is reflected in output",
+    "file": "gaussian/integration-tests",
+    "refs": [],
+    "title": "Multi-core execution succeeds and ncores is reflected in output",
+    "type": "scenario"
+  },
   "rq-4336c3cd": {
     "decl": "- `ValueError` if no coordinate information can be extracted from the log.",
     "file": "gaussian/harvester",
@@ -215,6 +259,13 @@
     "refs": [],
     "title": "Feature: Gaussian Harness — Runner",
     "type": "file"
+  },
+  "rq-475c8796": {
+    "decl": "Scenario: CCSD(T)/aug-cc-pVDZ RHF energy on water matches Gaussian-specific reference",
+    "file": "gaussian/integration-tests",
+    "refs": [],
+    "title": "CCSD(T)/aug-cc-pVDZ RHF energy on water matches Gaussian-specific reference",
+    "type": "scenario"
   },
   "rq-4ad16d95": {
     "decl": "Scenario: Memory directive uses integer GB for whole-number memory",
@@ -258,6 +309,13 @@
     "title": "Ghost atoms in the molecule raise InputError",
     "type": "scenario"
   },
+  "rq-519fbe49": {
+    "decl": "Scenario: Single-core execution succeeds",
+    "file": "gaussian/integration-tests",
+    "refs": [],
+    "title": "Single-core execution succeeds",
+    "type": "scenario"
+  },
   "rq-53f8ed12": {
     "decl": "Scenario: Missing Mulliken charges do not raise an error",
     "file": "gaussian/harvester",
@@ -272,11 +330,62 @@
     "title": "MP2 method maps to \"MP2\"",
     "type": "scenario"
   },
+  "rq-56e891e7": {
+    "decl": "### Empirical Reference Values",
+    "file": "gaussian/integration-tests",
+    "level": 3,
+    "refs": [],
+    "title": "Empirical Reference Values",
+    "type": "section"
+  },
   "rq-578bb785": {
     "decl": "Scenario: Parse MP2 total and correlation energies",
     "file": "gaussian/harvester",
     "refs": [],
     "title": "Parse MP2 total and correlation energies",
+    "type": "scenario"
+  },
+  "rq-5d9b0b40": {
+    "decl": "Scenario: UHF hessian is correctly aligned to the (scrambled) input frame",
+    "file": "gaussian/integration-tests",
+    "refs": [],
+    "title": "UHF hessian is correctly aligned to the (scrambled) input frame",
+    "type": "scenario"
+  },
+  "rq-637d486d": {
+    "decl": "Scenario: RHF gradient is correctly aligned to the (scrambled) input frame",
+    "file": "gaussian/integration-tests",
+    "refs": [],
+    "title": "RHF gradient is correctly aligned to the (scrambled) input frame",
+    "type": "scenario"
+  },
+  "rq-6423b98b": {
+    "decl": "### Files Modified",
+    "file": "gaussian/integration-tests",
+    "level": 3,
+    "refs": [],
+    "title": "Files Modified",
+    "type": "section"
+  },
+  "rq-647b596c": {
+    "decl": "Scenario: Gaussian appears in _canonical_methods",
+    "file": "gaussian/integration-tests",
+    "refs": [],
+    "title": "Gaussian appears in _canonical_methods",
+    "type": "scenario"
+  },
+  "rq-65cb367e": {
+    "decl": "Scenario: Memory configuration is applied with 1.555 GiB total node memory",
+    "file": "gaussian/integration-tests",
+    "refs": [],
+    "title": "Memory configuration is applied with 1.555 GiB total node memory",
+    "type": "scenario"
+  },
+  "rq-6a889dea": {
+    "decl": "Scenario: UHF energy is invariant to input frame scrambling",
+    "file": "gaussian/integration-tests",
+    "refs": [],
+    "title": "UHF energy is invariant to input frame scrambling",
     "type": "scenario"
   },
   "rq-6bff3228": {
@@ -307,6 +416,13 @@
     "title": "User keyword is appended to route line",
     "type": "scenario"
   },
+  "rq-71824b99": {
+    "decl": "Scenario: Scratch directory is used and files are left behind when scratch_messy=True",
+    "file": "gaussian/integration-tests",
+    "refs": [],
+    "title": "Scratch directory is used and files are left behind when scratch_messy=True",
+    "type": "scenario"
+  },
   "rq-71aceb93": {
     "decl": "Scenario: compute() raises UnknownError on abnormal termination with no known pattern",
     "file": "gaussian/runner",
@@ -327,6 +443,30 @@
     "level": 2,
     "refs": [],
     "title": "Molecule Block Construction",
+    "type": "section"
+  },
+  "rq-8070c4fd": {
+    "decl": "## Test Integrations",
+    "file": "gaussian/integration-tests",
+    "level": 2,
+    "refs": [],
+    "title": "Test Integrations",
+    "type": "section"
+  },
+  "rq-815d5fee": {
+    "decl": "### `test_local_options_scratch` (`test_canonical_config.py`)",
+    "file": "gaussian/integration-tests",
+    "level": 3,
+    "refs": [],
+    "title": "`test_local_options_scratch` (`test_canonical_config.py`)",
+    "type": "section"
+  },
+  "rq-81bc1d68": {
+    "decl": "### `test_hf_alignment` (`test_alignment.py`)",
+    "file": "gaussian/integration-tests",
+    "level": 3,
+    "refs": [],
+    "title": "`test_hf_alignment` (`test_alignment.py`)",
     "type": "section"
   },
   "rq-82942b90": {
@@ -357,6 +497,13 @@
     "title": "InputError",
     "type": "api-item"
   },
+  "rq-87c8fb49": {
+    "decl": "Scenario: RHF hessian is correctly aligned to the (scrambled) input frame",
+    "file": "gaussian/integration-tests",
+    "refs": [],
+    "title": "RHF hessian is correctly aligned to the (scrambled) input frame",
+    "type": "scenario"
+  },
   "rq-8d6fc024": {
     "decl": "### Output Molecule Construction",
     "file": "gaussian/harvester",
@@ -364,6 +511,13 @@
     "refs": [],
     "title": "Output Molecule Construction",
     "type": "section"
+  },
+  "rq-8df082e3": {
+    "decl": "Scenario: native_files protocol \"none\" returns empty native_files",
+    "file": "gaussian/integration-tests",
+    "refs": [],
+    "title": "native_files protocol \"none\" returns empty native_files",
+    "type": "scenario"
   },
   "rq-8e21b7d7": {
     "decl": "Scenario: found() returns False when neither g16 nor g09 is on PATH",
@@ -385,6 +539,13 @@
     "refs": [],
     "title": "ValueError",
     "type": "api-item"
+  },
+  "rq-923b3212": {
+    "decl": "Scenario: native_files protocol \"input\" returns only the input file",
+    "file": "gaussian/integration-tests",
+    "refs": [],
+    "title": "native_files protocol \"input\" returns only the input file",
+    "type": "scenario"
   },
   "rq-92492893": {
     "decl": "Scenario: CCSD(T) method maps to \"CCSD(T)\"",
@@ -428,6 +589,14 @@
     "level": 3,
     "refs": [],
     "title": "Class `GaussianHarness(ProgramHarness)`",
+    "type": "section"
+  },
+  "rq-9aa3cac4": {
+    "decl": "### `test_sp_ccsd_t_rhf_full` (`test_standard_suite_ccsd(t).py`)",
+    "file": "gaussian/integration-tests",
+    "level": 3,
+    "refs": [],
+    "title": "`test_sp_ccsd_t_rhf_full` (`test_standard_suite_ccsd(t).py`)",
     "type": "section"
   },
   "rq-9acd1ce5": {
@@ -487,6 +656,13 @@
     "title": "Nuclear repulsion energy cross-check passes for consistent geometry",
     "type": "scenario"
   },
+  "rq-aa991a3a": {
+    "decl": "Scenario: native_files protocol \"all\" returns input and output files",
+    "file": "gaussian/integration-tests",
+    "refs": [],
+    "title": "native_files protocol \"all\" returns input and output files",
+    "type": "scenario"
+  },
   "rq-af032242": {
     "decl": "Scenario: Route line for closed-shell HF energy",
     "file": "gaussian/input-builder",
@@ -522,6 +698,13 @@
     "title": "Atom coordinates appear in Angstrom with at least 10 decimal places",
     "type": "scenario"
   },
+  "rq-ba0f397f": {
+    "decl": "Scenario: RHF energy is invariant to input frame scrambling",
+    "file": "gaussian/integration-tests",
+    "refs": [],
+    "title": "RHF energy is invariant to input frame scrambling",
+    "type": "scenario"
+  },
   "rq-bb0a5d96": {
     "decl": "## cclib Integration",
     "file": "gaussian/harvester",
@@ -537,12 +720,28 @@
     "title": "cclib parse failure propagates as-is",
     "type": "scenario"
   },
+  "rq-bb7d680f": {
+    "decl": "## Prerequisite: native_files Key Convention",
+    "file": "gaussian/integration-tests",
+    "level": 2,
+    "refs": [],
+    "title": "Prerequisite: native_files Key Convention",
+    "type": "section"
+  },
   "rq-bd98d417": {
     "decl": "Scenario: found(raise_error=True) raises ModuleNotFoundError when g16 is missing",
     "file": "gaussian/runner",
     "refs": [],
     "title": "found(raise_error=True) raises ModuleNotFoundError when g16 is missing",
     "type": "scenario"
+  },
+  "rq-c01c892e": {
+    "decl": "### `test_protocol_native` (`test_canonical_fields.py`)",
+    "file": "gaussian/integration-tests",
+    "level": 3,
+    "refs": [],
+    "title": "`test_protocol_native` (`test_canonical_fields.py`)",
+    "type": "section"
   },
   "rq-c20746b1": {
     "decl": "## Regex Fallback",
@@ -632,6 +831,13 @@
     "title": "Link 0 section contains NProcShared and Mem directives",
     "type": "scenario"
   },
+  "rq-d87ddeb8": {
+    "decl": "Scenario: native_files never contains \"stdout\" or \"stderr\"",
+    "file": "gaussian/integration-tests",
+    "refs": [],
+    "title": "native_files never contains \"stdout\" or \"stderr\"",
+    "type": "scenario"
+  },
   "rq-d9434480": {
     "decl": "### `harvest(in_mol: Molecule, method: str, log_content: str) -> Tuple[PreservingDict, Optional[np.ndarray], Optional[np.ndarray], Molecule]`",
     "file": "gaussian/harvester",
@@ -661,12 +867,28 @@
     "title": "compute() returns AtomicResult with gradient for gradient driver",
     "type": "scenario"
   },
+  "rq-e71357c5": {
+    "decl": "## Canonical Methods Entry",
+    "file": "gaussian/integration-tests",
+    "level": 2,
+    "refs": [],
+    "title": "Canonical Methods Entry",
+    "type": "section"
+  },
   "rq-e7897f09": {
     "decl": "Scenario: Reserved user keywords (memory, nprocs) are not appended to route line",
     "file": "gaussian/input-builder",
     "refs": [],
     "title": "Reserved user keywords (memory, nprocs) are not appended to route line",
     "type": "scenario"
+  },
+  "rq-e7c13c1e": {
+    "decl": "## Gherkin Scenarios",
+    "file": "gaussian/integration-tests",
+    "level": 2,
+    "refs": [],
+    "title": "Gherkin Scenarios",
+    "type": "section"
   },
   "rq-edb73b83": {
     "decl": "Scenario: compute() raises InputError on internal coordinate error",
@@ -690,12 +912,27 @@
     "title": "`muster_modelchem(method: str, driver: str, multiplicity: int) -> Dict[str, Any]`",
     "type": "section"
   },
+  "rq-f13e0d24": {
+    "decl": "Scenario: parse_output uses standard \"input\" key in native_files",
+    "file": "gaussian/integration-tests",
+    "refs": [],
+    "title": "parse_output uses standard \"input\" key in native_files",
+    "type": "scenario"
+  },
   "rq-f1c116db": {
     "decl": "Scenario: Gradient driver produces \"Force=NoStep\"",
     "file": "gaussian/input-builder",
     "refs": [],
     "title": "Gradient driver produces \"Force=NoStep\"",
     "type": "scenario"
+  },
+  "rq-f28b3bed": {
+    "decl": "## Implementation Notes",
+    "file": "gaussian/integration-tests",
+    "level": 2,
+    "refs": [],
+    "title": "Implementation Notes",
+    "type": "section"
   },
   "rq-f2e32162": {
     "decl": "Scenario: Parse Hessian from frequency calculation",

--- a/rqm/registry.json
+++ b/rqm/registry.json
@@ -517,10 +517,10 @@
     "type": "scenario"
   },
   "rq-463ef385": {
-    "decl": "- `\"N ATOMS\"` — from `len(ccdata.atomnos)`.",
+    "decl": "- `\"N ATOMS\"` — from `ccdata.natom`.",
     "file": "gaussian/harvester",
     "refs": [],
-    "title": "- `\"N ATOMS\"` — from `len(ccdata.atomnos)`.",
+    "title": "- `\"N ATOMS\"` — from `ccdata.natom`.",
     "type": "api-item"
   },
   "rq-475c8796": {

--- a/rqm/registry.json
+++ b/rqm/registry.json
@@ -14,6 +14,14 @@
     "title": "HF method maps to \"HF\" method string",
     "type": "scenario"
   },
+  "rq-03c1f71c": {
+    "decl": "### `GaussianHarness.build_input` — confirmed behavior for labeled molecules",
+    "file": "gaussian/atom-labels",
+    "level": 3,
+    "refs": [],
+    "title": "`GaussianHarness.build_input` — confirmed behavior for labeled molecules",
+    "type": "section"
+  },
   "rq-04028610": {
     "decl": "Scenario: AtomicResult.molecule preserves ghost designation",
     "file": "gaussian/ghost-atoms",
@@ -58,6 +66,13 @@
     "title": "Method matching is case-insensitive",
     "type": "scenario"
   },
+  "rq-090d144e": {
+    "decl": "Scenario: Labels do not appear in the route line",
+    "file": "gaussian/atom-labels",
+    "refs": [],
+    "title": "Labels do not appear in the route line",
+    "type": "scenario"
+  },
   "rq-0aa99076": {
     "decl": "Scenario: BasisSet object for model.basis raises InputError",
     "file": "gaussian/input-builder",
@@ -86,6 +101,13 @@
     "title": "- `\"CURRENT REFERENCE ENERGY\"` — same value as `\"HF TOTAL ENERGY\"` (required by standard suite contracts).",
     "type": "api-item"
   },
+  "rq-0dab9c40": {
+    "decl": "# Feature: Gaussian Harness — Atom-Label Tolerance",
+    "file": "gaussian/atom-labels",
+    "refs": [],
+    "title": "Feature: Gaussian Harness — Atom-Label Tolerance",
+    "type": "file"
+  },
   "rq-0edebcd3": {
     "decl": "### `test_local_options_memory_gib` (`test_canonical_config.py`)",
     "file": "gaussian/integration-tests",
@@ -107,6 +129,14 @@
     "refs": [],
     "title": "Absent normal termination line is classified as abnormal",
     "type": "scenario"
+  },
+  "rq-1601c435": {
+    "decl": "## Migration Notes",
+    "file": "gaussian/atom-labels",
+    "level": 2,
+    "refs": [],
+    "title": "Migration Notes",
+    "type": "section"
   },
   "rq-165224fc": {
     "decl": "Scenario: compute() raises InputError when the log contains an unrecognised-keyword error",
@@ -157,6 +187,13 @@
     "file": "gaussian/harvester",
     "refs": [],
     "title": "Parse CCSD total energy",
+    "type": "scenario"
+  },
+  "rq-20063525": {
+    "decl": "Scenario: Labeled hydrogen atom emits a bare \"H \" line (no label suffix)",
+    "file": "gaussian/atom-labels",
+    "refs": [],
+    "title": "Labeled hydrogen atom emits a bare \"H \" line (no label suffix)",
     "type": "scenario"
   },
   "rq-2052a2fa": {
@@ -238,6 +275,28 @@
     "title": "Gherkin Scenarios",
     "type": "section"
   },
+  "rq-2cb2c5c0": {
+    "decl": "### `test_tricky_ghost` (eneyne+Ne, MP2)",
+    "file": "gaussian/ghost-atoms",
+    "level": 3,
+    "refs": [],
+    "title": "`test_tricky_ghost` (eneyne+Ne, MP2)",
+    "type": "section"
+  },
+  "rq-31334859": {
+    "decl": "Scenario: MP2/6-31G* energy on gAmB (ghost ethylene + real ethyne) matches reference",
+    "file": "gaussian/ghost-atoms",
+    "refs": [],
+    "title": "MP2/6-31G* energy on gAmB (ghost ethylene + real ethyne) matches reference",
+    "type": "scenario"
+  },
+  "rq-3257a6f5": {
+    "decl": "Scenario: MP2/6-31G* energy on eneyne dimer matches consensus reference",
+    "file": "gaussian/ghost-atoms",
+    "refs": [],
+    "title": "MP2/6-31G* energy on eneyne dimer matches consensus reference",
+    "type": "scenario"
+  },
   "rq-342a2ca3": {
     "decl": "Scenario: Charge and multiplicity are on one line in the molecule section",
     "file": "gaussian/input-builder",
@@ -257,6 +316,13 @@
     "file": "gaussian/integration-tests",
     "refs": [],
     "title": "UHF gradient is correctly aligned to the (scrambled) input frame",
+    "type": "scenario"
+  },
+  "rq-351864ac": {
+    "decl": "Scenario: Gaussian SCF and MP2 on the labeled-H system match one of the two accepted solutions",
+    "file": "gaussian/atom-labels",
+    "refs": [],
+    "title": "Gaussian SCF and MP2 on the labeled-H system match one of the two accepted solutions",
     "type": "scenario"
   },
   "rq-36736115": {
@@ -296,12 +362,27 @@
     "title": "`build_route_line(method_string: str, basis: str, job_type: str, extra_keywords: Dict[str, str], user_keywords: Dict[str, Any]) -> str`",
     "type": "section"
   },
+  "rq-3dd2d934": {
+    "decl": "Scenario: test_atom_labels runs successfully with Gaussian",
+    "file": "gaussian/atom-labels",
+    "refs": [],
+    "title": "test_atom_labels runs successfully with Gaussian",
+    "type": "scenario"
+  },
   "rq-3e134642": {
     "decl": "Scenario: get_version() caches the result after the first call",
     "file": "gaussian/runner",
     "refs": [],
     "title": "get_version() caches the result after the first call",
     "type": "scenario"
+  },
+  "rq-4061edf7": {
+    "decl": "### `test_atom_labels` (`test_ghost.py`)",
+    "file": "gaussian/atom-labels",
+    "level": 3,
+    "refs": [],
+    "title": "`test_atom_labels` (`test_ghost.py`)",
+    "type": "section"
   },
   "rq-4091a959": {
     "decl": "## Method and Driver Compatibility",
@@ -353,6 +434,14 @@
     "title": "Memory directive uses integer GB for whole-number memory",
     "type": "scenario"
   },
+  "rq-4bd911ec": {
+    "decl": "## Gherkin Scenarios",
+    "file": "gaussian/atom-labels",
+    "level": 2,
+    "refs": [],
+    "title": "Gherkin Scenarios",
+    "type": "section"
+  },
   "rq-4c4a1542": {
     "decl": "Scenario: Parse dipole moment for properties driver",
     "file": "gaussian/harvester",
@@ -380,6 +469,14 @@
     "refs": [],
     "title": "multiplicity",
     "type": "api-item"
+  },
+  "rq-4f50add1": {
+    "decl": "## Integration Test",
+    "file": "gaussian/atom-labels",
+    "level": 2,
+    "refs": [],
+    "title": "Integration Test",
+    "type": "section"
   },
   "rq-519fbe49": {
     "decl": "Scenario: Single-core execution succeeds",
@@ -417,11 +514,40 @@
     "title": "Parse MP2 total and correlation energies",
     "type": "scenario"
   },
+  "rq-5c529f02": {
+    "decl": "Scenario: out_mol preserves atom_labels when fix_com and fix_orientation are True",
+    "file": "gaussian/atom-labels",
+    "refs": [],
+    "title": "out_mol preserves atom_labels when fix_com and fix_orientation are True",
+    "type": "scenario"
+  },
+  "rq-5d5df0b4": {
+    "decl": "## Design Rationale",
+    "file": "gaussian/atom-labels",
+    "level": 2,
+    "refs": [],
+    "title": "Design Rationale",
+    "type": "section"
+  },
   "rq-5d9b0b40": {
     "decl": "Scenario: UHF hessian is correctly aligned to the (scrambled) input frame",
     "file": "gaussian/integration-tests",
     "refs": [],
     "title": "UHF hessian is correctly aligned to the (scrambled) input frame",
+    "type": "scenario"
+  },
+  "rq-609268f8": {
+    "decl": "Scenario: MP2/6-31G* gradient on eneyne dimer matches consensus reference",
+    "file": "gaussian/ghost-atoms",
+    "refs": [],
+    "title": "MP2/6-31G* gradient on eneyne dimer matches consensus reference",
+    "type": "scenario"
+  },
+  "rq-6121b3e1": {
+    "decl": "Scenario: test_tricky_ghost uses the default ref branch for non-mB Gaussian subjects",
+    "file": "gaussian/ghost-atoms",
+    "refs": [],
+    "title": "test_tricky_ghost uses the default ref branch for non-mB Gaussian subjects",
     "type": "scenario"
   },
   "rq-637d486d": {
@@ -451,6 +577,13 @@
     "file": "gaussian/integration-tests",
     "refs": [],
     "title": "Gaussian appears in _canonical_methods",
+    "type": "scenario"
+  },
+  "rq-64be1785": {
+    "decl": "Scenario: pgline regex matches Gaussian's \"Full point group\" line for linear C*V",
+    "file": "gaussian/ghost-atoms",
+    "refs": [],
+    "title": "pgline regex matches Gaussian's \"Full point group\" line for linear C*V",
     "type": "scenario"
   },
   "rq-65cb367e": {
@@ -552,6 +685,20 @@
     "title": "Molecule Block Construction",
     "type": "section"
   },
+  "rq-7a592160": {
+    "decl": "Scenario: Empty atom_labels (all-default) preserves existing behavior",
+    "file": "gaussian/atom-labels",
+    "refs": [],
+    "title": "Empty atom_labels (all-default) preserves existing behavior",
+    "type": "scenario"
+  },
+  "rq-7e1b0bb4": {
+    "decl": "Scenario: test_tricky_ghost accepts Gaussian's linear PG for the mB subject",
+    "file": "gaussian/ghost-atoms",
+    "refs": [],
+    "title": "test_tricky_ghost accepts Gaussian's linear PG for the mB subject",
+    "type": "scenario"
+  },
   "rq-7f2c22fd": {
     "decl": "- `\"N MOLECULAR ORBITALS\"` — from `ccdata.nmo` (when available).",
     "file": "gaussian/harvester",
@@ -581,6 +728,14 @@
     "level": 3,
     "refs": [],
     "title": "`test_hf_alignment` (`test_alignment.py`)",
+    "type": "section"
+  },
+  "rq-824f4a96": {
+    "decl": "## Feature API",
+    "file": "gaussian/atom-labels",
+    "level": 2,
+    "refs": [],
+    "title": "Feature API",
     "type": "section"
   },
   "rq-82942b90": {
@@ -648,6 +803,13 @@
     "title": "found() returns False when neither g16 nor g09 is on PATH",
     "type": "scenario"
   },
+  "rq-8fa7c4c3": {
+    "decl": "Scenario: Gaussian \"NoSymm\" keyword forces C1 symmetry in the route line",
+    "file": "gaussian/ghost-atoms",
+    "refs": [],
+    "title": "Gaussian \"NoSymm\" keyword forces C1 symmetry in the route line",
+    "type": "scenario"
+  },
   "rq-90141f40": {
     "decl": "Scenario: Normal termination line is present in a successful log",
     "file": "gaussian/harvester",
@@ -697,6 +859,14 @@
     "refs": [],
     "title": "- `\"DIPOLE MOMENT\"` — magnitude of `ccdata.moments[1]` in Debye.",
     "type": "api-item"
+  },
+  "rq-95dab09b": {
+    "decl": "### `test_simple_ghost` (He···Ne)",
+    "file": "gaussian/ghost-atoms",
+    "level": 3,
+    "refs": [],
+    "title": "`test_simple_ghost` (He···Ne)",
+    "type": "section"
   },
   "rq-972b6470": {
     "decl": "Scenario: Singlet uses method name as-is (no U prefix)",
@@ -764,11 +934,33 @@
     "title": "Route line is unchanged when ghost atoms are present",
     "type": "scenario"
   },
+  "rq-a1bc15af": {
+    "decl": "Scenario: build_input() accepts a labeled molecule without raising",
+    "file": "gaussian/atom-labels",
+    "refs": [],
+    "title": "build_input() accepts a labeled molecule without raising",
+    "type": "scenario"
+  },
+  "rq-a203a314": {
+    "decl": "### `harvest` — confirmed behavior for labeled molecules",
+    "file": "gaussian/atom-labels",
+    "level": 3,
+    "refs": [],
+    "title": "`harvest` — confirmed behavior for labeled molecules",
+    "type": "section"
+  },
   "rq-a4c449da": {
     "decl": "Scenario: compute() raises ResourceError on memory allocation failure",
     "file": "gaussian/runner",
     "refs": [],
     "title": "compute() raises ResourceError on memory allocation failure",
+    "type": "scenario"
+  },
+  "rq-a5593d5c": {
+    "decl": "Scenario: MP2/6-31G* on mB (linear ethyne alone) returns the correct energy",
+    "file": "gaussian/ghost-atoms",
+    "refs": [],
+    "title": "MP2/6-31G* on mB (linear ethyne alone) returns the correct energy",
     "type": "scenario"
   },
   "rq-a69d0898": {
@@ -800,6 +992,13 @@
     "title": "method",
     "type": "api-item"
   },
+  "rq-a9026c9f": {
+    "decl": "Scenario: Method \"mp2(full)\" is normalised back to \"mp2\" by the harvester",
+    "file": "gaussian/ghost-atoms",
+    "refs": [],
+    "title": "Method \"mp2(full)\" is normalised back to \"mp2\" by the harvester",
+    "type": "scenario"
+  },
   "rq-a9194afb": {
     "decl": "Scenario: Nuclear repulsion energy cross-check passes for consistent geometry",
     "file": "gaussian/harvester",
@@ -819,6 +1018,13 @@
     "file": "gaussian/input-builder",
     "refs": [],
     "title": "Route line for closed-shell HF energy",
+    "type": "scenario"
+  },
+  "rq-b074f046": {
+    "decl": "Scenario: The \"alternative SCF solution\" branch in test_atom_labels accepts Gaussian",
+    "file": "gaussian/atom-labels",
+    "refs": [],
+    "title": "The \"alternative SCF solution\" branch in test_atom_labels accepts Gaussian",
     "type": "scenario"
   },
   "rq-b27d4aff": {
@@ -847,6 +1053,13 @@
     "file": "gaussian/runner",
     "refs": [],
     "title": "found() returns False when cclib is not importable",
+    "type": "scenario"
+  },
+  "rq-b604feb4": {
+    "decl": "Scenario: A ghost atom with a non-empty label still emits \"<symbol>-Bq\" (label dropped)",
+    "file": "gaussian/atom-labels",
+    "refs": [],
+    "title": "A ghost atom with a non-empty label still emits \"<symbol>-Bq\" (label dropped)",
     "type": "scenario"
   },
   "rq-b7c7b8cb": {
@@ -929,6 +1142,29 @@
     "file": "gaussian/input-builder",
     "refs": [],
     "title": "Energy driver produces no job-type keyword",
+    "type": "scenario"
+  },
+  "rq-c2a6aabb": {
+    "decl": "## Out-of-Scope",
+    "file": "gaussian/atom-labels",
+    "level": 2,
+    "refs": [],
+    "title": "Out-of-Scope",
+    "type": "section"
+  },
+  "rq-c3ebee03": {
+    "decl": "## Method and Driver Compatibility",
+    "file": "gaussian/atom-labels",
+    "level": 2,
+    "refs": [],
+    "title": "Method and Driver Compatibility",
+    "type": "section"
+  },
+  "rq-c40101e6": {
+    "decl": "Scenario: Method \"mp2(full)\" maps to \"MP2(Full)\" in the Gaussian route line",
+    "file": "gaussian/ghost-atoms",
+    "refs": [],
+    "title": "Method \"mp2(full)\" maps to \"MP2(Full)\" in the Gaussian route line",
     "type": "scenario"
   },
   "rq-c4439b82": {
@@ -1027,6 +1263,13 @@
     "title": "found() falls back to g09 when g16 is absent",
     "type": "scenario"
   },
+  "rq-d4e60dd2": {
+    "decl": "Scenario: MP2/6-31G* energy on mAgB (real ethylene + ghost ethyne) matches reference",
+    "file": "gaussian/ghost-atoms",
+    "refs": [],
+    "title": "MP2/6-31G* energy on mAgB (real ethylene + ghost ethyne) matches reference",
+    "type": "scenario"
+  },
   "rq-d7e8161d": {
     "decl": "Scenario: Link 0 section contains NProcShared and Mem directives",
     "file": "gaussian/input-builder",
@@ -1056,11 +1299,25 @@
     "title": "Gradient array spans real and ghost atoms in input order",
     "type": "scenario"
   },
+  "rq-da7df6e9": {
+    "decl": "Scenario: Multiple same-element atoms with distinct labels each emit bare element lines",
+    "file": "gaussian/atom-labels",
+    "refs": [],
+    "title": "Multiple same-element atoms with distinct labels each emit bare element lines",
+    "type": "scenario"
+  },
   "rq-db92093a": {
     "decl": "Scenario: Memory directive rounds down to nearest integer GB (minimum 1)",
     "file": "gaussian/input-builder",
     "refs": [],
     "title": "Memory directive rounds down to nearest integer GB (minimum 1)",
+    "type": "scenario"
+  },
+  "rq-dc9a34d9": {
+    "decl": "Scenario: pgline regex matches Gaussian's \"Full point group\" line for C2v",
+    "file": "gaussian/ghost-atoms",
+    "refs": [],
+    "title": "pgline regex matches Gaussian's \"Full point group\" line for C2v",
     "type": "scenario"
   },
   "rq-dceb51f5": {

--- a/rqm/registry.json
+++ b/rqm/registry.json
@@ -36,6 +36,14 @@
     "title": "Gradient of a ghost-bearing system matches a reference vector",
     "type": "scenario"
   },
+  "rq-051e6b78": {
+    "decl": "## Gherkin Scenarios",
+    "file": "gaussian/e2e-coverage",
+    "level": 2,
+    "refs": [],
+    "title": "Gherkin Scenarios",
+    "type": "section"
+  },
   "rq-058819da": {
     "decl": "## Gherkin Scenarios",
     "file": "gaussian/harvester",
@@ -87,6 +95,14 @@
     "refs": [],
     "title": "BasisSet object for model.basis raises InputError",
     "type": "scenario"
+  },
+  "rq-0afebead": {
+    "decl": "## Out-of-Scope",
+    "file": "gaussian/e2e-coverage",
+    "level": 2,
+    "refs": [],
+    "title": "Out-of-Scope",
+    "type": "section"
   },
   "rq-0b4cf843": {
     "decl": "Scenario: Nuclear repulsion energy mismatch raises ValueError",
@@ -204,6 +220,13 @@
     "title": "get_version() returns a normalised version string for Gaussian 16",
     "type": "scenario"
   },
+  "rq-18a8cc19": {
+    "decl": "Scenario: UHF/cc-pVDZ energy on NH2 radical matches reference and emits UHF route line",
+    "file": "gaussian/e2e-coverage",
+    "refs": [],
+    "title": "UHF/cc-pVDZ energy on NH2 radical matches reference and emits UHF route line",
+    "type": "scenario"
+  },
   "rq-1a01df8f": {
     "decl": "## Feature API",
     "file": "gaussian/harvester",
@@ -239,6 +262,22 @@
     "level": 3,
     "refs": [],
     "title": "Extended: `harvest(in_mol, method, log_content)`",
+    "type": "section"
+  },
+  "rq-1e76932b": {
+    "decl": "### T3: Plain B3LYP energy on water",
+    "file": "gaussian/e2e-coverage",
+    "level": 3,
+    "refs": [],
+    "title": "T3: Plain B3LYP energy on water",
+    "type": "section"
+  },
+  "rq-1ed899e3": {
+    "decl": "## Implementation Notes",
+    "file": "gaussian/e2e-coverage",
+    "level": 2,
+    "refs": [],
+    "title": "Implementation Notes",
     "type": "section"
   },
   "rq-20063525": {
@@ -435,6 +474,13 @@
     "title": "Parse gradient and negate forces",
     "type": "scenario"
   },
+  "rq-3727e53b": {
+    "decl": "- `test_gaussian_dft_b3lyp_water` (T3)",
+    "file": "gaussian/e2e-coverage",
+    "refs": [],
+    "title": "test_gaussian_dft_b3lyp_water",
+    "type": "api-item"
+  },
   "rq-37f40e92": {
     "decl": "- `\"HF TOTAL ENERGY\"` — from `ccdata.scfenergies[-1]` converted via `cclib.parser.utils.convertor(\"eV\", \"hartree\")`.",
     "file": "gaussian/harvester",
@@ -630,6 +676,13 @@
     "title": "MP2 method maps to \"MP2\"",
     "type": "scenario"
   },
+  "rq-54afb7b8": {
+    "decl": "- `test_gaussian_hessian_hf_water` (T1)",
+    "file": "gaussian/e2e-coverage",
+    "refs": [],
+    "title": "test_gaussian_hessian_hf_water",
+    "type": "api-item"
+  },
   "rq-56e891e7": {
     "decl": "### Empirical Reference Values",
     "file": "gaussian/integration-tests",
@@ -652,6 +705,13 @@
     "refs": [],
     "title": "Extended: `build_input(input_model, config, template=None)`",
     "type": "section"
+  },
+  "rq-5c04235d": {
+    "decl": "Scenario: HF/cc-pVDZ energy on a single He atom returns the expected value with NRE=0",
+    "file": "gaussian/e2e-coverage",
+    "refs": [],
+    "title": "HF/cc-pVDZ energy on a single He atom returns the expected value with NRE=0",
+    "type": "scenario"
   },
   "rq-5c529f02": {
     "decl": "Scenario: out_mol preserves atom_labels when fix_com and fix_orientation are True",
@@ -696,6 +756,14 @@
     "title": "RHF gradient is correctly aligned to the (scrambled) input frame",
     "type": "scenario"
   },
+  "rq-6385e33d": {
+    "decl": "### T1: HF Hessian on water",
+    "file": "gaussian/e2e-coverage",
+    "level": 3,
+    "refs": [],
+    "title": "T1: HF Hessian on water",
+    "type": "section"
+  },
   "rq-6423b98b": {
     "decl": "### Files Modified",
     "file": "gaussian/integration-tests",
@@ -731,6 +799,13 @@
     "refs": [],
     "title": "Atom count mismatch raises ValueError when ghosts are present",
     "type": "scenario"
+  },
+  "rq-66ca9a20": {
+    "decl": "- `test_gaussian_b3lyp_d3_gradient_water` (T4)",
+    "file": "gaussian/e2e-coverage",
+    "refs": [],
+    "title": "test_gaussian_b3lyp_d3_gradient_water",
+    "type": "api-item"
   },
   "rq-68840f83": {
     "decl": "Scenario: Gradient is unchanged when dispersion is present",
@@ -788,6 +863,13 @@
     "title": "SCF is an alias for HF",
     "type": "scenario"
   },
+  "rq-70b16c33": {
+    "decl": "- `test_gaussian_properties_hf_water` (T2)",
+    "file": "gaussian/e2e-coverage",
+    "refs": [],
+    "title": "test_gaussian_properties_hf_water",
+    "type": "api-item"
+  },
   "rq-7152455e": {
     "decl": "Scenario: User keyword is appended to route line",
     "file": "gaussian/input-builder",
@@ -844,6 +926,14 @@
     "title": "Atom count sanity check passes when cclib atom count matches in_mol",
     "type": "scenario"
   },
+  "rq-7472fc74": {
+    "decl": "## Coverage Gaps Closed by This Feature",
+    "file": "gaussian/e2e-coverage",
+    "level": 2,
+    "refs": [],
+    "title": "Coverage Gaps Closed by This Feature",
+    "type": "section"
+  },
   "rq-74e0110c": {
     "decl": "## Molecule Block Construction",
     "file": "gaussian/input-builder",
@@ -858,6 +948,14 @@
     "refs": [],
     "title": "muster_modelchem recognises canonical key alias \"d3zero2b\"",
     "type": "scenario"
+  },
+  "rq-7c70da2a": {
+    "decl": "## Reference Values",
+    "file": "gaussian/e2e-coverage",
+    "level": 2,
+    "refs": [],
+    "title": "Reference Values",
+    "type": "section"
   },
   "rq-7d1fb16e": {
     "decl": "## Feature API",
@@ -887,6 +985,14 @@
     "level": 2,
     "refs": [],
     "title": "Test Integrations",
+    "type": "section"
+  },
+  "rq-80a8de50": {
+    "decl": "### T4: B3LYP-D3 gradient on water",
+    "file": "gaussian/e2e-coverage",
+    "level": 3,
+    "refs": [],
+    "title": "T4: B3LYP-D3 gradient on water",
     "type": "section"
   },
   "rq-815d5fee": {
@@ -942,6 +1048,14 @@
     "title": "Unknown method is passed through verbatim (uppercased)",
     "type": "scenario"
   },
+  "rq-86480a7b": {
+    "decl": "## Feature API",
+    "file": "gaussian/e2e-coverage",
+    "level": 2,
+    "refs": [],
+    "title": "Feature API",
+    "type": "section"
+  },
   "rq-86c27356": {
     "decl": "- `InputError` — if `driver` is not one of the four supported values.",
     "file": "gaussian/input-builder",
@@ -961,6 +1075,13 @@
     "file": "gaussian/integration-tests",
     "refs": [],
     "title": "RHF hessian is correctly aligned to the (scrambled) input frame",
+    "type": "scenario"
+  },
+  "rq-89896430": {
+    "decl": "Scenario: HF/STO-3G Hessian on water has correct shape and reference values",
+    "file": "gaussian/e2e-coverage",
+    "refs": [],
+    "title": "HF/STO-3G Hessian on water has correct shape and reference values",
     "type": "scenario"
   },
   "rq-8d6fc024": {
@@ -1048,6 +1169,14 @@
     "refs": [],
     "title": "- `\"DIPOLE MOMENT\"` — magnitude of `ccdata.moments[1]` in Debye.",
     "type": "api-item"
+  },
+  "rq-954dd6f3": {
+    "decl": "### T6: Single-atom He HF/cc-pVDZ",
+    "file": "gaussian/e2e-coverage",
+    "level": 3,
+    "refs": [],
+    "title": "T6: Single-atom He HF/cc-pVDZ",
+    "type": "section"
   },
   "rq-95535d13": {
     "decl": "Scenario: muster_modelchem raises InputError for D3M(BJ)",
@@ -1217,6 +1346,13 @@
     "title": "Nuclear repulsion energy cross-check passes for consistent geometry",
     "type": "scenario"
   },
+  "rq-a9ab12b3": {
+    "decl": "# Feature: Gaussian Harness — End-to-End Coverage Tests",
+    "file": "gaussian/e2e-coverage",
+    "refs": [],
+    "title": "Feature: Gaussian Harness — End-to-End Coverage Tests",
+    "type": "file"
+  },
   "rq-aa991a3a": {
     "decl": "Scenario: native_files protocol \"all\" returns input and output files",
     "file": "gaussian/integration-tests",
@@ -1231,6 +1367,13 @@
     "title": "Route line for closed-shell HF energy",
     "type": "scenario"
   },
+  "rq-af1fd6a9": {
+    "decl": "Scenario: B3LYP/cc-pVDZ energy on water matches reference without emitting dispersion qcvars",
+    "file": "gaussian/e2e-coverage",
+    "refs": [],
+    "title": "B3LYP/cc-pVDZ energy on water matches reference without emitting dispersion qcvars",
+    "type": "scenario"
+  },
   "rq-af4f9bf0": {
     "decl": "Scenario: muster_modelchem strips \"-d2\" and emits EmpiricalDispersion=GD2",
     "file": "gaussian/dispersion",
@@ -1243,6 +1386,13 @@
     "file": "gaussian/atom-labels",
     "refs": [],
     "title": "The \"alternative SCF solution\" branch in test_atom_labels accepts Gaussian",
+    "type": "scenario"
+  },
+  "rq-b10501a0": {
+    "decl": "Scenario: B3LYP-D3/6-31G* gradient on water matches reference and exposes dispersion qcvars",
+    "file": "gaussian/e2e-coverage",
+    "refs": [],
+    "title": "B3LYP-D3/6-31G* gradient on water matches reference and exposes dispersion qcvars",
     "type": "scenario"
   },
   "rq-b27d4aff": {
@@ -1286,6 +1436,13 @@
     "refs": [],
     "title": "Log with no coordinate data raises ValueError",
     "type": "scenario"
+  },
+  "rq-b8065553": {
+    "decl": "- `test_gaussian_b3lyp_d3_hessian_water` (T7)",
+    "file": "gaussian/e2e-coverage",
+    "refs": [],
+    "title": "test_gaussian_b3lyp_d3_hessian_water",
+    "type": "api-item"
   },
   "rq-b819d8e0": {
     "decl": "Scenario: Atom coordinates appear in Angstrom with at least 10 decimal places",
@@ -1370,6 +1527,14 @@
     "title": "Out-of-Scope",
     "type": "section"
   },
+  "rq-c38f1b61": {
+    "decl": "### T5: NH₂· UHF on cc-pVDZ",
+    "file": "gaussian/e2e-coverage",
+    "level": 3,
+    "refs": [],
+    "title": "T5: NH₂· UHF on cc-pVDZ",
+    "type": "section"
+  },
   "rq-c3ebee03": {
     "decl": "## Method and Driver Compatibility",
     "file": "gaussian/atom-labels",
@@ -1429,6 +1594,14 @@
     "title": "- `\"MULLIKEN CHARGES\"` — from `ccdata.atomcharges[\"mulliken\"]`.",
     "type": "api-item"
   },
+  "rq-c88cc8ec": {
+    "decl": "### Fixtures and helpers",
+    "file": "gaussian/e2e-coverage",
+    "level": 3,
+    "refs": [],
+    "title": "Fixtures and helpers",
+    "type": "section"
+  },
   "rq-c946c285": {
     "decl": "Scenario: Triplet automatically prepends U to B3LYP",
     "file": "gaussian/input-builder",
@@ -1459,6 +1632,21 @@
     "title": "Route line for properties calculation includes Pop=Full",
     "type": "scenario"
   },
+  "rq-cd65e68a": {
+    "decl": "- `test_gaussian_single_atom_he` (T6)",
+    "file": "gaussian/e2e-coverage",
+    "refs": [],
+    "title": "test_gaussian_single_atom_he",
+    "type": "api-item"
+  },
+  "rq-ce2ecf6a": {
+    "decl": "### Reference-value provenance",
+    "file": "gaussian/e2e-coverage",
+    "level": 3,
+    "refs": [],
+    "title": "Reference-value provenance",
+    "type": "section"
+  },
   "rq-ce76f384": {
     "decl": "Scenario: All-ghost molecule produces an atom block with every line \"-Bq\"-suffixed",
     "file": "gaussian/ghost-atoms",
@@ -1473,6 +1661,13 @@
     "refs": [],
     "title": "Integration Test",
     "type": "section"
+  },
+  "rq-cedda71e": {
+    "decl": "Scenario: B3LYP-D3/6-31G* Hessian on water succeeds and emits the dispersion qcvar",
+    "file": "gaussian/e2e-coverage",
+    "refs": [],
+    "title": "B3LYP-D3/6-31G* Hessian on water succeeds and emits the dispersion qcvar",
+    "type": "scenario"
   },
   "rq-ceef73bd": {
     "decl": "Scenario: Coordinate precision is preserved for ghost atoms",
@@ -1489,12 +1684,27 @@
     "title": "Feature API",
     "type": "section"
   },
+  "rq-d06d7266": {
+    "decl": "- `test_gaussian_uhf_nh2` (T5)",
+    "file": "gaussian/e2e-coverage",
+    "refs": [],
+    "title": "test_gaussian_uhf_nh2",
+    "type": "api-item"
+  },
   "rq-d3b8d8c3": {
     "decl": "Scenario: found() falls back to g09 when g16 is absent",
     "file": "gaussian/runner",
     "refs": [],
     "title": "found() falls back to g09 when g16 is absent",
     "type": "scenario"
+  },
+  "rq-d42168a0": {
+    "decl": "### Test runtime budget",
+    "file": "gaussian/e2e-coverage",
+    "level": 3,
+    "refs": [],
+    "title": "Test runtime budget",
+    "type": "section"
   },
   "rq-d4e60dd2": {
     "decl": "Scenario: MP2/6-31G* energy on mAgB (real ethylene + ghost ethyne) matches reference",
@@ -1551,6 +1761,21 @@
     "file": "gaussian/input-builder",
     "refs": [],
     "title": "Memory directive rounds down to nearest integer GB (minimum 1)",
+    "type": "scenario"
+  },
+  "rq-dbf8a9a5": {
+    "decl": "### T7: B3LYP-D3 Hessian on water",
+    "file": "gaussian/e2e-coverage",
+    "level": 3,
+    "refs": [],
+    "title": "T7: B3LYP-D3 Hessian on water",
+    "type": "section"
+  },
+  "rq-dc1bf912": {
+    "decl": "Scenario: HF/STO-3G properties on water populates dipole and Mulliken charges",
+    "file": "gaussian/e2e-coverage",
+    "refs": [],
+    "title": "HF/STO-3G properties on water populates dipole and Mulliken charges",
     "type": "scenario"
   },
   "rq-dceb51f5": {
@@ -1611,6 +1836,14 @@
     "refs": [],
     "title": "ROHF + dispersion does not double-prefix U",
     "type": "scenario"
+  },
+  "rq-e199db9a": {
+    "decl": "### T2: HF properties on water",
+    "file": "gaussian/e2e-coverage",
+    "level": 3,
+    "refs": [],
+    "title": "T2: HF properties on water",
+    "type": "section"
   },
   "rq-e5a98119": {
     "decl": "Scenario: NRE cross-check is unchanged for all-real molecules",

--- a/rqm/registry.json
+++ b/rqm/registry.json
@@ -74,13 +74,6 @@
     "title": "Method matching is case-insensitive",
     "type": "scenario"
   },
-  "rq-090d144e": {
-    "decl": "Scenario: Labels do not appear in the route line",
-    "file": "gaussian/atom-labels",
-    "refs": [],
-    "title": "Labels do not appear in the route line",
-    "type": "scenario"
-  },
   "rq-09dd261d": {
     "decl": "Scenario: muster_modelchem raises InputError for D4",
     "file": "gaussian/dispersion",
@@ -530,13 +523,6 @@
     "title": "Feature: Gaussian Harness — Runner",
     "type": "file"
   },
-  "rq-44289c40": {
-    "decl": "Scenario: Dispersion energy is read from ccdata.dispersionenergies",
-    "file": "gaussian/harvester",
-    "refs": [],
-    "title": "Dispersion energy is read from ccdata.dispersionenergies",
-    "type": "scenario"
-  },
   "rq-44319e8c": {
     "decl": "Scenario: Conflict detection is case-insensitive on the keyword name",
     "file": "gaussian/dispersion",
@@ -732,13 +718,6 @@
     "title": "Gaussian appears in _canonical_methods",
     "type": "scenario"
   },
-  "rq-64be1785": {
-    "decl": "Scenario: pgline regex matches Gaussian's \"Full point group\" line for linear C*V",
-    "file": "gaussian/ghost-atoms",
-    "refs": [],
-    "title": "pgline regex matches Gaussian's \"Full point group\" line for linear C*V",
-    "type": "scenario"
-  },
   "rq-65cb367e": {
     "decl": "Scenario: Memory configuration is applied with 1.555 GiB total node memory",
     "file": "gaussian/integration-tests",
@@ -796,10 +775,10 @@
     "type": "scenario"
   },
   "rq-6f52a6d9": {
-    "decl": "Scenario: Functional-specific dispersion qcvar uses the formal label",
+    "decl": "Scenario: Dispersion energy populates generic and functional-specific qcvars",
     "file": "gaussian/dispersion",
     "refs": [],
-    "title": "Functional-specific dispersion qcvar uses the formal label",
+    "title": "Dispersion energy populates generic and functional-specific qcvars",
     "type": "scenario"
   },
   "rq-7049aaa5": {
@@ -873,13 +852,6 @@
     "title": "Molecule Block Construction",
     "type": "section"
   },
-  "rq-7a592160": {
-    "decl": "Scenario: Empty atom_labels (all-default) preserves existing behavior",
-    "file": "gaussian/atom-labels",
-    "refs": [],
-    "title": "Empty atom_labels (all-default) preserves existing behavior",
-    "type": "scenario"
-  },
   "rq-7c3a72b9": {
     "decl": "Scenario: muster_modelchem recognises canonical key alias \"d3zero2b\"",
     "file": "gaussian/dispersion",
@@ -900,13 +872,6 @@
     "file": "gaussian/ghost-atoms",
     "refs": [],
     "title": "test_tricky_ghost accepts Gaussian's linear PG for the mB subject",
-    "type": "scenario"
-  },
-  "rq-7edf875d": {
-    "decl": "Scenario: No log-text regex is used for SCF, MP*, CC, or dispersion energies",
-    "file": "gaussian/harvester",
-    "refs": [],
-    "title": "No log-text regex is used for SCF, MP*, CC, or dispersion energies",
     "type": "scenario"
   },
   "rq-7f2c22fd": {
@@ -1179,13 +1144,6 @@
     "title": "Route line is unchanged when ghost atoms are present",
     "type": "scenario"
   },
-  "rq-a1bc15af": {
-    "decl": "Scenario: build_input() accepts a labeled molecule without raising",
-    "file": "gaussian/atom-labels",
-    "refs": [],
-    "title": "build_input() accepts a labeled molecule without raising",
-    "type": "scenario"
-  },
   "rq-a203a314": {
     "decl": "### `harvest` — confirmed behavior for labeled molecules",
     "file": "gaussian/atom-labels",
@@ -1237,13 +1195,6 @@
     "refs": [],
     "title": "Feature API",
     "type": "section"
-  },
-  "rq-a83b7d5f": {
-    "decl": "Scenario: Dispersion energy is read from ccdata.dispersionenergies via cclib's convertor",
-    "file": "gaussian/dispersion",
-    "refs": [],
-    "title": "Dispersion energy is read from ccdata.dispersionenergies via cclib's convertor",
-    "type": "scenario"
   },
   "rq-a88c706f": {
     "decl": "- `method` — method string from `AtomicInput.model.method` (case-insensitive).",
@@ -1600,13 +1551,6 @@
     "file": "gaussian/input-builder",
     "refs": [],
     "title": "Memory directive rounds down to nearest integer GB (minimum 1)",
-    "type": "scenario"
-  },
-  "rq-dc9a34d9": {
-    "decl": "Scenario: pgline regex matches Gaussian's \"Full point group\" line for C2v",
-    "file": "gaussian/ghost-atoms",
-    "refs": [],
-    "title": "pgline regex matches Gaussian's \"Full point group\" line for C2v",
     "type": "scenario"
   },
   "rq-dceb51f5": {

--- a/rqm/registry.json
+++ b/rqm/registry.json
@@ -14,6 +14,20 @@
     "title": "HF method maps to \"HF\" method string",
     "type": "scenario"
   },
+  "rq-04028610": {
+    "decl": "Scenario: AtomicResult.molecule preserves ghost designation",
+    "file": "gaussian/ghost-atoms",
+    "refs": [],
+    "title": "AtomicResult.molecule preserves ghost designation",
+    "type": "scenario"
+  },
+  "rq-04ed684d": {
+    "decl": "Scenario: Gradient of a ghost-bearing system matches a reference vector",
+    "file": "gaussian/ghost-atoms",
+    "refs": [],
+    "title": "Gradient of a ghost-bearing system matches a reference vector",
+    "type": "scenario"
+  },
   "rq-058819da": {
     "decl": "## Gherkin Scenarios",
     "file": "gaussian/harvester",
@@ -159,6 +173,13 @@
     "title": "get_version() raises UnknownError if version cannot be parsed",
     "type": "scenario"
   },
+  "rq-2229f087": {
+    "decl": "Scenario: Real atom emits a plain element symbol in the atom block",
+    "file": "gaussian/ghost-atoms",
+    "refs": [],
+    "title": "Real atom emits a plain element symbol in the atom block",
+    "type": "scenario"
+  },
   "rq-23d8b2c6": {
     "decl": "Scenario: The .com file ends with a trailing blank line",
     "file": "gaussian/input-builder",
@@ -173,11 +194,25 @@
     "title": "found(raise_error=True) raises ModuleNotFoundError when cclib is missing",
     "type": "scenario"
   },
+  "rq-24d73182": {
+    "decl": "Scenario: Energy of a ghost-bearing system matches a reference value",
+    "file": "gaussian/ghost-atoms",
+    "refs": [],
+    "title": "Energy of a ghost-bearing system matches a reference value",
+    "type": "scenario"
+  },
   "rq-25c4ad49": {
     "decl": "Scenario: Method already starting with U is not double-prefixed",
     "file": "gaussian/input-builder",
     "refs": [],
     "title": "Method already starting with U is not double-prefixed",
+    "type": "scenario"
+  },
+  "rq-2a015edf": {
+    "decl": "Scenario: Mixed real and ghost atoms in one molecule",
+    "file": "gaussian/ghost-atoms",
+    "refs": [],
+    "title": "Mixed real and ghost atoms in one molecule",
     "type": "scenario"
   },
   "rq-2aa0e9e1": {
@@ -268,6 +303,14 @@
     "title": "get_version() caches the result after the first call",
     "type": "scenario"
   },
+  "rq-4091a959": {
+    "decl": "## Method and Driver Compatibility",
+    "file": "gaussian/ghost-atoms",
+    "level": 2,
+    "refs": [],
+    "title": "Method and Driver Compatibility",
+    "type": "section"
+  },
   "rq-4252ac2d": {
     "decl": "Scenario: Multi-core execution succeeds and ncores is reflected in output",
     "file": "gaussian/integration-tests",
@@ -337,13 +380,6 @@
     "refs": [],
     "title": "multiplicity",
     "type": "api-item"
-  },
-  "rq-5053204b": {
-    "decl": "Scenario: Ghost atoms in the molecule raise InputError",
-    "file": "gaussian/input-builder",
-    "refs": [],
-    "title": "Ghost atoms in the molecule raise InputError",
-    "type": "scenario"
   },
   "rq-519fbe49": {
     "decl": "Scenario: Single-core execution succeeds",
@@ -424,6 +460,13 @@
     "title": "Memory configuration is applied with 1.555 GiB total node memory",
     "type": "scenario"
   },
+  "rq-66067019": {
+    "decl": "Scenario: Atom count mismatch raises ValueError when ghosts are present",
+    "file": "gaussian/ghost-atoms",
+    "refs": [],
+    "title": "Atom count mismatch raises ValueError when ghosts are present",
+    "type": "scenario"
+  },
   "rq-6a889dea": {
     "decl": "Scenario: UHF energy is invariant to input frame scrambling",
     "file": "gaussian/integration-tests",
@@ -480,6 +523,27 @@
     "title": "Parse HF total energy from a closed-shell log",
     "type": "scenario"
   },
+  "rq-731f01ba": {
+    "decl": "Scenario: out_mol.symbols are copied from in_mol for ghost positions",
+    "file": "gaussian/ghost-atoms",
+    "refs": [],
+    "title": "out_mol.symbols are copied from in_mol for ghost positions",
+    "type": "scenario"
+  },
+  "rq-73c1f919": {
+    "decl": "# Feature: Gaussian Harness — Ghost Atom Support",
+    "file": "gaussian/ghost-atoms",
+    "refs": [],
+    "title": "Feature: Gaussian Harness — Ghost Atom Support",
+    "type": "file"
+  },
+  "rq-7411efa0": {
+    "decl": "Scenario: Atom count sanity check passes when cclib atom count matches in_mol",
+    "file": "gaussian/ghost-atoms",
+    "refs": [],
+    "title": "Atom count sanity check passes when cclib atom count matches in_mol",
+    "type": "scenario"
+  },
   "rq-74e0110c": {
     "decl": "## Molecule Block Construction",
     "file": "gaussian/input-builder",
@@ -525,6 +589,14 @@
     "refs": [],
     "title": "Hessian driver produces \"Freq\"",
     "type": "scenario"
+  },
+  "rq-84b093c1": {
+    "decl": "## Gherkin Scenarios",
+    "file": "gaussian/ghost-atoms",
+    "level": 2,
+    "refs": [],
+    "title": "Gherkin Scenarios",
+    "type": "section"
   },
   "rq-850ede4f": {
     "decl": "Scenario: get_version() returns a normalised version string for Gaussian 09",
@@ -589,6 +661,13 @@
     "refs": [],
     "title": "ValueError",
     "type": "api-item"
+  },
+  "rq-916e4919": {
+    "decl": "Scenario: Ghost atom emits a \"-Bq\" suffix in the atom block",
+    "file": "gaussian/ghost-atoms",
+    "refs": [],
+    "title": "Ghost atom emits a \"-Bq\" suffix in the atom block",
+    "type": "scenario"
   },
   "rq-923b3212": {
     "decl": "Scenario: native_files protocol \"input\" returns only the input file",
@@ -678,11 +757,25 @@
     "title": "Gaussian Input File Format",
     "type": "section"
   },
+  "rq-a100502c": {
+    "decl": "Scenario: Route line is unchanged when ghost atoms are present",
+    "file": "gaussian/ghost-atoms",
+    "refs": [],
+    "title": "Route line is unchanged when ghost atoms are present",
+    "type": "scenario"
+  },
   "rq-a4c449da": {
     "decl": "Scenario: compute() raises ResourceError on memory allocation failure",
     "file": "gaussian/runner",
     "refs": [],
     "title": "compute() raises ResourceError on memory allocation failure",
+    "type": "scenario"
+  },
+  "rq-a69d0898": {
+    "decl": "Scenario: NRE cross-check excludes ghost atoms when present",
+    "file": "gaussian/ghost-atoms",
+    "refs": [],
+    "title": "NRE cross-check excludes ghost atoms when present",
     "type": "scenario"
   },
   "rq-a76c3d7b": {
@@ -691,6 +784,14 @@
     "refs": [],
     "title": "Output molecule geometry is constructed from ccdata",
     "type": "scenario"
+  },
+  "rq-a78c68a8": {
+    "decl": "## Feature API",
+    "file": "gaussian/ghost-atoms",
+    "level": 2,
+    "refs": [],
+    "title": "Feature API",
+    "type": "section"
   },
   "rq-a88c706f": {
     "decl": "- `method` — method string from `AtomicInput.model.method` (case-insensitive).",
@@ -720,12 +821,26 @@
     "title": "Route line for closed-shell HF energy",
     "type": "scenario"
   },
+  "rq-b27d4aff": {
+    "decl": "Scenario: out_mol.real is copied from in_mol when ghosts are present",
+    "file": "gaussian/ghost-atoms",
+    "refs": [],
+    "title": "out_mol.real is copied from in_mol when ghosts are present",
+    "type": "scenario"
+  },
   "rq-b49bb2a2": {
     "decl": "- `driver` — one of `\"energy\"`, `\"gradient\"`, `\"hessian\"`, `\"properties\"`.",
     "file": "gaussian/input-builder",
     "refs": [],
     "title": "driver",
     "type": "api-item"
+  },
+  "rq-b57c882b": {
+    "decl": "Scenario: NRE cross-check still catches geometry mismatches with ghosts present",
+    "file": "gaussian/ghost-atoms",
+    "refs": [],
+    "title": "NRE cross-check still catches geometry mismatches with ghosts present",
+    "type": "scenario"
   },
   "rq-b5e72c6d": {
     "decl": "Scenario: found() returns False when cclib is not importable",
@@ -778,6 +893,14 @@
     "title": "Prerequisite: native_files Key Convention",
     "type": "section"
   },
+  "rq-bd6cd9a4": {
+    "decl": "### Modified: `GaussianHarness.build_input(input_model, config, template=None)`",
+    "file": "gaussian/ghost-atoms",
+    "level": 3,
+    "refs": [],
+    "title": "Modified: `GaussianHarness.build_input(input_model, config, template=None)`",
+    "type": "section"
+  },
   "rq-bd98d417": {
     "decl": "Scenario: found(raise_error=True) raises ModuleNotFoundError when g16 is missing",
     "file": "gaussian/runner",
@@ -807,6 +930,14 @@
     "refs": [],
     "title": "Energy driver produces no job-type keyword",
     "type": "scenario"
+  },
+  "rq-c4439b82": {
+    "decl": "## Integration Tests",
+    "file": "gaussian/ghost-atoms",
+    "level": 2,
+    "refs": [],
+    "title": "Integration Tests",
+    "type": "section"
   },
   "rq-c5165f1f": {
     "decl": "- `\"CURRENT ENERGY\"` — set to the highest-level energy available (see below).",
@@ -867,6 +998,20 @@
     "title": "Route line for properties calculation includes Pop=Full",
     "type": "scenario"
   },
+  "rq-ce76f384": {
+    "decl": "Scenario: All-ghost molecule produces an atom block with every line \"-Bq\"-suffixed",
+    "file": "gaussian/ghost-atoms",
+    "refs": [],
+    "title": "All-ghost molecule produces an atom block with every line \"-Bq\"-suffixed",
+    "type": "scenario"
+  },
+  "rq-ceef73bd": {
+    "decl": "Scenario: Coordinate precision is preserved for ghost atoms",
+    "file": "gaussian/ghost-atoms",
+    "refs": [],
+    "title": "Coordinate precision is preserved for ghost atoms",
+    "type": "scenario"
+  },
   "rq-cf6fdf8a": {
     "decl": "## Feature API",
     "file": "gaussian/runner",
@@ -904,6 +1049,13 @@
     "title": "`harvest(in_mol: Molecule, method: str, log_content: str) -> Tuple[PreservingDict, Optional[np.ndarray], Optional[np.ndarray], Molecule]`",
     "type": "section"
   },
+  "rq-d97cc860": {
+    "decl": "Scenario: Gradient array spans real and ghost atoms in input order",
+    "file": "gaussian/ghost-atoms",
+    "refs": [],
+    "title": "Gradient array spans real and ghost atoms in input order",
+    "type": "scenario"
+  },
   "rq-db92093a": {
     "decl": "Scenario: Memory directive rounds down to nearest integer GB (minimum 1)",
     "file": "gaussian/input-builder",
@@ -911,11 +1063,34 @@
     "title": "Memory directive rounds down to nearest integer GB (minimum 1)",
     "type": "scenario"
   },
+  "rq-dceb51f5": {
+    "decl": "## Background: Gaussian Ghost-Atom Syntax",
+    "file": "gaussian/ghost-atoms",
+    "level": 2,
+    "refs": [],
+    "title": "Background: Gaussian Ghost-Atom Syntax",
+    "type": "section"
+  },
+  "rq-df7eb0c3": {
+    "decl": "## Migration Notes",
+    "file": "gaussian/ghost-atoms",
+    "level": 2,
+    "refs": [],
+    "title": "Migration Notes",
+    "type": "section"
+  },
   "rq-e008c6fe": {
     "decl": "Scenario: Unsupported driver raises InputError",
     "file": "gaussian/input-builder",
     "refs": [],
     "title": "Unsupported driver raises InputError",
+    "type": "scenario"
+  },
+  "rq-e5a98119": {
+    "decl": "Scenario: NRE cross-check is unchanged for all-real molecules",
+    "file": "gaussian/ghost-atoms",
+    "refs": [],
+    "title": "NRE cross-check is unchanged for all-real molecules",
     "type": "scenario"
   },
   "rq-e62578e2": {
@@ -984,6 +1159,14 @@
     "title": "Gradient driver produces \"Force=NoStep\"",
     "type": "scenario"
   },
+  "rq-f1d712bb": {
+    "decl": "### Modified: `harvest(in_mol, method, log_content)`",
+    "file": "gaussian/ghost-atoms",
+    "level": 3,
+    "refs": [],
+    "title": "Modified: `harvest(in_mol, method, log_content)`",
+    "type": "section"
+  },
   "rq-f28b3bed": {
     "decl": "## Implementation Notes",
     "file": "gaussian/integration-tests",
@@ -1028,6 +1211,13 @@
     "refs": [],
     "title": "cclib Limitations",
     "type": "section"
+  },
+  "rq-f8ce079b": {
+    "decl": "Scenario: align() calls use generic_ghosts=True when ghosts are present",
+    "file": "gaussian/ghost-atoms",
+    "refs": [],
+    "title": "align() calls use generic_ghosts=True when ghosts are present",
+    "type": "scenario"
   },
   "rq-fe13245b": {
     "decl": "Scenario: Method starting with RO is not prefixed with U",

--- a/rqm/registry.json
+++ b/rqm/registry.json
@@ -22,6 +22,14 @@
     "title": "Gherkin Scenarios",
     "type": "section"
   },
+  "rq-0743e952": {
+    "decl": "## Other Regex Items",
+    "file": "gaussian/harvester",
+    "level": 2,
+    "refs": [],
+    "title": "Other Regex Items",
+    "type": "section"
+  },
   "rq-0753cd03": {
     "decl": "- `\"NUCLEAR REPULSION ENERGY\"` — from parsed geometry.",
     "file": "gaussian/harvester",
@@ -49,6 +57,20 @@
     "refs": [],
     "title": "Nuclear repulsion energy mismatch raises ValueError",
     "type": "scenario"
+  },
+  "rq-0cdd386d": {
+    "decl": "- `\"N BETA ELECTRONS\"` — from `ccdata.homos[-1] + 1` (or same as alpha for closed-shell).",
+    "file": "gaussian/harvester",
+    "refs": [],
+    "title": "- `\"N BETA ELECTRONS\"` — from `ccdata.homos[-1] + 1` (or same as alpha for closed-shell).",
+    "type": "api-item"
+  },
+  "rq-0d2711f1": {
+    "decl": "- `\"CURRENT REFERENCE ENERGY\"` — same value as `\"HF TOTAL ENERGY\"` (required by standard suite contracts).",
+    "file": "gaussian/harvester",
+    "refs": [],
+    "title": "- `\"CURRENT REFERENCE ENERGY\"` — same value as `\"HF TOTAL ENERGY\"` (required by standard suite contracts).",
+    "type": "api-item"
   },
   "rq-0edebcd3": {
     "decl": "### `test_local_options_memory_gib` (`test_canonical_config.py`)",
@@ -86,6 +108,13 @@
     "refs": [],
     "title": "Registration",
     "type": "section"
+  },
+  "rq-17e8c0f7": {
+    "decl": "- `\"N BASIS FUNCTIONS\"` — from `ccdata.nbasis` (when available).",
+    "file": "gaussian/harvester",
+    "refs": [],
+    "title": "- `\"N BASIS FUNCTIONS\"` — from `ccdata.nbasis` (when available).",
+    "type": "api-item"
   },
   "rq-186c5060": {
     "decl": "Scenario: get_version() returns a normalised version string for Gaussian 16",
@@ -203,10 +232,10 @@
     "type": "scenario"
   },
   "rq-37f40e92": {
-    "decl": "- `\"HF TOTAL ENERGY\"` — always set from `ccdata.scfenergies[-1]` (in Hartree).",
+    "decl": "- `\"HF TOTAL ENERGY\"` — from direct log parsing (SCF Done line), falling back to `ccdata.scfenergies[-1]` converted from eV.",
     "file": "gaussian/harvester",
     "refs": [],
-    "title": "- `\"HF TOTAL ENERGY\"` — always set from `ccdata.scfenergies[-1]` (in Hartree).",
+    "title": "- `\"HF TOTAL ENERGY\"` — from direct log parsing (SCF Done line), falling back to `ccdata.scfenergies[-1]` converted from eV.",
     "type": "api-item"
   },
   "rq-3a18d6af": {
@@ -259,6 +288,13 @@
     "refs": [],
     "title": "Feature: Gaussian Harness — Runner",
     "type": "file"
+  },
+  "rq-463ef385": {
+    "decl": "- `\"N ATOMS\"` — from `len(ccdata.atomnos)`.",
+    "file": "gaussian/harvester",
+    "refs": [],
+    "title": "- `\"N ATOMS\"` — from `len(ccdata.atomnos)`.",
+    "type": "api-item"
   },
   "rq-475c8796": {
     "decl": "Scenario: CCSD(T)/aug-cc-pVDZ RHF energy on water matches Gaussian-specific reference",
@@ -367,6 +403,13 @@
     "title": "Files Modified",
     "type": "section"
   },
+  "rq-6453046a": {
+    "decl": "- `\"N ALPHA ELECTRONS\"` — from `ccdata.homos[0] + 1`.",
+    "file": "gaussian/harvester",
+    "refs": [],
+    "title": "- `\"N ALPHA ELECTRONS\"` — from `ccdata.homos[0] + 1`.",
+    "type": "api-item"
+  },
   "rq-647b596c": {
     "decl": "Scenario: Gaussian appears in _canonical_methods",
     "file": "gaussian/integration-tests",
@@ -445,6 +488,13 @@
     "title": "Molecule Block Construction",
     "type": "section"
   },
+  "rq-7f2c22fd": {
+    "decl": "- `\"N MOLECULAR ORBITALS\"` — from `ccdata.nmo` (when available).",
+    "file": "gaussian/harvester",
+    "refs": [],
+    "title": "- `\"N MOLECULAR ORBITALS\"` — from `ccdata.nmo` (when available).",
+    "type": "api-item"
+  },
   "rq-8070c4fd": {
     "decl": "## Test Integrations",
     "file": "gaussian/integration-tests",
@@ -505,11 +555,11 @@
     "type": "scenario"
   },
   "rq-8d6fc024": {
-    "decl": "### Output Molecule Construction",
+    "decl": "### Output Molecule Construction and Frame Alignment",
     "file": "gaussian/harvester",
     "level": 3,
     "refs": [],
-    "title": "Output Molecule Construction",
+    "title": "Output Molecule Construction and Frame Alignment",
     "type": "section"
   },
   "rq-8df082e3": {
@@ -744,11 +794,11 @@
     "type": "section"
   },
   "rq-c20746b1": {
-    "decl": "## Regex Fallback",
+    "decl": "## Direct Energy Parsing",
     "file": "gaussian/harvester",
     "level": 2,
     "refs": [],
-    "title": "Regex Fallback",
+    "title": "Direct Energy Parsing",
     "type": "section"
   },
   "rq-c266b9bb": {
@@ -764,6 +814,14 @@
     "refs": [],
     "title": "- `\"CURRENT ENERGY\"` — set to the highest-level energy available (see below).",
     "type": "api-item"
+  },
+  "rq-c5b27d26": {
+    "decl": "## Hessian Parsing",
+    "file": "gaussian/harvester",
+    "level": 2,
+    "refs": [],
+    "title": "Hessian Parsing",
+    "type": "section"
   },
   "rq-c77a2c13": {
     "decl": "Scenario: compute() raises InputError when model.basis is a BasisSet object",
@@ -941,12 +999,35 @@
     "title": "Parse Hessian from frequency calculation",
     "type": "scenario"
   },
+  "rq-f4900ee1": {
+    "decl": "### Coordinate Frame",
+    "file": "gaussian/harvester",
+    "level": 3,
+    "refs": [],
+    "title": "Coordinate Frame",
+    "type": "section"
+  },
   "rq-f512b60b": {
     "decl": "Scenario: Properties driver produces Pop=Full in extra_keywords",
     "file": "gaussian/input-builder",
     "refs": [],
     "title": "Properties driver produces Pop=Full in extra_keywords",
     "type": "scenario"
+  },
+  "rq-f59a07b8": {
+    "decl": "- `\"SCF TOTAL ENERGY\"` — same value as `\"HF TOTAL ENERGY\"` (required by standard suite contracts).",
+    "file": "gaussian/harvester",
+    "refs": [],
+    "title": "- `\"SCF TOTAL ENERGY\"` — same value as `\"HF TOTAL ENERGY\"` (required by standard suite contracts).",
+    "type": "api-item"
+  },
+  "rq-f6537c40": {
+    "decl": "### cclib Limitations",
+    "file": "gaussian/harvester",
+    "level": 3,
+    "refs": [],
+    "title": "cclib Limitations",
+    "type": "section"
   },
   "rq-fe13245b": {
     "decl": "Scenario: Method starting with RO is not prefixed with U",

--- a/rqm/registry.json
+++ b/rqm/registry.json
@@ -53,11 +53,11 @@
     "type": "section"
   },
   "rq-0743e952": {
-    "decl": "## Other Regex Items",
+    "decl": "## Regex Use",
     "file": "gaussian/harvester",
     "level": 2,
     "refs": [],
-    "title": "Other Regex Items",
+    "title": "Regex Use",
     "type": "section"
   },
   "rq-0753cd03": {
@@ -304,6 +304,20 @@
     "title": "Method already starting with U is not double-prefixed",
     "type": "scenario"
   },
+  "rq-2816c5f6": {
+    "decl": "Scenario: SCF energy round-trips through cclib's convertor exactly",
+    "file": "gaussian/harvester",
+    "refs": [],
+    "title": "SCF energy round-trips through cclib's convertor exactly",
+    "type": "scenario"
+  },
+  "rq-28b5b1b3": {
+    "decl": "Scenario: Missing scfenergies for an HF/DFT job raises ValueError",
+    "file": "gaussian/harvester",
+    "refs": [],
+    "title": "Missing scfenergies for an HF/DFT job raises ValueError",
+    "type": "scenario"
+  },
   "rq-29751017": {
     "decl": "## Background: Gaussian Dispersion Output",
     "file": "gaussian/dispersion",
@@ -332,6 +346,13 @@
     "file": "gaussian/integration-tests",
     "refs": [],
     "title": "Memory configuration is not overridden by conflicting DSL keywords",
+    "type": "scenario"
+  },
+  "rq-2abaea4c": {
+    "decl": "Scenario: Missing ccenergies for a CCSD job raises ValueError",
+    "file": "gaussian/harvester",
+    "refs": [],
+    "title": "Missing ccenergies for a CCSD job raises ValueError",
     "type": "scenario"
   },
   "rq-2ad053f2": {
@@ -373,10 +394,10 @@
     "type": "scenario"
   },
   "rq-3136523b": {
-    "decl": "Scenario: Dispersion energy falls back to ccdata.dispersionenergies when regex misses",
+    "decl": "Scenario: No dispersionenergies attribute means no dispersion qcvars",
     "file": "gaussian/dispersion",
     "refs": [],
-    "title": "Dispersion energy falls back to ccdata.dispersionenergies when regex misses",
+    "title": "No dispersionenergies attribute means no dispersion qcvars",
     "type": "scenario"
   },
   "rq-3257a6f5": {
@@ -422,10 +443,10 @@
     "type": "scenario"
   },
   "rq-37f40e92": {
-    "decl": "- `\"HF TOTAL ENERGY\"` — from direct log parsing (SCF Done line), falling back to `ccdata.scfenergies[-1]` converted from eV.",
+    "decl": "- `\"HF TOTAL ENERGY\"` — from `ccdata.scfenergies[-1]` converted via `cclib.parser.utils.convertor(\"eV\", \"hartree\")`.",
     "file": "gaussian/harvester",
     "refs": [],
-    "title": "- `\"HF TOTAL ENERGY\"` — from direct log parsing (SCF Done line), falling back to `ccdata.scfenergies[-1]` converted from eV.",
+    "title": "- `\"HF TOTAL ENERGY\"` — from `ccdata.scfenergies[-1]` converted via `cclib.parser.utils.convertor(\"eV\", \"hartree\")`.",
     "type": "api-item"
   },
   "rq-3a18d6af": {
@@ -509,6 +530,13 @@
     "title": "Feature: Gaussian Harness — Runner",
     "type": "file"
   },
+  "rq-44289c40": {
+    "decl": "Scenario: Dispersion energy is read from ccdata.dispersionenergies",
+    "file": "gaussian/harvester",
+    "refs": [],
+    "title": "Dispersion energy is read from ccdata.dispersionenergies",
+    "type": "scenario"
+  },
   "rq-44319e8c": {
     "decl": "Scenario: Conflict detection is case-insensitive on the keyword name",
     "file": "gaussian/dispersion",
@@ -557,6 +585,13 @@
     "file": "gaussian/runner",
     "refs": [],
     "title": "found() returns True when g16 and cclib are both available",
+    "type": "scenario"
+  },
+  "rq-4d653775": {
+    "decl": "Scenario: CCSD(T) total energy is read from ccenergies[-1]",
+    "file": "gaussian/harvester",
+    "refs": [],
+    "title": "CCSD(T) total energy is read from ccenergies[-1]",
     "type": "scenario"
   },
   "rq-4d683dac": {
@@ -725,6 +760,13 @@
     "title": "Gradient is unchanged when dispersion is present",
     "type": "scenario"
   },
+  "rq-69740b1b": {
+    "decl": "Scenario: Missing mpenergies for an MP2 job raises ValueError",
+    "file": "gaussian/harvester",
+    "refs": [],
+    "title": "Missing mpenergies for an MP2 job raises ValueError",
+    "type": "scenario"
+  },
   "rq-6a889dea": {
     "decl": "Scenario: UHF energy is invariant to input frame scrambling",
     "file": "gaussian/integration-tests",
@@ -858,6 +900,13 @@
     "file": "gaussian/ghost-atoms",
     "refs": [],
     "title": "test_tricky_ghost accepts Gaussian's linear PG for the mB subject",
+    "type": "scenario"
+  },
+  "rq-7edf875d": {
+    "decl": "Scenario: No log-text regex is used for SCF, MP*, CC, or dispersion energies",
+    "file": "gaussian/harvester",
+    "refs": [],
+    "title": "No log-text regex is used for SCF, MP*, CC, or dispersion energies",
     "type": "scenario"
   },
   "rq-7f2c22fd": {
@@ -1145,6 +1194,14 @@
     "title": "`harvest` — confirmed behavior for labeled molecules",
     "type": "section"
   },
+  "rq-a3c37e5d": {
+    "decl": "### cclib Limitation: Full Cartesian Hessian not extracted",
+    "file": "gaussian/harvester",
+    "level": 3,
+    "refs": [],
+    "title": "cclib Limitation: Full Cartesian Hessian not extracted",
+    "type": "section"
+  },
   "rq-a4c449da": {
     "decl": "Scenario: compute() raises ResourceError on memory allocation failure",
     "file": "gaussian/runner",
@@ -1182,10 +1239,10 @@
     "type": "section"
   },
   "rq-a83b7d5f": {
-    "decl": "Scenario: Dispersion energy is parsed via regex when the log contains the line",
+    "decl": "Scenario: Dispersion energy is read from ccdata.dispersionenergies via cclib's convertor",
     "file": "gaussian/dispersion",
     "refs": [],
-    "title": "Dispersion energy is parsed via regex when the log contains the line",
+    "title": "Dispersion energy is read from ccdata.dispersionenergies via cclib's convertor",
     "type": "scenario"
   },
   "rq-a88c706f": {
@@ -1340,11 +1397,11 @@
     "type": "section"
   },
   "rq-c20746b1": {
-    "decl": "## Direct Energy Parsing",
+    "decl": "## Energy Extraction",
     "file": "gaussian/harvester",
     "level": 2,
     "refs": [],
-    "title": "Direct Energy Parsing",
+    "title": "Energy Extraction",
     "type": "section"
   },
   "rq-c266b9bb": {
@@ -1560,6 +1617,13 @@
     "title": "Background: Gaussian Ghost-Atom Syntax",
     "type": "section"
   },
+  "rq-dd7024df": {
+    "decl": "Scenario: MP2 total energy is read from mpenergies[-1][-1]",
+    "file": "gaussian/harvester",
+    "refs": [],
+    "title": "MP2 total energy is read from mpenergies[-1][-1]",
+    "type": "scenario"
+  },
   "rq-dea9f7c9": {
     "decl": "## Gherkin Scenarios",
     "file": "gaussian/dispersion",
@@ -1569,10 +1633,10 @@
     "type": "section"
   },
   "rq-df49b3b8": {
-    "decl": "Scenario: No dispersion in log produces no dispersion qcvars",
+    "decl": "Scenario: No dispersionenergies attribute produces no dispersion qcvars",
     "file": "gaussian/dispersion",
     "refs": [],
-    "title": "No dispersion in log produces no dispersion qcvars",
+    "title": "No dispersionenergies attribute produces no dispersion qcvars",
     "type": "scenario"
   },
   "rq-df7eb0c3": {
@@ -1588,6 +1652,13 @@
     "file": "gaussian/input-builder",
     "refs": [],
     "title": "Unsupported driver raises InputError",
+    "type": "scenario"
+  },
+  "rq-e05f5cfe": {
+    "decl": "Scenario: Missing ccenergies for a CCSD(T) job raises ValueError",
+    "file": "gaussian/harvester",
+    "refs": [],
+    "title": "Missing ccenergies for a CCSD(T) job raises ValueError",
     "type": "scenario"
   },
   "rq-e1150329": {
@@ -1747,10 +1818,10 @@
     "type": "section"
   },
   "rq-f49de098": {
-    "decl": "Scenario: Methods without dispersion suffix do not get dispersion qcvars even if log has the line",
+    "decl": "Scenario: Methods without dispersion suffix still get the generic qcvar when dispersionenergies is present",
     "file": "gaussian/dispersion",
     "refs": [],
-    "title": "Methods without dispersion suffix do not get dispersion qcvars even if log has the line",
+    "title": "Methods without dispersion suffix still get the generic qcvar when dispersionenergies is present",
     "type": "scenario"
   },
   "rq-f4cbb515": {
@@ -1782,11 +1853,11 @@
     "type": "scenario"
   },
   "rq-f6537c40": {
-    "decl": "### cclib Limitations",
+    "decl": "### cclib Energy Precision",
     "file": "gaussian/harvester",
     "level": 3,
     "refs": [],
-    "title": "cclib Limitations",
+    "title": "cclib Energy Precision",
     "type": "section"
   },
   "rq-f8ce079b": {

--- a/rqm/registry.json
+++ b/rqm/registry.json
@@ -44,6 +44,14 @@
     "title": "Gherkin Scenarios",
     "type": "section"
   },
+  "rq-06ce6129": {
+    "decl": "## Out-of-Scope",
+    "file": "gaussian/dispersion",
+    "level": 2,
+    "refs": [],
+    "title": "Out-of-Scope",
+    "type": "section"
+  },
   "rq-0743e952": {
     "decl": "## Other Regex Items",
     "file": "gaussian/harvester",
@@ -73,6 +81,13 @@
     "title": "Labels do not appear in the route line",
     "type": "scenario"
   },
+  "rq-09dd261d": {
+    "decl": "Scenario: muster_modelchem raises InputError for D4",
+    "file": "gaussian/dispersion",
+    "refs": [],
+    "title": "muster_modelchem raises InputError for D4",
+    "type": "scenario"
+  },
   "rq-0aa99076": {
     "decl": "Scenario: BasisSet object for model.basis raises InputError",
     "file": "gaussian/input-builder",
@@ -86,6 +101,14 @@
     "refs": [],
     "title": "Nuclear repulsion energy mismatch raises ValueError",
     "type": "scenario"
+  },
+  "rq-0c1b5066": {
+    "decl": "### Extended: `muster_modelchem(method, driver, multiplicity)`",
+    "file": "gaussian/dispersion",
+    "level": 3,
+    "refs": [],
+    "title": "Extended: `muster_modelchem(method, driver, multiplicity)`",
+    "type": "section"
   },
   "rq-0cdd386d": {
     "decl": "- `\"N BETA ELECTRONS\"` — from `ccdata.homos[-1] + 1` (or same as alpha for closed-shell).",
@@ -123,6 +146,20 @@
     "title": "Feature: Gaussian Harness --- Cross-Program Integration Tests",
     "type": "file"
   },
+  "rq-0fe273a8": {
+    "decl": "Scenario: End-to-end B3LYP-D3/6-31G* energy on water with real Gaussian",
+    "file": "gaussian/dispersion",
+    "refs": [],
+    "title": "End-to-end B3LYP-D3/6-31G* energy on water with real Gaussian",
+    "type": "scenario"
+  },
+  "rq-11602838": {
+    "decl": "Scenario: HF with dispersion produces an HF functional",
+    "file": "gaussian/dispersion",
+    "refs": [],
+    "title": "HF with dispersion produces an HF functional",
+    "type": "scenario"
+  },
   "rq-12c41d5e": {
     "decl": "Scenario: Absent normal termination line is classified as abnormal",
     "file": "gaussian/harvester",
@@ -152,6 +189,13 @@
     "refs": [],
     "title": "Registration",
     "type": "section"
+  },
+  "rq-17959824": {
+    "decl": "# Feature: Gaussian Harness — Empirical Dispersion Support",
+    "file": "gaussian/dispersion",
+    "refs": [],
+    "title": "Feature: Gaussian Harness — Empirical Dispersion Support",
+    "type": "file"
   },
   "rq-17e8c0f7": {
     "decl": "- `\"N BASIS FUNCTIONS\"` — from `ccdata.nbasis` (when available).",
@@ -188,6 +232,21 @@
     "refs": [],
     "title": "Parse CCSD total energy",
     "type": "scenario"
+  },
+  "rq-1bdc1372": {
+    "decl": "Scenario: muster_modelchem strips \"-d3\" and emits EmpiricalDispersion=GD3",
+    "file": "gaussian/dispersion",
+    "refs": [],
+    "title": "muster_modelchem strips \"-d3\" and emits EmpiricalDispersion=GD3",
+    "type": "scenario"
+  },
+  "rq-1d5da737": {
+    "decl": "### Extended: `harvest(in_mol, method, log_content)`",
+    "file": "gaussian/dispersion",
+    "level": 3,
+    "refs": [],
+    "title": "Extended: `harvest(in_mol, method, log_content)`",
+    "type": "section"
   },
   "rq-20063525": {
     "decl": "Scenario: Labeled hydrogen atom emits a bare \"H \" line (no label suffix)",
@@ -245,6 +304,22 @@
     "title": "Method already starting with U is not double-prefixed",
     "type": "scenario"
   },
+  "rq-29751017": {
+    "decl": "## Background: Gaussian Dispersion Output",
+    "file": "gaussian/dispersion",
+    "level": 2,
+    "refs": [],
+    "title": "Background: Gaussian Dispersion Output",
+    "type": "section"
+  },
+  "rq-29bb67d8": {
+    "decl": "## References",
+    "file": "gaussian/dispersion",
+    "level": 2,
+    "refs": [],
+    "title": "References",
+    "type": "section"
+  },
   "rq-2a015edf": {
     "decl": "Scenario: Mixed real and ghost atoms in one molecule",
     "file": "gaussian/ghost-atoms",
@@ -283,11 +358,25 @@
     "title": "`test_tricky_ghost` (eneyne+Ne, MP2)",
     "type": "section"
   },
+  "rq-2de0fabe": {
+    "decl": "Scenario: muster_modelchem raises InputError for -NL non-local dispersion alias",
+    "file": "gaussian/dispersion",
+    "refs": [],
+    "title": "muster_modelchem raises InputError for -NL non-local dispersion alias",
+    "type": "scenario"
+  },
   "rq-31334859": {
     "decl": "Scenario: MP2/6-31G* energy on gAmB (ghost ethylene + real ethyne) matches reference",
     "file": "gaussian/ghost-atoms",
     "refs": [],
     "title": "MP2/6-31G* energy on gAmB (ghost ethylene + real ethyne) matches reference",
+    "type": "scenario"
+  },
+  "rq-3136523b": {
+    "decl": "Scenario: Dispersion energy falls back to ccdata.dispersionenergies when regex misses",
+    "file": "gaussian/dispersion",
+    "refs": [],
+    "title": "Dispersion energy falls back to ccdata.dispersionenergies when regex misses",
     "type": "scenario"
   },
   "rq-3257a6f5": {
@@ -399,6 +488,13 @@
     "title": "Multi-core execution succeeds and ncores is reflected in output",
     "type": "scenario"
   },
+  "rq-4262d5f2": {
+    "decl": "Scenario: muster_modelchem leaves a hyphenated non-dispersion method unchanged",
+    "file": "gaussian/dispersion",
+    "refs": [],
+    "title": "muster_modelchem leaves a hyphenated non-dispersion method unchanged",
+    "type": "scenario"
+  },
   "rq-4336c3cd": {
     "decl": "- `ValueError` if no coordinate information can be extracted from the log.",
     "file": "gaussian/harvester",
@@ -412,6 +508,13 @@
     "refs": [],
     "title": "Feature: Gaussian Harness — Runner",
     "type": "file"
+  },
+  "rq-44319e8c": {
+    "decl": "Scenario: Conflict detection is case-insensitive on the keyword name",
+    "file": "gaussian/dispersion",
+    "refs": [],
+    "title": "Conflict detection is case-insensitive on the keyword name",
+    "type": "scenario"
   },
   "rq-463ef385": {
     "decl": "- `\"N ATOMS\"` — from `len(ccdata.atomnos)`.",
@@ -492,6 +595,13 @@
     "title": "Missing Mulliken charges do not raise an error",
     "type": "scenario"
   },
+  "rq-540caf62": {
+    "decl": "Scenario: Conflict between method suffix and user keyword raises InputError",
+    "file": "gaussian/dispersion",
+    "refs": [],
+    "title": "Conflict between method suffix and user keyword raises InputError",
+    "type": "scenario"
+  },
   "rq-546faafb": {
     "decl": "Scenario: MP2 method maps to \"MP2\"",
     "file": "gaussian/input-builder",
@@ -513,6 +623,14 @@
     "refs": [],
     "title": "Parse MP2 total and correlation energies",
     "type": "scenario"
+  },
+  "rq-59b816b7": {
+    "decl": "### Extended: `build_input(input_model, config, template=None)`",
+    "file": "gaussian/dispersion",
+    "level": 3,
+    "refs": [],
+    "title": "Extended: `build_input(input_model, config, template=None)`",
+    "type": "section"
   },
   "rq-5c529f02": {
     "decl": "Scenario: out_mol preserves atom_labels when fix_com and fix_orientation are True",
@@ -600,11 +718,25 @@
     "title": "Atom count mismatch raises ValueError when ghosts are present",
     "type": "scenario"
   },
+  "rq-68840f83": {
+    "decl": "Scenario: Gradient is unchanged when dispersion is present",
+    "file": "gaussian/dispersion",
+    "refs": [],
+    "title": "Gradient is unchanged when dispersion is present",
+    "type": "scenario"
+  },
   "rq-6a889dea": {
     "decl": "Scenario: UHF energy is invariant to input frame scrambling",
     "file": "gaussian/integration-tests",
     "refs": [],
     "title": "UHF energy is invariant to input frame scrambling",
+    "type": "scenario"
+  },
+  "rq-6a93ae95": {
+    "decl": "Scenario: muster_modelchem strips \"-d3bj\" and emits EmpiricalDispersion=GD3BJ",
+    "file": "gaussian/dispersion",
+    "refs": [],
+    "title": "muster_modelchem strips \"-d3bj\" and emits EmpiricalDispersion=GD3BJ",
     "type": "scenario"
   },
   "rq-6bff3228": {
@@ -619,6 +751,13 @@
     "file": "gaussian/input-builder",
     "refs": [],
     "title": "Doublet automatically prepends U to HF",
+    "type": "scenario"
+  },
+  "rq-6f52a6d9": {
+    "decl": "Scenario: Functional-specific dispersion qcvar uses the formal label",
+    "file": "gaussian/dispersion",
+    "refs": [],
+    "title": "Functional-specific dispersion qcvar uses the formal label",
     "type": "scenario"
   },
   "rq-7049aaa5": {
@@ -656,6 +795,13 @@
     "title": "Parse HF total energy from a closed-shell log",
     "type": "scenario"
   },
+  "rq-7211fb49": {
+    "decl": "Scenario: SCF TOTAL ENERGY and HF TOTAL ENERGY exclude dispersion",
+    "file": "gaussian/dispersion",
+    "refs": [],
+    "title": "SCF TOTAL ENERGY and HF TOTAL ENERGY exclude dispersion",
+    "type": "scenario"
+  },
   "rq-731f01ba": {
     "decl": "Scenario: out_mol.symbols are copied from in_mol for ghost positions",
     "file": "gaussian/ghost-atoms",
@@ -691,6 +837,21 @@
     "refs": [],
     "title": "Empty atom_labels (all-default) preserves existing behavior",
     "type": "scenario"
+  },
+  "rq-7c3a72b9": {
+    "decl": "Scenario: muster_modelchem recognises canonical key alias \"d3zero2b\"",
+    "file": "gaussian/dispersion",
+    "refs": [],
+    "title": "muster_modelchem recognises canonical key alias \"d3zero2b\"",
+    "type": "scenario"
+  },
+  "rq-7d1fb16e": {
+    "decl": "## Feature API",
+    "file": "gaussian/dispersion",
+    "level": 2,
+    "refs": [],
+    "title": "Feature API",
+    "type": "section"
   },
   "rq-7e1b0bb4": {
     "decl": "Scenario: test_tricky_ghost accepts Gaussian's linear PG for the mB subject",
@@ -774,6 +935,13 @@
     "title": "InputError",
     "type": "api-item"
   },
+  "rq-879110d8": {
+    "decl": "Scenario: Doublet adds U prefix to functional before stripping dispersion",
+    "file": "gaussian/dispersion",
+    "refs": [],
+    "title": "Doublet adds U prefix to functional before stripping dispersion",
+    "type": "scenario"
+  },
   "rq-87c8fb49": {
     "decl": "Scenario: RHF hessian is correctly aligned to the (scrambled) input frame",
     "file": "gaussian/integration-tests",
@@ -853,12 +1021,33 @@
     "title": "QC Variables Populated",
     "type": "section"
   },
+  "rq-93777ba8": {
+    "decl": "Scenario: NLC method (wB97M-V) does not emit dispersion qcvars",
+    "file": "gaussian/dispersion",
+    "refs": [],
+    "title": "NLC method (wB97M-V) does not emit dispersion qcvars",
+    "type": "scenario"
+  },
   "rq-943856cc": {
     "decl": "- `\"DIPOLE MOMENT\"` — magnitude of `ccdata.moments[1]` in Debye.",
     "file": "gaussian/harvester",
     "refs": [],
     "title": "- `\"DIPOLE MOMENT\"` — magnitude of `ccdata.moments[1]` in Debye.",
     "type": "api-item"
+  },
+  "rq-95535d13": {
+    "decl": "Scenario: muster_modelchem raises InputError for D3M(BJ)",
+    "file": "gaussian/dispersion",
+    "refs": [],
+    "title": "muster_modelchem raises InputError for D3M(BJ)",
+    "type": "scenario"
+  },
+  "rq-95aa6edf": {
+    "decl": "Scenario: muster_modelchem recognises the bare alias \"d\" as D2",
+    "file": "gaussian/dispersion",
+    "refs": [],
+    "title": "muster_modelchem recognises the bare alias \"d\" as D2",
+    "type": "scenario"
   },
   "rq-95dab09b": {
     "decl": "### `test_simple_ghost` (He···Ne)",
@@ -867,6 +1056,13 @@
     "refs": [],
     "title": "`test_simple_ghost` (He···Ne)",
     "type": "section"
+  },
+  "rq-96507cf6": {
+    "decl": "Scenario: Method suffix alone (no keyword) produces a single EmpiricalDispersion route token",
+    "file": "gaussian/dispersion",
+    "refs": [],
+    "title": "Method suffix alone (no keyword) produces a single EmpiricalDispersion route token",
+    "type": "scenario"
   },
   "rq-972b6470": {
     "decl": "Scenario: Singlet uses method name as-is (no U prefix)",
@@ -985,6 +1181,13 @@
     "title": "Feature API",
     "type": "section"
   },
+  "rq-a83b7d5f": {
+    "decl": "Scenario: Dispersion energy is parsed via regex when the log contains the line",
+    "file": "gaussian/dispersion",
+    "refs": [],
+    "title": "Dispersion energy is parsed via regex when the log contains the line",
+    "type": "scenario"
+  },
   "rq-a88c706f": {
     "decl": "- `method` — method string from `AtomicInput.model.method` (case-insensitive).",
     "file": "gaussian/input-builder",
@@ -1018,6 +1221,13 @@
     "file": "gaussian/input-builder",
     "refs": [],
     "title": "Route line for closed-shell HF energy",
+    "type": "scenario"
+  },
+  "rq-af4f9bf0": {
+    "decl": "Scenario: muster_modelchem strips \"-d2\" and emits EmpiricalDispersion=GD2",
+    "file": "gaussian/dispersion",
+    "refs": [],
+    "title": "muster_modelchem strips \"-d2\" and emits EmpiricalDispersion=GD2",
     "type": "scenario"
   },
   "rq-b074f046": {
@@ -1190,6 +1400,13 @@
     "title": "Hessian Parsing",
     "type": "section"
   },
+  "rq-c68dde2e": {
+    "decl": "Scenario: User keyword alone (no method suffix) passes through unchanged",
+    "file": "gaussian/dispersion",
+    "refs": [],
+    "title": "User keyword alone (no method suffix) passes through unchanged",
+    "type": "scenario"
+  },
   "rq-c77a2c13": {
     "decl": "Scenario: compute() raises InputError when model.basis is a BasisSet object",
     "file": "gaussian/runner",
@@ -1240,6 +1457,14 @@
     "refs": [],
     "title": "All-ghost molecule produces an atom block with every line \"-Bq\"-suffixed",
     "type": "scenario"
+  },
+  "rq-ce8f4843": {
+    "decl": "## Integration Test",
+    "file": "gaussian/dispersion",
+    "level": 2,
+    "refs": [],
+    "title": "Integration Test",
+    "type": "section"
   },
   "rq-ceef73bd": {
     "decl": "Scenario: Coordinate precision is preserved for ghost atoms",
@@ -1292,6 +1517,13 @@
     "title": "`harvest(in_mol: Molecule, method: str, log_content: str) -> Tuple[PreservingDict, Optional[np.ndarray], Optional[np.ndarray], Molecule]`",
     "type": "section"
   },
+  "rq-d96c128f": {
+    "decl": "Scenario: muster_modelchem raises InputError for D3M",
+    "file": "gaussian/dispersion",
+    "refs": [],
+    "title": "muster_modelchem raises InputError for D3M",
+    "type": "scenario"
+  },
   "rq-d97cc860": {
     "decl": "Scenario: Gradient array spans real and ghost atoms in input order",
     "file": "gaussian/ghost-atoms",
@@ -1328,6 +1560,21 @@
     "title": "Background: Gaussian Ghost-Atom Syntax",
     "type": "section"
   },
+  "rq-dea9f7c9": {
+    "decl": "## Gherkin Scenarios",
+    "file": "gaussian/dispersion",
+    "level": 2,
+    "refs": [],
+    "title": "Gherkin Scenarios",
+    "type": "section"
+  },
+  "rq-df49b3b8": {
+    "decl": "Scenario: No dispersion in log produces no dispersion qcvars",
+    "file": "gaussian/dispersion",
+    "refs": [],
+    "title": "No dispersion in log produces no dispersion qcvars",
+    "type": "scenario"
+  },
   "rq-df7eb0c3": {
     "decl": "## Migration Notes",
     "file": "gaussian/ghost-atoms",
@@ -1341,6 +1588,13 @@
     "file": "gaussian/input-builder",
     "refs": [],
     "title": "Unsupported driver raises InputError",
+    "type": "scenario"
+  },
+  "rq-e1150329": {
+    "decl": "Scenario: ROHF + dispersion does not double-prefix U",
+    "file": "gaussian/dispersion",
+    "refs": [],
+    "title": "ROHF + dispersion does not double-prefix U",
     "type": "scenario"
   },
   "rq-e5a98119": {
@@ -1380,6 +1634,28 @@
     "title": "Gherkin Scenarios",
     "type": "section"
   },
+  "rq-e89c4144": {
+    "decl": "Scenario: BJ-damped variant uses parenthesised formal label",
+    "file": "gaussian/dispersion",
+    "refs": [],
+    "title": "BJ-damped variant uses parenthesised formal label",
+    "type": "scenario"
+  },
+  "rq-e9a472db": {
+    "decl": "Scenario: muster_modelchem raises InputError for OP damping",
+    "file": "gaussian/dispersion",
+    "refs": [],
+    "title": "muster_modelchem raises InputError for OP damping",
+    "type": "scenario"
+  },
+  "rq-ea37df39": {
+    "decl": "## Migration Notes",
+    "file": "gaussian/dispersion",
+    "level": 2,
+    "refs": [],
+    "title": "Migration Notes",
+    "type": "section"
+  },
   "rq-edb73b83": {
     "decl": "Scenario: compute() raises InputError on internal coordinate error",
     "file": "gaussian/runner",
@@ -1401,6 +1677,13 @@
     "refs": [],
     "title": "`muster_modelchem(method: str, driver: str, multiplicity: int) -> Dict[str, Any]`",
     "type": "section"
+  },
+  "rq-ef982ff3": {
+    "decl": "Scenario: muster_modelchem prefers the longer suffix (d3bj over d3)",
+    "file": "gaussian/dispersion",
+    "refs": [],
+    "title": "muster_modelchem prefers the longer suffix (d3bj over d3)",
+    "type": "scenario"
   },
   "rq-f13e0d24": {
     "decl": "Scenario: parse_output uses standard \"input\" key in native_files",
@@ -1424,6 +1707,14 @@
     "title": "Modified: `harvest(in_mol, method, log_content)`",
     "type": "section"
   },
+  "rq-f237caf7": {
+    "decl": "## Open Cases",
+    "file": "gaussian/dispersion",
+    "level": 2,
+    "refs": [],
+    "title": "Open Cases",
+    "type": "section"
+  },
   "rq-f28b3bed": {
     "decl": "## Implementation Notes",
     "file": "gaussian/integration-tests",
@@ -1439,6 +1730,14 @@
     "title": "Parse Hessian from frequency calculation",
     "type": "scenario"
   },
+  "rq-f357f8db": {
+    "decl": "## Method-Name Recognition Details",
+    "file": "gaussian/dispersion",
+    "level": 2,
+    "refs": [],
+    "title": "Method-Name Recognition Details",
+    "type": "section"
+  },
   "rq-f4900ee1": {
     "decl": "### Coordinate Frame",
     "file": "gaussian/harvester",
@@ -1446,6 +1745,20 @@
     "refs": [],
     "title": "Coordinate Frame",
     "type": "section"
+  },
+  "rq-f49de098": {
+    "decl": "Scenario: Methods without dispersion suffix do not get dispersion qcvars even if log has the line",
+    "file": "gaussian/dispersion",
+    "refs": [],
+    "title": "Methods without dispersion suffix do not get dispersion qcvars even if log has the line",
+    "type": "scenario"
+  },
+  "rq-f4cbb515": {
+    "decl": "Scenario: muster_modelchem leaves a non-dispersion method unchanged",
+    "file": "gaussian/dispersion",
+    "refs": [],
+    "title": "muster_modelchem leaves a non-dispersion method unchanged",
+    "type": "scenario"
   },
   "rq-f512b60b": {
     "decl": "Scenario: Properties driver produces Pop=Full in extra_keywords",
@@ -1460,6 +1773,13 @@
     "refs": [],
     "title": "- `\"SCF TOTAL ENERGY\"` — same value as `\"HF TOTAL ENERGY\"` (required by standard suite contracts).",
     "type": "api-item"
+  },
+  "rq-f5d05419": {
+    "decl": "Scenario: Functional total energy excludes dispersion",
+    "file": "gaussian/dispersion",
+    "refs": [],
+    "title": "Functional total energy excludes dispersion",
+    "type": "scenario"
   },
   "rq-f6537c40": {
     "decl": "### cclib Limitations",


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->

This PR contains an initial effort to implement support for Gaussian in QCEngine.

The code was largely generated with Claude Code, using requirements files in the `rqm` directory that this PR introduces.  The various requirements hashes (e.g., `rq-ef62979b`, `rq-c266b9bb`, `rq-f1c116db`, etc.) are identifiers for individual elements of the requirements specification, and form an explicit map between the code and the requirements.  These hashes and the requirements files can be removed from the PR, if desired.  If nothing else, perhaps this serves as an opportunity to assess the quality of AI-generated harnesses.

In addition to the tests in `test_gaussian.py`, you can reference the following as an example.  It should work with either `g16` or `g09`, but I've only tested with `g16` thus far.

```python
from qcelemental.models.v2 import AtomicInput, AtomicSpecification, Molecule
import qcengine as qcng

mol = Molecule(
    symbols=["O", "H", "H"],
    geometry=[
        0.000000,  0.000000,  0.226296,
        0.000000,  1.430901, -0.905183,
        0.000000, -1.430901, -0.905183,
    ],
)

inp = AtomicInput(
    molecule=mol,
    specification=AtomicSpecification(
        program="gaussian",
        driver="energy",
        model={"method": "HF", "basis": "STO-3G"},
    ),
)

result = qcng.compute(inp, "gaussian")

print(f"Success:       {result.success}")
print(f"Total energy:  {result.return_result:.10f} Eh")
print(f"Version:       {result.provenance.version}")
```

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->
Implementation of a Gaussian harness.

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [ ] Code base linted
- [ ] Ready to go
