### PR TITLE
Fix gctc-gcp gradient for 2.4.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         env:
           # Public indexes reject setuptools-scm's local +g<hash> suffix.
           # The commit distance still makes consecutive main builds unique.
-          SETUPTOOLS_SCM_OVERRIDES_FOR_QCMANYBODY: '{local_scheme = "no-local-version"}'
+          SETUPTOOLS_SCM_OVERRIDES_FOR_QCENGINE: '{local_scheme = "no-local-version"}'
         run: python -m build
 
       - name: Check distribution metadata and version

--- a/codemeta.json
+++ b/codemeta.json
@@ -322,6 +322,14 @@
             "affiliation": "Stanford University",
             "@id": "https://orcid.org/0000-0003-2834-318X",
             "identifier": "https://github.com/coltonbh"
+        },
+        {
+            "@type": "Person",
+            "givenName": "Ty",
+            "familyName": "Balduf",
+            "affiliation": "Schrodinger",
+            "@id": "https://orcid.org/0000-0002-2066-2314",
+            "identifier": "https://github.com/TyBalduf"
         }
     ],
     "developmentStatus": "active",

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -41,13 +41,10 @@ Changelog
 
 .. _`sec:cl0510`:
 
-v0.51.0 / 2026-MM-DD (Unreleased)
+v0.51.0 / 2026-08-18
 --------------------
 
 :docs:`v0.51.0` for current. :docs:`v0.34.1` for QCSchema v1.
-
-Breaking Changes
-++++++++++++++++
 
 New Features
 ++++++++++++
@@ -58,11 +55,8 @@ Enhancements
 - (:pr:`521`) MCTC-GCP -- Parse the new gradient output from gcp-correction v2.4.0
   while retaining support for older versions.
 
-Bug Fixes
-+++++++++
 
-
-.. _`sec:cl0510`:
+.. _`sec:cl0501`:
 
 v0.50.1 / 2026-08-15
 --------------------

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -41,6 +41,29 @@ Changelog
 
 .. _`sec:cl0510`:
 
+v0.51.0 / 2026-MM-DD (Unreleased)
+--------------------
+
+:docs:`v0.51.0` for current. :docs:`v0.34.1` for QCSchema v1.
+
+Breaking Changes
+++++++++++++++++
+
+New Features
+++++++++++++
+- (:pr:`513`) Jaguar -- New harness for Schrodinger Jaguar with E/G/H SCF. @TyBalduf
+
+Enhancements
+++++++++++++
+- (:pr:`521`) MCTC-GCP -- Parse the new gradient output from gcp-correction v2.4.0
+  while retaining support for older versions.
+
+Bug Fixes
++++++++++
+
+
+.. _`sec:cl0510`:
+
 v0.50.1 / 2026-08-15
 --------------------
 

--- a/qcengine/programs/gcp.py
+++ b/qcengine/programs/gcp.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, Dict, Optional, Tuple
 import numpy as np
 import qcelemental as qcel
 from qcelemental.models.v2 import AtomicResult, FailedOperation, Provenance
-from qcelemental.util import safe_version, which
+from qcelemental.util import parse_version, safe_version, which
 
 from ..exceptions import InputError, UnknownError
 from ..util import execute
@@ -107,6 +107,7 @@ class GCPHarness(ProgramHarness):
             scratch_messy=inputs["scratch_messy"],
             scratch_directory=inputs["scratch_directory"],
             blocking_files=inputs["blocking_files"],
+            as_binary=inputs.get("as_binary"),
         )
         return success, dexe
 
@@ -192,10 +193,13 @@ class GCPHarness(ProgramHarness):
         if method == "FILE":
             infiles[".gcppar"] = input_model.extras["parameters"]
 
+        new_mctc_gradient = executable == "mctc-gcp" and parse_version(self.get_version()) >= parse_version("2.4.0")
+
         return {
             "command": command,
             "infiles": infiles,
-            "outfiles": ["gcp_gradient"],
+            "outfiles": ["gradient"] if new_mctc_gradient else ["gcp_gradient"],
+            "as_binary": ["gradient"] if new_mctc_gradient else None,
             "scratch_messy": config.scratch_messy,
             "scratch_directory": config.scratch_directory,
             "input_result": input_model.model_copy(deep=True),
@@ -225,7 +229,20 @@ class GCPHarness(ProgramHarness):
                 )
 
         # parse gradient output
-        if outfiles["gcp_gradient"] is not None:
+        new_mctc_gradient = self._defaults["name"] == "MCTC-GCP" and parse_version(self.get_version()) >= parse_version(
+            "2.4.0"
+        )
+        if new_mctc_gradient and outfiles["gradient"] is not None:
+            gradient = outfiles["gradient"].decode("ascii", errors="replace")
+            outfiles["gradient"] = gradient
+            gradient_lines = gradient.replace("D", "E").splitlines()
+            try:
+                end = next(i for i, line in reversed(list(enumerate(gradient_lines))) if line.strip() == "$end")
+                gradient_rows = gradient_lines[end - int(real_nat) : end]
+                realgrad = np.fromstring(" ".join(gradient_rows), count=3 * real_nat, sep=" ").reshape((-1, 3))
+            except (StopIteration, ValueError) as exc:
+                raise UnknownError("Unsuccessful gradient collection.") from exc
+        elif not new_mctc_gradient and outfiles["gcp_gradient"] is not None:
             srealgrad = outfiles["gcp_gradient"].replace("D", "E")
             realgrad = np.fromstring(srealgrad, count=3 * real_nat, sep=" ").reshape((-1, 3))
         elif real_nat == 1:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
See changelog. Fixes gcp-correction harness. Checked that the fix heals gcp tests in psi4. CI coverage hits both longstanding 2.3.2 and new 2.4.0 versions.

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
