### PR TITLE
add Orb universal machine learned force field harness

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -159,6 +159,13 @@ jobs:
             runs-on: ubuntu-latest
             pytest: ""
 
+          # 3.12 only: orb pins dm-tree==0.1.8, which has no wheel beyond cp312
+          - conda-env: orb
+            python-version: "3.12"
+            label: ORB
+            runs-on: ubuntu-latest
+            pytest: ""
+
           #- conda-env: opt-disp-cf
           #  python-version: 3.12
           #  label: QCSk-next

--- a/devtools/conda-envs/orb.yaml
+++ b/devtools/conda-envs/orb.yaml
@@ -1,0 +1,27 @@
+name: test
+channels:
+  - conda-forge
+dependencies:
+    # keep the scientific stack on the pip side: conda's llvm-openmp and the libomp
+    # bundled in the torch wheels collide at import time (fatal on macOS)
+  - python
+  - pip
+  - pip:
+    # Core
+    - pyyaml
+    - py-cpuinfo
+    - psutil
+    - qcelemental>=0.50.4,<0.70.0
+    - pydantic>=2.11
+    - pydantic-settings
+    - msgpack
+    - packaging
+
+    # orb pins dm-tree==0.1.8, whose newest wheel is cp312; python >3.12 has no
+    # binary and falls back to a bazel source build
+    - orb-models
+
+    # Testing
+    - pytest
+    - pytest-cov
+    - codecov

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,7 @@ markers = [
     "classic-gcp: tests using GCP executable software; skip if unavailable",
     "geometric: tests using geomeTRIC software; skip if unavailable",
     "mace: tests using MACE software; skip if unavailable",
+    "orb: tests using ORB software; skip if unavailable",
     "mdi: tests using MDI software; skip if unavailable",
     "molpro: tests using Molpro software; skip if unavailable",
     "mopac: tests using Mopac software; skip if unavailable",

--- a/qcengine/programs/base.py
+++ b/qcengine/programs/base.py
@@ -20,6 +20,7 @@ from .mp2d import MP2DHarness
 from .mrchem import MRChemHarness
 from .nwchem import NWChemHarness
 from .openmm import OpenMMHarness
+from .orb import ORBHarness
 from .psi4 import Psi4Harness
 from .qchem import QChemHarness
 from .qcore import EntosHarness, QcoreHarness
@@ -129,6 +130,7 @@ register_program(XTBHarness())
 register_program(TorchANIHarness())
 register_program(MACEHarness())
 register_program(AIMNET2Harness())
+register_program(ORBHarness())
 
 # Molecular Mechanics
 register_program(RDKitHarness())

--- a/qcengine/programs/orb.py
+++ b/qcengine/programs/orb.py
@@ -1,0 +1,133 @@
+from typing import TYPE_CHECKING, Any, ClassVar, Dict
+
+from qcelemental.models.v2 import AtomicResult, Provenance
+from qcelemental.util import safe_version, which_import
+
+from qcengine.exceptions import InputError
+from qcengine.programs.model import ProgramHarness
+
+if TYPE_CHECKING:
+    from qcelemental.models.v2 import AtomicInput
+
+    from qcengine.config import TaskConfig
+
+
+class ORBHarness(ProgramHarness):
+    """A harness to run ORB models <https://github.com/orbital-materials/orb-models>"""
+
+    _CACHE = {}
+
+    _defaults: ClassVar[Dict[str, Any]] = {
+        "name": "ORB",
+        "scratch": False,
+        "thread_safe": True,
+        "thread_parallel": False,
+        "node_parallel": False,
+        "managed_memory": False,
+    }
+
+    version_cache: Dict[str, str] = {}
+
+    @staticmethod
+    def found(raise_error: bool = False) -> bool:
+        return which_import(
+            "orb_models",
+            return_bool=True,
+            raise_error=raise_error,
+            raise_msg="Please install via `pip install orb-models`.",
+        )
+
+    def get_version(self) -> str:
+        self.found(raise_error=True)
+
+        which_prog = which_import("orb_models")
+        if which_prog not in self.version_cache:
+            import orb_models
+
+            self.version_cache[which_prog] = safe_version(orb_models.__version__)
+
+        return self.version_cache[which_prog]
+
+    @staticmethod
+    def resolve_device(keywords: Dict[str, Any]) -> str:
+        """Pick the torch device, honouring an explicit ``device`` keyword over autodetection.
+
+        orb loads models with an unconditional ``.cuda(device)``, so cpu and cuda are the only
+        options (no mps)
+        """
+        import torch
+
+        requested = keywords.get("device", "auto")
+        if requested != "auto":
+            return requested
+        return "cuda" if torch.cuda.is_available() else "cpu"
+
+    def load_model(self, name: str, device: str):
+        """Return the (model, adapter) pair orb's loaders hand back."""
+        # cache on device too, else a cpu-loaded model is handed back for a gpu request
+        key = (name.lower(), device)
+        if key in self._CACHE:
+            return self._CACHE[key]
+
+        from orb_models.forcefield import pretrained
+
+        if key[0] not in pretrained.ORB_PRETRAINED_MODELS:
+            raise InputError(f"ORB model {name} not recognized. Available: {sorted(pretrained.ORB_PRETRAINED_MODELS)}")
+
+        self._CACHE[key] = pretrained.ORB_PRETRAINED_MODELS[key[0]](device=device)
+        return self._CACHE[key]
+
+    def compute(self, input_data: "AtomicInput", config: "TaskConfig"):
+        self.found(raise_error=True)
+
+        from qcengine.units import ureg
+
+        method = input_data.specification.model.method
+        device = self.resolve_device(input_data.specification.keywords)
+        model, adapter = self.load_model(name=method, device=device)
+
+        if input_data.specification.driver not in ["energy", "gradient"]:
+            raise InputError(
+                f"ORB can only compute energy and gradient driver methods. Requested {input_data.specification.driver} not supported."
+            )
+
+        from ase import Atoms
+
+        # the omol models are charge/spin conditioned and require both together in atoms.info
+        atoms = Atoms(
+            numbers=input_data.molecule.atomic_numbers,
+            positions=input_data.molecule.geometry * ureg.conversion_factor("bohr", "angstrom"),
+            info={
+                "charge": input_data.molecule.molecular_charge,
+                "spin": input_data.molecule.molecular_multiplicity,
+            },
+        )
+        batch = adapter.batch([adapter.from_ase_atoms(atoms, device=device)])
+        out = model.predict(batch)
+
+        # conservative regressors name their outputs on the model (and may suffix a level of
+        # theory); direct regressors just key on the head names
+        energy = out[getattr(model, "energy_name", "energy")].item()
+        forces = out[getattr(model, "grad_forces_name", "forces")].detach().cpu().numpy()
+
+        ret_data = {
+            "input_data": input_data,
+            "molecule": input_data.molecule,
+            "success": False,
+            "properties": {
+                "return_energy": energy * ureg.conversion_factor("eV", "hartree"),
+                "return_gradient": -1.0 * forces * ureg.conversion_factor("eV / angstrom", "hartree / bohr"),
+                "calcinfo_natom": len(input_data.molecule.atomic_numbers),
+            },
+            "extras": {"orb": {"device": device}},
+        }
+        if input_data.specification.driver == "energy":
+            ret_data["return_result"] = ret_data["properties"]["return_energy"]
+        else:
+            ret_data["return_result"] = ret_data["properties"]["return_gradient"]
+
+        ret_data["provenance"] = Provenance(creator="orb_models", version=self.get_version(), routine="load_model")
+
+        ret_data["success"] = True
+
+        return AtomicResult(**ret_data)

--- a/qcengine/programs/tests/test_programs.py
+++ b/qcengine/programs/tests/test_programs.py
@@ -775,6 +775,91 @@ def test_aimnet2_gradient(schema_versions, request):
     assert "charges" in result.extras["aimnet2"]
 
 
+@uusing("orb")
+@pytest.mark.parametrize(
+    "model, expected_energy",
+    [
+        pytest.param("orb-v3-direct-omol", -76.43103942777961, id="orb-v3-direct-omol"),
+        pytest.param("orb-v3-conservative-omol", -76.4310729627201, id="orb-v3-conservative-omol"),
+    ],
+)
+def test_orb_energy(model, expected_energy, schema_versions, request):
+    """Test computing the energies of water with the direct and conservative orb models.
+
+    The expected values are in hartree, so they also pin the eV -> hartree conversion.
+    """
+    models, retver, _ = schema_versions
+
+    water = models.Molecule(**qcng.get_molecule("water", return_dict=True))
+    # pin the device so the reference values do not depend on the runner's hardware
+    keywords = {"device": "cpu"}
+    if from_v2(request.node.name):
+        atomic_input = models.AtomicInput(
+            molecule=water,
+            specification={"driver": "energy", "model": {"method": model, "basis": None}, "keywords": keywords},
+        )
+    else:
+        atomic_input = models.AtomicInput(
+            molecule=water, model={"method": model, "basis": None}, driver="energy", keywords=keywords
+        )
+
+    atomic_input = checkver_and_convert(atomic_input, request.node.name, "pre")
+    result = qcng.compute(atomic_input, "orb", return_version=retver)
+    result = checkver_and_convert(result, request.node.name, "post")
+
+    assert result.success
+    assert pytest.approx(result.return_result) == expected_energy
+    assert result.extras["orb"]["device"] == "cpu"
+
+
+@uusing("orb")
+def test_orb_gradient(schema_versions, request):
+    """Test computing the gradient of water with one orb model.
+
+    The reference array pins both the eV/angstrom -> hartree/bohr conversion and the
+    sign convention: QCSchema wants the energy gradient, which is minus the force.
+    """
+    models, retver, _ = schema_versions
+
+    water = models.Molecule(**qcng.get_molecule("water", return_dict=True))
+    keywords = {"device": "cpu"}
+    if from_v2(request.node.name):
+        atomic_input = models.AtomicInput(
+            molecule=water,
+            specification={
+                "driver": "gradient",
+                "model": {"method": "orb-v3-direct-omol", "basis": None},
+                "keywords": keywords,
+            },
+        )
+    else:
+        atomic_input = models.AtomicInput(
+            molecule=water,
+            model={"method": "orb-v3-direct-omol", "basis": None},
+            driver="gradient",
+            keywords=keywords,
+        )
+
+    atomic_input = checkver_and_convert(atomic_input, request.node.name, "pre")
+    result = qcng.compute(atomic_input, "orb", return_version=retver)
+    result = checkver_and_convert(result, request.node.name, "post")
+
+    assert result.success
+    # make sure the gradient is now the return result
+    assert np.allclose(
+        result.return_result,
+        np.array(
+            [
+                [9.055670276147954e-12, 1.1031361282221042e-05, -0.038908492773771286],
+                [-9.055670276147954e-12, -0.02770164981484413, 0.01945851743221283],
+                [-3.3958764619757e-12, 0.027690617367625237, 0.019449975341558456],
+            ]
+        ),
+        atol=1e-6,
+    )
+    assert pytest.approx(result.properties.return_energy) == -76.43103942777961
+
+
 @uusing("psi4")
 def test_psi4_properties_driver(schema_versions, request):
     models, retver, _ = schema_versions

--- a/qcengine/testing.py
+++ b/qcengine/testing.py
@@ -205,6 +205,7 @@ _programs = {
     "mrchem": is_program_new_enough("mrchem", "1.0.0"),
     "mace": is_program_new_enough("mace", "0.3.2"),
     "aimnet2": which_import("pyaimnet2", return_bool=True),
+    "orb": which_import("orb_models", return_bool=True),
     "optking_v2": is_program_new_enough("optking", "0.5"),
 }
 _programs["openmm"] = _programs["rdkit"] and which_import(".openmm", package="simtk", return_bool=True)

--- a/qcengine/tests/test_harness_canonical.py
+++ b/qcengine/tests/test_harness_canonical.py
@@ -39,6 +39,7 @@ _canonical_methods = [
     pytest.param("mctc-gcp", {"method": "dft/sv"}, {}, marks=using("mctc-gcp")),
     pytest.param("mace", {"method": "small"}, {}, marks=using("mace")),
     pytest.param("aimnet2", {"method": "b973c"}, {}, marks=using("aimnet2")),
+    pytest.param("orb", {"method": "orb-v3-direct-omol"}, {"device": "cpu"}, marks=using("orb")),
     pytest.param("s-dftd3", {"method": "b3lyp-d3"}, {}, marks=using("s-dftd3")),
     pytest.param("dftd4", {"method": "b3lyp-d4"}, {}, marks=using("dftd4")),
     # add as programs available


### PR DESCRIPTION
## Description

I've added a harness for [orb-models](https://github.com/orbital-materials/orb-models). It is based on the previously implemented AIMNET2 harness. It supports `energy` and `gradient` drivers, same as AIMNET2. Three main things are different from the AIMNET2 implementation.

- **Force output keys differ between orb's two model types.** AIMNET2 only has one mode
  (forces by autograd on the energy). For Orb direct models return a
  `forces` key while conservative models return `grad_forces` since Orb has both direct and conservative models. The harness reads the key name off the model rather than hardcoding it, so both families of models go through the same code path.
- **The omol models need both charge and multiplicity for the input** AIMNET2 passes charge but never needs
  multiplicity whereas Orb's omol models need both charge and spin multiplicity. Orb requires both on `atoms.info` and will throw an error if either is missing.
- **The device is selectable for orb models** AIMNET2 hardcodes cpu but in Orb a `device` keyword chooses cpu/cuda and defaults to cuda when available. The tests pin `"cpu"` so reference values don't depend on the runner.

### Verification

- Tests are the same as AIMNET2 with hardcoded water energies/gradients so a dropped unit conversion or flipped sign fails CI, which was checked by introducing both bugs.
- As a final check I ran geometry optimizations on some caffeine conformers. I generated 4 ETKDG
  starting conformers and ran a geometry optimization with 3 models (orb direct, orb conservative and AIMNET2) and every run converged.

<img width="6023" height="3897" alt="Convergence plot, inset is one of the rendered minima, done using OVITO the marker is the last step above each run's converged energy which is off scale." src="https://github.com/user-attachments/assets/ade0b6dd-f576-476f-b729-b5504692e142" />

*Convergence plot, inset is a render of one of the minima done using OVITO, the marker is the last step above each run's converged energy which is off scale.

## Changelog description

ORB - Added harness for orb-models universal ML interatomic potentials.

## Status

- [x] Code base linted
- [x] Ready to go
